### PR TITLE
LowLevelKeyboardHook: Specify marshal return type for GetLastInputInfo

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Input/LowLevelKeyboardHook.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Input/LowLevelKeyboardHook.cs
@@ -301,6 +301,7 @@ namespace LiveSplit.Model.Input
             Int32 dwThreadId);
 
         [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Important because the C++ bool type is usually 1 byte in size (with its equivalent being `UnmanagedType.U1`) whereas the windows typedef, BOOL, is 4 bytes in size.

The C++ prototype for GetLastInputInfo returns a `BOOL` so, this is a more correct form of marshalling the value.
