### PR TITLE
Fix the Window Titles so that OBS can capture it

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -271,14 +271,13 @@ namespace LiveSplit.View
         {
             var lowestAvailableNumber = 0;
             var currentName = "LiveSplit";
-            foreach (var process in Process.GetProcesses().Where(x => x.ProcessName == "LiveSplit").OrderBy(x => x.MainWindowTitle))
+            var processNames = Process.GetProcessesByName("LiveSplit").Select(x => x.MainWindowTitle);
+
+            while (processNames.Contains(currentName))
             {
-                if (process.MainWindowTitle == currentName)
-                {
-                    lowestAvailableNumber++;
-                    currentName = String.Format("LiveSplit ({0})", lowestAvailableNumber);
-                }
+                currentName = String.Format("LiveSplit ({0})", ++lowestAvailableNumber);
             }
+
             this.Text = currentName;
         }
 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -121,6 +121,18 @@ namespace LiveSplit.View
 
         private void Init(string splitsPath = null, string layoutPath = null)
         {
+            var lowestAvailableNumber = 0;
+            var currentName = "LiveSplit";
+            foreach (var process in Process.GetProcesses().Where(x => x.ProcessName == "LiveSplit").OrderBy(x => x.MainWindowTitle))
+            {
+                if (process.MainWindowTitle == currentName)
+                {
+                    lowestAvailableNumber++;
+                    currentName = String.Format("LiveSplit ({0})", lowestAvailableNumber);
+                }
+            }
+            this.Text = currentName;
+
             GlobalCache = new GraphicsCache();
             Invalidator = new Invalidator(this);
             SetStyle(ControlStyles.SupportsTransparentBackColor, true);
@@ -1095,11 +1107,6 @@ namespace LiveSplit.View
                     {
                         if (Hook != null)
                             Hook.Poll();
-
-                        this.Text = string.Format("LiveSplit - {0} - {1} - {2}", 
-                            CurrentState.Run.GameName, 
-                            CurrentState.Run.CategoryName, 
-                            Path.GetFileNameWithoutExtension(Layout.FilePath ?? string.Empty));
 
                         if (CurrentState.Run.IsAutoSplitterActive())
                             CurrentState.Run.AutoSplitter.Component.Update(null, CurrentState, 0, 0, Layout.Mode);

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -121,17 +121,7 @@ namespace LiveSplit.View
 
         private void Init(string splitsPath = null, string layoutPath = null)
         {
-            var lowestAvailableNumber = 0;
-            var currentName = "LiveSplit";
-            foreach (var process in Process.GetProcesses().Where(x => x.ProcessName == "LiveSplit").OrderBy(x => x.MainWindowTitle))
-            {
-                if (process.MainWindowTitle == currentName)
-                {
-                    lowestAvailableNumber++;
-                    currentName = String.Format("LiveSplit ({0})", lowestAvailableNumber);
-                }
-            }
-            this.Text = currentName;
+            SetWindowTitle();
 
             GlobalCache = new GraphicsCache();
             Invalidator = new Invalidator(this);
@@ -275,6 +265,21 @@ namespace LiveSplit.View
             }
 
             TopMost = Layout.Settings.AlwaysOnTop;
+        }
+
+        void SetWindowTitle()
+        {
+            var lowestAvailableNumber = 0;
+            var currentName = "LiveSplit";
+            foreach (var process in Process.GetProcesses().Where(x => x.ProcessName == "LiveSplit").OrderBy(x => x.MainWindowTitle))
+            {
+                if (process.MainWindowTitle == currentName)
+                {
+                    lowestAvailableNumber++;
+                    currentName = String.Format("LiveSplit ({0})", lowestAvailableNumber);
+                }
+            }
+            this.Text = currentName;
         }
 
         void CurrentState_OnSwitchComparisonNext(object sender, EventArgs e)

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1096,6 +1096,11 @@ namespace LiveSplit.View
                         if (Hook != null)
                             Hook.Poll();
 
+                        this.Text = string.Format("LiveSplit - {0} - {1} - {2}", 
+                            CurrentState.Run.GameName, 
+                            CurrentState.Run.CategoryName, 
+                            Path.GetFileNameWithoutExtension(Layout.FilePath ?? string.Empty));
+
                         if (CurrentState.Run.IsAutoSplitterActive())
                             CurrentState.Run.AutoSplitter.Component.Update(null, CurrentState, 0, 0, Layout.Mode);
 


### PR DESCRIPTION
Due to LiveSplit always having the same class name and same window title, OBS couldn't differentiate between the different LiveSplit windows, which is why a lot of people preferred using WSplit as a secondary timer. This fixes that.

Fixes #287 

Note: I'm not sure if I like the solution of setting it every update. Otherwise we need to use a lot of events though, which might not be that cool.