### PR TITLE
Core: Dispose object handles when no longer needed

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/RunFactories/LlanfairRunFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunFactories/LlanfairRunFactory.cs
@@ -39,14 +39,19 @@ namespace LiveSplit.Model.RunFactories
             }
             try
             {
-                var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-                return FindJavaInRegistry(baseKey);
+                using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64))
+                {
+                    return FindJavaInRegistry(baseKey);
+                }
             }
             catch (Exception ex)
             {
                 Log.Error(ex);
-                var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
-                return FindJavaInRegistry(baseKey);
+
+                using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+                {
+                    return FindJavaInRegistry(baseKey);
+                }
             }
         }
 

--- a/LiveSplit/LiveSplit.Core/Model/RunFactories/XMLRunFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunFactories/XMLRunFactory.cs
@@ -26,8 +26,11 @@ namespace LiveSplit.Model.RunFactories
 
                 var base64String = element.InnerText;
                 var data = Convert.FromBase64String(base64String);
-                var ms = new MemoryStream(data);
-                return (Image)bf.Deserialize(ms);
+
+                using (var ms = new MemoryStream(data))
+                {
+                    return (Image)bf.Deserialize(ms);
+                }
             }
             return null;
         }

--- a/LiveSplit/LiveSplit.Core/Model/TripleDateTime.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TripleDateTime.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net.Sockets;
 
 namespace LiveSplit.Model
 {
@@ -100,9 +101,11 @@ namespace LiveSplit.Model
                 try
                 {
                     // Open a StreamReader to a random time server
-                    StreamReader reader = new StreamReader(new System.Net.Sockets.TcpClient(servers[ran.Next(0, servers.Length)], 13).GetStream());
-                    serverResponse = reader.ReadToEnd();
-                    reader.Close();
+                    using (var tcpClient = new TcpClient(servers[ran.Next(0, servers.Length)], 13))
+                    using (var reader = new StreamReader(tcpClient.GetStream()))
+                    {
+                        serverResponse = reader.ReadToEnd();
+                    }
 
                     // Check to see that the signature is there
                     if (serverResponse.Length > 47 && serverResponse.Substring(38, 9).Equals("UTC(NIST)"))

--- a/LiveSplit/LiveSplit.Core/UI/Components/LineComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/LineComponent.cs
@@ -27,7 +27,10 @@ namespace LiveSplit.UI.Components
 
         public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
         {
-            g.FillRectangle(new SolidBrush(LineColor), 0.0f, 0.0f, width, VerticalHeight);
+            using (var solidBrush = new SolidBrush(LineColor))
+            {
+                g.FillRectangle(solidBrush, 0.0f, 0.0f, width, VerticalHeight);
+            }
         }
 
         public string ComponentName
@@ -87,7 +90,10 @@ namespace LiveSplit.UI.Components
 
         public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
         {
-            g.FillRectangle(new SolidBrush(LineColor), 0.0f, 0.0f, HorizontalWidth, height);
+            using (var solidBrush = new SolidBrush(LineColor))
+            {
+                g.FillRectangle(solidBrush, 0.0f, 0.0f, HorizontalWidth, height);
+            }
         }
 
         public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)

--- a/LiveSplit/LiveSplit.Core/UI/InputBox.cs
+++ b/LiveSplit/LiveSplit.Core/UI/InputBox.cs
@@ -13,44 +13,46 @@ namespace LiveSplit.UI
 
         public static DialogResult Show(IWin32Window owner, string title, string promptText, ref string value)
         {
-            Form form = new Form();
-            Label label = new Label();
-            TextBox textBox = new TextBox();
-            Button buttonOk = new Button();
-            Button buttonCancel = new Button();
+            using (Form form = new Form())
+            {
+                Label label = new Label();
+                TextBox textBox = new TextBox();
+                Button buttonOk = new Button();
+                Button buttonCancel = new Button();
 
-            form.Text = title;
-            label.Text = promptText;
-            textBox.Text = value;
+                form.Text = title;
+                label.Text = promptText;
+                textBox.Text = value;
 
-            buttonOk.Text = "OK";
-            buttonCancel.Text = "Cancel";
-            buttonOk.DialogResult = DialogResult.OK;
-            buttonCancel.DialogResult = DialogResult.Cancel;
+                buttonOk.Text = "OK";
+                buttonCancel.Text = "Cancel";
+                buttonOk.DialogResult = DialogResult.OK;
+                buttonCancel.DialogResult = DialogResult.Cancel;
 
-            label.SetBounds(9, 20, 372, 13);
-            textBox.SetBounds(12, 36, 372, 20);
-            buttonOk.SetBounds(228, 72, 75, 23);
-            buttonCancel.SetBounds(309, 72, 75, 23);
+                label.SetBounds(9, 20, 372, 13);
+                textBox.SetBounds(12, 36, 372, 20);
+                buttonOk.SetBounds(228, 72, 75, 23);
+                buttonCancel.SetBounds(309, 72, 75, 23);
 
-            label.AutoSize = true;
-            textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
-            buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                label.AutoSize = true;
+                textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
+                buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
 
-            form.ClientSize = new Size(396, 107);
-            form.Controls.AddRange(new Control[] { label, textBox, buttonOk, buttonCancel });
-            form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
-            form.FormBorderStyle = FormBorderStyle.FixedDialog;
-            form.StartPosition = FormStartPosition.CenterScreen;
-            form.MinimizeBox = false;
-            form.MaximizeBox = false;
-            form.AcceptButton = buttonOk;
-            form.CancelButton = buttonCancel;
+                form.ClientSize = new Size(396, 107);
+                form.Controls.AddRange(new Control[] {label, textBox, buttonOk, buttonCancel});
+                form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterScreen;
+                form.MinimizeBox = false;
+                form.MaximizeBox = false;
+                form.AcceptButton = buttonOk;
+                form.CancelButton = buttonCancel;
 
-            DialogResult dialogResult = owner != null ? form.ShowDialog(owner) : form.ShowDialog();
-            value = textBox.Text;
-            return dialogResult;
+                DialogResult dialogResult = owner != null ? form.ShowDialog(owner) : form.ShowDialog();
+                value = textBox.Text;
+                return dialogResult;
+            }
         }
 
         public static DialogResult Show(string title, string promptText, string promptText2, ref string value, ref string value2)
@@ -60,53 +62,55 @@ namespace LiveSplit.UI
 
         public static DialogResult Show(IWin32Window owner, string title, string promptText, string promptText2, ref string value, ref string value2)
         {
-            Form form = new Form();
-            Label label = new Label();
-            Label label2 = new Label();
-            TextBox textBox = new TextBox();
-            TextBox textBox2 = new TextBox();
-            Button buttonOk = new Button();
-            Button buttonCancel = new Button();
+            using (Form form = new Form())
+            {
+                Label label = new Label();
+                Label label2 = new Label();
+                TextBox textBox = new TextBox();
+                TextBox textBox2 = new TextBox();
+                Button buttonOk = new Button();
+                Button buttonCancel = new Button();
 
-            form.Text = title;
-            label.Text = promptText;
-            label2.Text = promptText2;
-            textBox.Text = value;
-            textBox2.Text = value2;
+                form.Text = title;
+                label.Text = promptText;
+                label2.Text = promptText2;
+                textBox.Text = value;
+                textBox2.Text = value2;
 
-            buttonOk.Text = "OK";
-            buttonCancel.Text = "Cancel";
-            buttonOk.DialogResult = DialogResult.OK;
-            buttonCancel.DialogResult = DialogResult.Cancel;
+                buttonOk.Text = "OK";
+                buttonCancel.Text = "Cancel";
+                buttonOk.DialogResult = DialogResult.OK;
+                buttonCancel.DialogResult = DialogResult.Cancel;
 
-            label.SetBounds(9, 20, 372, 13);
-            label2.SetBounds(9, 66, 372, 13);
-            textBox.SetBounds(12, 36, 372, 20);
-            textBox2.SetBounds(12, 82, 372, 20);
-            buttonOk.SetBounds(228, 118, 75, 23);
-            buttonCancel.SetBounds(309, 118, 75, 23);
+                label.SetBounds(9, 20, 372, 13);
+                label2.SetBounds(9, 66, 372, 13);
+                textBox.SetBounds(12, 36, 372, 20);
+                textBox2.SetBounds(12, 82, 372, 20);
+                buttonOk.SetBounds(228, 118, 75, 23);
+                buttonCancel.SetBounds(309, 118, 75, 23);
 
-            label.AutoSize = true;
-            label2.AutoSize = true;
-            textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
-            textBox2.Anchor = textBox.Anchor | AnchorStyles.Right;
-            buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                label.AutoSize = true;
+                label2.AutoSize = true;
+                textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
+                textBox2.Anchor = textBox.Anchor | AnchorStyles.Right;
+                buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
 
-            form.ClientSize = new Size(396, 153);
-            form.Controls.AddRange(new Control[] { label, label2, textBox, textBox2, buttonOk, buttonCancel });
-            form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
-            form.FormBorderStyle = FormBorderStyle.FixedDialog;
-            form.StartPosition = FormStartPosition.CenterScreen;
-            form.MinimizeBox = false;
-            form.MaximizeBox = false;
-            form.AcceptButton = buttonOk;
-            form.CancelButton = buttonCancel;
+                form.ClientSize = new Size(396, 153);
+                form.Controls.AddRange(new Control[] {label, label2, textBox, textBox2, buttonOk, buttonCancel});
+                form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterScreen;
+                form.MinimizeBox = false;
+                form.MaximizeBox = false;
+                form.AcceptButton = buttonOk;
+                form.CancelButton = buttonCancel;
 
-            DialogResult dialogResult = owner != null ? form.ShowDialog(owner) : form.ShowDialog();
-            value = textBox.Text;
-            value2 = textBox2.Text;
-            return dialogResult;
+                DialogResult dialogResult = owner != null ? form.ShowDialog(owner) : form.ShowDialog();
+                value = textBox.Text;
+                value2 = textBox2.Text;
+                return dialogResult;
+            }
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/UI/LayoutFactories/XMLLayoutFactory.cs
+++ b/LiveSplit/LiveSplit.Core/UI/LayoutFactories/XMLLayoutFactory.cs
@@ -27,8 +27,11 @@ namespace LiveSplit.UI.LayoutFactories
 
                 var base64String = element.InnerText;
                 var data = Convert.FromBase64String(base64String);
-                var ms = new MemoryStream(data);
-                return (Image)bf.Deserialize(ms);
+
+                using (var ms = new MemoryStream(data))
+                {
+                    return (Image)bf.Deserialize(ms);
+                }
             }
             return null;
         }
