### PR TITLE
TimerForm: Use FileMode.Create instead of bitwise ORs.

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1622,7 +1622,7 @@ namespace LiveSplit.View
             {
                 if (!File.Exists(savePath))
                     File.Create(savePath).Close();
-                using (var stream = File.Open(savePath, FileMode.OpenOrCreate | FileMode.Truncate, FileAccess.Write))
+                using (var stream = File.Open(savePath, FileMode.Create, FileAccess.Write))
                 {
                     RunSaver.Save(stateCopy.Run, stream);
                     CurrentState.Run.HasChanged = false;
@@ -1663,7 +1663,7 @@ namespace LiveSplit.View
             {
                 if (!File.Exists(savePath))
                     File.Create(savePath).Close();
-                using (var stream = File.Open(savePath, FileMode.OpenOrCreate | FileMode.Truncate, FileAccess.Write))
+                using (var stream = File.Open(savePath, FileMode.Create, FileAccess.Write))
                 {
                     LayoutSaver.Save(Layout, stream);
                     Layout.HasChanged = false;
@@ -2125,7 +2125,7 @@ namespace LiveSplit.View
             var settingsPath = Path.Combine(BasePath, SETTINGS_PATH);
             if (!File.Exists(settingsPath))
                 File.Create(settingsPath).Close();
-            using (var stream = File.Open(settingsPath, FileMode.OpenOrCreate | FileMode.Truncate, FileAccess.Write))
+            using (var stream = File.Open(settingsPath, FileMode.Create, FileAccess.Write))
             {
                 SettingsSaver.Save(Settings, stream);
             }


### PR DESCRIPTION
FileMode.Create will create a new file if it doesn't exist. If it encounters a file that exists, then it truncates it.

Also since the FileMode enum isn't marked with a [Flags] attribute, the previous code is technically incorrect.