### PR TITLE
Fix exception rethrows

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Input/XGamePad.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Input/XGamePad.cs
@@ -511,7 +511,7 @@ namespace XGamePad
                 }
                 else
                 {
-                    throw e; // Unknown error, rethrow
+                    throw; // Unknown error, rethrow
                 }
             }
         }

--- a/LiveSplit/LiveSplit.Core/UI/Components/ControlComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ControlComponent.cs
@@ -63,7 +63,7 @@ namespace LiveSplit.UI.Components
             {
                 if (errorCallback != null)
                     errorCallback(ex);
-                throw ex;
+                throw;
             }
         }
 


### PR DESCRIPTION
The previous way of rethrowing the exceptions would destroy the stacktrace information associated with them.
