### PR TITLE
LiveSplitImageSource: Get rid of obsoleted ApartmentManager property usage

### DIFF
--- a/LiveSplit/LiveSplit.Plugin/LiveSplitImageSource.cs
+++ b/LiveSplit/LiveSplit.Plugin/LiveSplitImageSource.cs
@@ -44,17 +44,20 @@ namespace LiveSplit.Plugin
 
         public override void BeginScene()
         {
-            new Thread(() =>
+            var formThread = new Thread(() =>
             {
                 Application.EnableVisualStyles();
 
                 form = new TimerForm(
-                    splitsPath: splitsPath, 
+                    splitsPath: splitsPath,
                     layoutPath: layoutPath,
-                    drawToBackBuffer: true, 
+                    drawToBackBuffer: true,
                     basePath: File.ReadAllText(@"plugins\CLRHostPlugin\livesplit.cfg"));
                 Application.Run(form);
-            }) { Name = "LiveSplit Form Thread", ApartmentState = ApartmentState.STA }.Start();
+            }) { Name = "LiveSplit Form Thread" };
+
+            formThread.SetApartmentState(ApartmentState.STA);
+            formThread.Start();
         }
 
         public override void EndScene()


### PR DESCRIPTION
Its obsoletion is indicated on the ApartmentManager page here:
http://msdn.microsoft.com/en-us/library/system.threading.thread.apartmentstate%28v=vs.100%29.aspx