@@ -41,8 +44,11 @@ namespace LiveSplit.UI.LayoutFactories
 
                 var base64String = element.InnerText;
                 var data = Convert.FromBase64String(base64String);
-                var ms = new MemoryStream(data);
-                return (Font)bf.Deserialize(ms);
+
+                using (var ms = new MemoryStream(data))
+                {
+                    return (Font)bf.Deserialize(ms);
+                }
             }
             return null;
         }
@@ -100,10 +106,13 @@ namespace LiveSplit.UI.LayoutFactories
                 settings.TimesFont = GetFontFromElement(element["MainFont"]);
                 settings.TextFont = GetFontFromElement(element["SplitNamesFont"]);
             }
+
             settings.TimerFont = GetFontFromElement(element["TimerFont"]);
-            var timerFont = new Font(settings.TimerFont.FontFamily.Name, (settings.TimerFont.Size / 50f) * 18f, settings.TimerFont.Style, GraphicsUnit.Point);
-            settings.TimerFont = new Font(timerFont.FontFamily.Name, (timerFont.Size / 18f) * 50f, timerFont.Style, GraphicsUnit.Pixel);
-            
+            using (var timerFont = new Font(settings.TimerFont.FontFamily.Name, (settings.TimerFont.Size / 50f) * 18f, settings.TimerFont.Style, GraphicsUnit.Point))
+            {
+                settings.TimerFont = new Font(timerFont.FontFamily.Name, (timerFont.Size / 18f) * 50f, timerFont.Style, GraphicsUnit.Pixel);
+            }
+
             settings.ShowBestSegments = Boolean.Parse(element["ShowBestSegments"].InnerText);
             settings.AlwaysOnTop = Boolean.Parse(element["AlwaysOnTop"].InnerText);
             return settings;

