### PR TITLE
TimerForm: Explicitly specify marshalling types on P/Invoke functions with booleans

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -94,12 +94,9 @@ namespace LiveSplit.View
         public TimedBroadcasterPlugin XSplit { get; set; }
 #endif
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
         [DllImport("user32.dll")]
-        public static extern bool ReleaseCapture();
-        [DllImport("user32.dll")]
-        static extern int GetUpdateRgn(IntPtr hWnd, IntPtr hRgn, bool bErase);
+        static extern int GetUpdateRgn(IntPtr hWnd, IntPtr hRgn, [MarshalAs(UnmanagedType.Bool)] bool bErase);
+
         [DllImport("gdi32.dll")]
         static extern IntPtr CreateRectRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
 


### PR DESCRIPTION
This is recommended in Microsoft guidelines to differentiate between BOOL (which is a 32-bit int alias, and the C++ bool).

This also removes two unused P/Invoke function definitions.