### PR TITLE
TimerForm: Get rid of two possible exception throws

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -154,7 +154,7 @@ namespace LiveSplit.View
             UpdateRecentSplits();
             UpdateRecentLayouts();
 
-            IRun run = null;
+            IRun run = TimerOnlyRun;
             try
             {
                 if (!string.IsNullOrEmpty(splitsPath))
@@ -163,14 +163,13 @@ namespace LiveSplit.View
                 }
                 else
                 {
-                    run = LoadRunFromFile(Settings.RecentSplits.Last(), true);
+                    if (Settings.RecentSplits.Count > 0)
+                        run = LoadRunFromFile(Settings.RecentSplits.Last(), true);
                 }
             }
             catch (Exception e)
             {
                 Log.Error(e);
-
-                run = TimerOnlyRun;
             }
 
             run.FixSplits();
@@ -185,20 +184,24 @@ namespace LiveSplit.View
                 }
                 else
                 {
-                    Layout = LoadLayoutFromFile(Settings.RecentLayouts.Last());
+                    if (Settings.RecentLayouts.Count > 0)
+                    {
+                        Layout = LoadLayoutFromFile(Settings.RecentLayouts.Last());
+                    }
+                    else if (run == TimerOnlyRun)
+                    {
+                        Layout = TimerOnlyLayout;
+                        InTimerOnlyMode = true;
+                    }
+                    else
+                    {
+                        Layout = new StandardLayoutFactory().Create(CurrentState);
+                    }
                 }
             }
             catch (Exception e)
             {
-                Log.Error(e);
-
-                if (run == TimerOnlyRun)
-                {
-                    Layout = TimerOnlyLayout;
-                    InTimerOnlyMode = true;
-                }
-                else
-                    Layout = new StandardLayoutFactory().Create(CurrentState);
+                Log.Error(e); 
             }
 
             CurrentState.LayoutSettings = Layout.Settings;


### PR DESCRIPTION
Calling .Last() on a collection that's empty results in an InvalidOperationException to be thrown. Gets rid of overall noise on loading up LiveSplit.