### PR TITLE
ShortNameExtensions: Prevent multiple re-enumerations of an IEnumerable

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/ShortNameExtensions.cs
+++ b/LiveSplit/LiveSplit.Core/Model/ShortNameExtensions.cs
@@ -31,8 +31,8 @@ namespace LiveSplit.Model
                 var splits = name.Split(new[] { splitToken }, 2, StringSplitOptions.None);
                 var seriesTitle = splits[0];
                 var subTitle = splits[1];
-                var seriesTitleAbbreviations = seriesTitle.GetShortNames();
-                var subTitleAbbreviations = subTitle.GetShortNames();
+                var seriesTitleAbbreviations = seriesTitle.GetShortNames().ToList();
+                var subTitleAbbreviations = subTitle.GetShortNames().ToList();
                 var seriesTitleTrimmed = seriesTitle.Trim();
 
                 var isSeriesTitleRepresentative = !string.IsNullOrEmpty(seriesTitleTrimmed)


### PR DESCRIPTION
Due to how IEnumerable functions, iterating over these directly will actually call GetShortNames() twice for each collection, which is not necessary. Reifying them into lists prevents this.