### PR TITLE
RunEditorDialog: Uppercase url

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -991,7 +991,7 @@ namespace LiveSplit.View
                         catch (Exception ex)
                         {
                             Log.Error(ex);
-                            MessageBox.Show("The url was not recognized as an image.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            MessageBox.Show("The URL was not recognized as an image.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                 }


### PR DESCRIPTION
Other strings use the upper-case form, so this keeps it consistent.