### PR TITLE
Update PercentileComparisonGenerator.cs

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
@@ -76,7 +76,7 @@ namespace LiveSplit.Model.Comparisons
                             curList.Add(PBindex.Value.Ticks);
                         else
                         {
-                            if (Run[allHistory.IndexOf(curList) - 1].PersonalBestSplitTime[method].HasValue)
+                            if (Run[index - 1].PersonalBestSplitTime[method].HasValue)
                                 curList.Add(PBindex.Value.Ticks - Run[index - 1].PersonalBestSplitTime[method].Value.Ticks);
                             else
                             {

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
@@ -68,8 +68,27 @@ namespace LiveSplit.Model.Comparisons
             {
                 if (curList.Count == 0)
                 {
-                    forceMedian = true;
-                    break;
+                    if (Run[allHistory.IndexOf(curList)].PersonalBestSplitTime[method].HasValue)
+                    {
+                        if (allHistory.IndexOf(curList) == 0)
+                            curList.Add(Run[allHistory.IndexOf(curList)].PersonalBestSplitTime[method].Value.Ticks);
+                        else
+                        {
+                            if (Run[allHistory.IndexOf(curList) - 1].PersonalBestSplitTime[method].HasValue)
+                                curList.Add(Run[allHistory.IndexOf(curList)].PersonalBestSplitTime[method].Value.Ticks - Run[allHistory.IndexOf(curList) - 1].PersonalBestSplitTime[method].Value.Ticks);
+                            else
+                            {
+                                forceMedian = true;
+                                break;
+                            }
+
+                        }
+                    }
+                    else
+                    {
+                        forceMedian = true;
+                        break;
+                    }
                 }
                 var tempList = curList.Select((x, i) => new KeyValuePair<double, double>(GetWeight(i, curList.Count), x)).ToList();
                 var weightedList = new List<KeyValuePair<double, double>>();

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
@@ -68,14 +68,16 @@ namespace LiveSplit.Model.Comparisons
             {
                 if (curList.Count == 0)
                 {
-                    if (Run[allHistory.IndexOf(curList)].PersonalBestSplitTime[method].HasValue)
+                    var index = allHistory.IndexOf(curList);
+                    var PBindex = Run[index].PersonalBestSplitTime[method];
+                    if (PBindex.HasValue)
                     {
                         if (allHistory.IndexOf(curList) == 0)
-                            curList.Add(Run[allHistory.IndexOf(curList)].PersonalBestSplitTime[method].Value.Ticks);
+                            curList.Add(PBindex.Value.Ticks);
                         else
                         {
                             if (Run[allHistory.IndexOf(curList) - 1].PersonalBestSplitTime[method].HasValue)
-                                curList.Add(Run[allHistory.IndexOf(curList)].PersonalBestSplitTime[method].Value.Ticks - Run[allHistory.IndexOf(curList) - 1].PersonalBestSplitTime[method].Value.Ticks);
+                                curList.Add(PBindex.Value.Ticks - Run[index - 1].PersonalBestSplitTime[method].Value.Ticks);
                             else
                             {
                                 forceMedian = true;


### PR DESCRIPTION
Allows estimates that are added into the PB spot to be included when there's no splits recorded for that segment.

Okay that description is hard to understand, just look at the code lol.