### PR TITLE
SpeedRunsLiveIRC: Fix unused var in SpeedRunsLive_MessageReceived

### DIFF
--- a/LiveSplit/LiveSplit.Core/Web/SRL/SpeedRunsLiveIRC.cs
+++ b/LiveSplit/LiveSplit.Core/Web/SRL/SpeedRunsLiveIRC.cs
@@ -443,13 +443,13 @@ namespace LiveSplit.Web.SRL
                 if (e.Targets[0] is IrcChannel)
                 {
                     var target = e.Targets[0] as IrcChannel;
-                    var source = target.Users.Where(x => x.User.NickName == e.Source.Name).FirstOrDefault();
+                    var source = target.Users.FirstOrDefault(x => x.User.NickName == e.Source.Name);
                     if (source != null)
                     {
                         rights = SRLIRCRightsHelper.FromIrcChannelUser(source);
                     }
                 }
-                MessageReceived(this, new Tuple<string, SRLIRCUser, string>(e.Targets[0].Name, new SRLIRCUser(e.Source.Name), e.Text));
+                MessageReceived(this, new Tuple<string, SRLIRCUser, string>(e.Targets[0].Name, new SRLIRCUser(e.Source.Name, rights), e.Text));
             }
         }
 


### PR DESCRIPTION
(also simplifies the LINQ statement a little)

I'm assuming this was intended to be used. If it wasn't, but just forgotten, I can update the PR and just remove it.