--- a/LiveSplit/LiveSplit.Core/UI/SimpleLabel.cs
+++ b/LiveSplit/LiveSplit.Core/UI/SimpleLabel.cs
@@ -108,9 +108,11 @@ namespace LiveSplit.UI
 
                 if (HasShadow)
                 {
-                    var shadowBrush = new SolidBrush(ShadowColor);
-                    g.DrawString(actualText, Font, shadowBrush, new RectangleF(X + 1, Y + 1, Width, Height), format);
-                    g.DrawString(actualText, Font, shadowBrush, new RectangleF(X + 2, Y + 2, Width, Height), format);
+                    using (var shadowBrush = new SolidBrush(ShadowColor))
+                    {
+                        g.DrawString(actualText, Font, shadowBrush, new RectangleF(X + 1, Y + 1, Width, Height), format);
+                        g.DrawString(actualText, Font, shadowBrush, new RectangleF(X + 2, Y + 2, Width, Height), format);
+                    }
                 }
                 g.DrawString(actualText, Font, Brush, new RectangleF(X, Y, Width, Height), format);
             }
@@ -144,9 +146,11 @@ namespace LiveSplit.UI
 
                     if (HasShadow)
                     {
-                        var shadowBrush = new SolidBrush(ShadowColor);
-                        g.DrawString(curChar.ToString(), Font, shadowBrush, new RectangleF(X + 1 + offset - curOffset * 2f, Y + 1, curOffset * 5f, Height), monoFormat);
-                        g.DrawString(curChar.ToString(), Font, shadowBrush, new RectangleF(X + 2 + offset - curOffset * 2f, Y + 2, curOffset * 5f, Height), monoFormat);
+                        using (var shadowBrush = new SolidBrush(ShadowColor))
+                        {
+                            g.DrawString(curChar.ToString(), Font, shadowBrush, new RectangleF(X + 1 + offset - curOffset * 2f, Y + 1, curOffset * 5f, Height), monoFormat);
+                            g.DrawString(curChar.ToString(), Font, shadowBrush, new RectangleF(X + 2 + offset - curOffset * 2f, Y + 2, curOffset * 5f, Height), monoFormat);
+                        }
                     }
 
                     g.DrawString(cutOffText[charIndex].ToString(), Font, Brush, new RectangleF(X + offset - curOffset / 2f, Y, curOffset * 2f, Height), monoFormat);

