### PR TITLE
Core: Add GC.SuppressFinalize to control Dispose methods

### DIFF
--- a/LiveSplit/LiveSplit.Core/UI/Components/ComponentRendererComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ComponentRendererComponent.cs
@@ -57,6 +57,8 @@ namespace LiveSplit.UI.Components
         {
             foreach (var component in VisibleComponents)
                 component.Dispose();
+
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/UI/Components/ControlComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ControlComponent.cs
@@ -121,6 +121,8 @@ namespace LiveSplit.UI.Components
         {
             Form.Controls.Remove(Control);
             Control.Dispose();
+
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/UI/Components/InfoTextComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/InfoTextComponent.cs
@@ -202,6 +202,7 @@ namespace LiveSplit.UI.Components
 
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/UI/Components/LineComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/LineComponent.cs
@@ -97,6 +97,7 @@ namespace LiveSplit.UI.Components
 
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/UI/Components/SeparatorComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/SeparatorComponent.cs
@@ -163,6 +163,7 @@ namespace LiveSplit.UI.Components
 
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/UI/Components/ThinSeparatorComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ThinSeparatorComponent.cs
@@ -147,6 +147,7 @@ namespace LiveSplit.UI.Components
 
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/Web/SRL/SpeedRunsLiveIRC.cs
+++ b/LiveSplit/LiveSplit.Core/Web/SRL/SpeedRunsLiveIRC.cs
@@ -581,6 +581,8 @@ namespace LiveSplit.Web.SRL
         public void Dispose()
         {
             Client.Dispose();
+
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
With the Dispose pattern, it isn't necessary for the garbage collector to call the object's finalizer, since Dispose handles the releasing of acquired resources. This is also recommended practice.
