### PR TITLE
Made cancel button affect Auto Splitters as well

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
+++ b/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
@@ -13,7 +13,7 @@ namespace LiveSplit.Model
     {
         Component, Script
     }
-    public class AutoSplitter
+    public class AutoSplitter : ICloneable
     {
         public string Description { get; set; }
         public IEnumerable<string> Games { get; set; }
@@ -87,6 +87,20 @@ namespace LiveSplit.Model
                 Component.Dispose();
                 Component = null;
             }
+        }
+
+        public object Clone()
+        {
+            return new AutoSplitter()
+            {
+                Description = Description,
+                Games = new List<string>(Games),
+                URLs = new List<string>(URLs),
+                Type = Type,
+                ShowInLayoutEditor = ShowInLayoutEditor,
+                Component = Component,
+                Factory = Factory
+            };
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/Model/AutoSplitterFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/AutoSplitterFactory.cs
@@ -74,15 +74,16 @@ namespace LiveSplit.Model
                 //autoSplitters.Load("https://raw.githubusercontent.com/LiveSplit/LiveSplit/master/LiveSplit.AutoSplitters.DevBuild.xml");
                 autoSplitters.Load("https://raw.githubusercontent.com/LiveSplit/LiveSplit/master/LiveSplit.AutoSplitters.xml");
                 autoSplitters.Save("LiveSplit.AutoSplitters.xml");
-                return autoSplitters;
             }
             catch (Exception ex)
             {
                 Log.Error(ex);
                 if (File.Exists("LiveSplit.AutoSplitters.xml"))
                     autoSplitters.Load("LiveSplit.AutoSplitters.xml");
-                return null;
+                else
+                    return null;
             }
+            return autoSplitters;
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/Model/Run.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Run.cs
@@ -178,7 +178,8 @@ namespace LiveSplit.Model
                 FilePath = FilePath,
                 CustomComparisons = new List<string>(CustomComparisons),
                 ComparisonGenerators = new List<IComparisonGenerator>(ComparisonGenerators),
-                AutoSplitter = AutoSplitter != null ? (AutoSplitter)AutoSplitter.Clone() : null
+                AutoSplitter = AutoSplitter != null ? (AutoSplitter)AutoSplitter.Clone() : null,
+                AutoSplitterSettings = AutoSplitterSettings
             };
         }
 

--- a/LiveSplit/LiveSplit.Core/Model/Run.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Run.cs
@@ -178,7 +178,7 @@ namespace LiveSplit.Model
                 FilePath = FilePath,
                 CustomComparisons = new List<string>(CustomComparisons),
                 ComparisonGenerators = new List<IComparisonGenerator>(ComparisonGenerators),
-                AutoSplitter = AutoSplitter
+                AutoSplitter = AutoSplitter != null ? (AutoSplitter)AutoSplitter.Clone() : null
             };
         }
 

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -212,7 +212,7 @@
             this.cbxGameName.Name = "cbxGameName";
             this.cbxGameName.Size = new System.Drawing.Size(427, 21);
             this.cbxGameName.TabIndex = 1;
-            this.cbxGameName.TextChanged += new System.EventHandler(this.tbxGameName_TextChanged);
+            this.cbxGameName.TextChanged += new System.EventHandler(this.cbxGameName_TextChanged);
             // 
             // cbxRunCategory
             // 
@@ -223,7 +223,7 @@
             this.cbxRunCategory.Name = "cbxRunCategory";
             this.cbxRunCategory.Size = new System.Drawing.Size(427, 21);
             this.cbxRunCategory.TabIndex = 2;
-            this.cbxRunCategory.TextChanged += new System.EventHandler(this.tbxRunCategory_TextChanged);
+            this.cbxRunCategory.TextChanged += new System.EventHandler(this.cbxRunCategory_TextChanged);
             // 
             // tbxTimeOffset
             // 

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -118,7 +118,6 @@ namespace LiveSplit.View
             runGrid.Columns.Add(column);
 
             column = new DataGridViewTextBoxColumn();
-            //column.DataPropertyName = "PersonalBestSplitTime";
             column.Name = "Split Time";
             column.Width = 100;
             column.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
@@ -132,11 +131,9 @@ namespace LiveSplit.View
             column.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
             column.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
             column.SortMode = DataGridViewColumnSortMode.NotSortable;
-            //column.ReadOnly = true;
             runGrid.Columns.Add(column);
 
             column = new DataGridViewTextBoxColumn();
-            //column.DataPropertyName = "BestSegmentTime";
             column.Name = "Best Segment";
             column.Width = 100;
             column.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
@@ -182,7 +179,6 @@ namespace LiveSplit.View
                 });
 
             cbxGameName.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
-            cbxGameName.TextChanged += cbxGameName_TextChanged;
 
             cbxRunCategory.AutoCompleteSource = AutoCompleteSource.ListItems;
             cbxRunCategory.Items.AddRange(new[] { "Any%", "Low%", "100%" });
@@ -190,23 +186,27 @@ namespace LiveSplit.View
 
             RefreshCategoryAutoCompleteList();
             UpdateSegmentList();