--- a/LiveSplit/LiveSplit.Core/Updates/ScrollableMessageBox.cs
+++ b/LiveSplit/LiveSplit.Core/Updates/ScrollableMessageBox.cs
@@ -92,9 +92,11 @@ namespace LiveSplit.Updates
         public DialogResult ShowFromFile(string filename, string caption, MessageBoxButtons buttonType)
         {
             // read the file into the message box
-            StreamReader sr = new StreamReader(filename);
-            txtMessage.Text = sr.ReadToEnd();
-            sr.Close();
+            using (StreamReader sr = new StreamReader(filename))
+            {
+                txtMessage.Text = sr.ReadToEnd();
+            }
+
             this.Text = caption;
             ChooseButtons(buttonType);
             this.ActiveControl = this.Controls[this.Controls.Count - 1];

--- a/LiveSplit/LiveSplit.Core/Web/Share/Screenshot.cs
+++ b/LiveSplit/LiveSplit.Core/Web/Share/Screenshot.cs
@@ -63,13 +63,16 @@ namespace LiveSplit.Web.Share
             try
             {
                 var image = screenShotFunction();
-                var dialog = new SaveFileDialog();
-                dialog.Filter = "PNG (*.png)|*.png|JPEG (*.jpeg)|*.jpeg|GIF (*.gif)|*.gif|Bitmap (*.bmp)|*.bmp|TIFF (*.tiff)|*.tiff|WMF (*.wmf)|*.wmf";
-                var result = dialog.ShowDialog();
-                if (result == DialogResult.OK)
+
+                using (var dialog = new SaveFileDialog())
                 {
-                    image.Save(dialog.FileName);
-                    return true;
+                    dialog.Filter = "PNG (*.png)|*.png|JPEG (*.jpeg)|*.jpeg|GIF (*.gif)|*.gif|Bitmap (*.bmp)|*.bmp|TIFF (*.tiff)|*.tiff|WMF (*.wmf)|*.wmf";
+                    var result = dialog.ShowDialog();
+                    if (result == DialogResult.OK)
+                    {
+                        image.Save(dialog.FileName);
+                        return true;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Since these object instances internally inherit from IDisposable, they should be disposed. Especially so for graphics drawing, since it frees up GDI handles.
