### PR TITLE
TimerModel: Remove unnecessary default parameter

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
@@ -106,7 +106,7 @@ namespace LiveSplit.Model
             Reset(true);
         }
 
-        public void Reset(bool updateSplits = true)
+        public void Reset(bool updateSplits)
         {
             if (CurrentState.CurrentPhase != TimerPhase.NotRunning)
             {


### PR DESCRIPTION
Reset without parameters does the same thing.