-            cbxGameName_TextChanged(this, null);
+            RefreshAutoSplittingUI();
         }
 
         void cbxGameName_TextChanged(object sender, EventArgs e)
         {
-            DeactivateAutoSplitter();
-            var splitter = AutoSplitterFactory.Instance.Create(cbxGameName.Text);
-            Run.AutoSplitter = splitter;
-            if (splitter != null && CurrentState.Settings.ActiveAutoSplitters.Contains(cbxGameName.Text))
+            if (IsInitialized)
             {
-                splitter.Activate(CurrentState);
-                if (Run.AutoSplitterSettings != null
-                && splitter.IsActivated
-                && Run.AutoSplitterSettings.Attributes["gameName"].InnerText == cbxGameName.Text)
-                    Run.AutoSplitter.Component.SetSettings(Run.AutoSplitterSettings);
+                DeactivateAutoSplitter();
+                var splitter = AutoSplitterFactory.Instance.Create(cbxGameName.Text);
+                Run.AutoSplitter = splitter;
+                if (splitter != null && CurrentState.Settings.ActiveAutoSplitters.Contains(cbxGameName.Text))
+                {
+                    splitter.Activate(CurrentState);
+                    if (Run.AutoSplitterSettings != null
+                    && splitter.IsActivated
+                    && Run.AutoSplitterSettings.Attributes["gameName"].InnerText == cbxGameName.Text)
+                        Run.AutoSplitter.Component.SetSettings(Run.AutoSplitterSettings);
+                }
+                RefreshAutoSplittingUI();
             }
-            RefreshAutoSplittingUI();
+            RaiseRunEdited();
         }
 
         private void DeactivateAutoSplitter()
@@ -880,12 +880,7 @@ namespace LiveSplit.View
             }
         }
 
-        private void tbxGameName_TextChanged(object sender, EventArgs e)
-        {
-            RaiseRunEdited();
-        }
-
-        private void tbxRunCategory_TextChanged(object sender, EventArgs e)
+        private void cbxRunCategory_TextChanged(object sender, EventArgs e)
         {
             RaiseRunEdited();
         }

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -211,7 +211,7 @@ namespace LiveSplit.View
 
         private void DeactivateAutoSplitter()
         {
-            if (Run.AutoSplitter != null)
+            if (Run.IsAutoSplitterActive())
                 Run.AutoSplitter.Deactivate();
         }
 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1695,6 +1695,7 @@ namespace LiveSplit.View
             var autoSplitterSettings = CurrentState.Run.IsAutoSplitterActive()
                 ? CurrentState.Run.AutoSplitter.Component.GetSettings(new XmlDocument()) 
                 : null;
+            var activeAutoSplitters = new List<string>(CurrentState.Settings.ActiveAutoSplitters);
             var editor = new RunEditorDialog(CurrentState);
             editor.RunEdited += editor_RunEdited;
             editor.ComparisonRenamed += editor_ComparisonRenamed;
@@ -1708,10 +1709,7 @@ namespace LiveSplit.View
                 var result = editor.ShowDialog(this);
                 if (result == DialogResult.Cancel)
                 {
-                    if (CurrentState.Run.IsAutoSplitterActive() && !CurrentState.Settings.ActiveAutoSplitters.Contains(CurrentState.Run.GameName))
-                        CurrentState.Settings.ActiveAutoSplitters.Add(CurrentState.Run.GameName);
-                    else if (!CurrentState.Run.IsAutoSplitterActive() && CurrentState.Settings.ActiveAutoSplitters.Contains(CurrentState.Run.GameName))
-                        CurrentState.Settings.ActiveAutoSplitters.Remove(CurrentState.Run.GameName);
+                    CurrentState.Settings.ActiveAutoSplitters = activeAutoSplitters;
                     SetRun(runCopy);
                     CurrentState.CallRunManuallyModified();
                     if (CurrentState.Run.IsAutoSplitterActive())

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1692,9 +1692,6 @@ namespace LiveSplit.View
         private void EditSplits()
         {
             var runCopy = CurrentState.Run.Clone() as IRun;
-            var autoSplitterSettings = CurrentState.Run.IsAutoSplitterActive()
-                ? CurrentState.Run.AutoSplitter.Component.GetSettings(new XmlDocument()) 
-                : null;
             var activeAutoSplitters = new List<string>(CurrentState.Settings.ActiveAutoSplitters);
             var editor = new RunEditorDialog(CurrentState);
             editor.RunEdited += editor_RunEdited;
@@ -1712,8 +1709,6 @@ namespace LiveSplit.View
                     CurrentState.Settings.ActiveAutoSplitters = activeAutoSplitters;
                     SetRun(runCopy);
                     CurrentState.CallRunManuallyModified();
-                    if (CurrentState.Run.IsAutoSplitterActive())
-                        CurrentState.Run.AutoSplitter.Component.SetSettings(autoSplitterSettings);
                 }
             }
             finally


### PR DESCRIPTION
The code we had before didn't do anything because it used
CurrentState.Run instead of runCopy and Auto Splitters weren't cloned so
the old settings could be set on an Auto Splitter without a component.

Currently the Auto Splitter's Component is disposed immediately when it is deactivated, but it should only be disposed if the user doesn't hit cancel (can be done similarly to Layout Components)

Fixes #190 