### PR TITLE
TimerForm: Eliminate redundant stream creation

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1511,7 +1511,7 @@ namespace LiveSplit.View
         {
             using (var stream = File.OpenRead(filePath))
             {
-                var layout = new XMLLayoutFactory(File.OpenRead(filePath)).Create(CurrentState);
+                var layout = new XMLLayoutFactory(stream).Create(CurrentState);
                 layout.FilePath = filePath;
                 Settings.AddToRecentLayouts(filePath);
                 UpdateRecentLayouts();


### PR DESCRIPTION
This could have also technically caused an exception, since the second call was attempting to open a file that was already opened.