### PR TITLE
Core: Add missing SuppressFinalizer calls to LowLevelKeyboardHook

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Input/LowLevelKeyboardHook.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Input/LowLevelKeyboardHook.cs
@@ -243,6 +243,7 @@ namespace LiveSplit.Model.Input
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
The destructor/finalizer shouldn't be executed on normal Dispose functionality.