### PR TITLE
GamepadHook: Implement GetHashCode for GamepadButton

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Input/GamepadHook.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Input/GamepadHook.cs
@@ -34,6 +34,11 @@ namespace LiveSplit.Model.Input
 
             return base.Equals(obj);
         }
+
+        public override int GetHashCode()
+        {
+            return GamepadName.GetHashCode() ^ Button.GetHashCode();
+        }
     }
 
     public class GamepadHook


### PR DESCRIPTION
It's general convention to implement both. (You can also have a warning triggered by this iirc).
