### PR TITLE
Improved ComponentRenderer calculations

### DIFF
--- a/LiveSplit/LiveSplit.Core/UI/Components/ComponentRenderer.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ComponentRenderer.cs
@@ -132,7 +132,7 @@ namespace LiveSplit.UI.Components
             return component.HorizontalWidth - rightPadding * 2f;
         }
 
-        public void CalculateOverallHeight(LayoutMode mode)
+        public void CalculateOverallSize(LayoutMode mode)
         {
             var totalSize = 0f;
             var index = 0;
@@ -146,15 +146,9 @@ namespace LiveSplit.UI.Components
             }
 
             if (mode == LayoutMode.Vertical)
-            {
                 OverallHeight = totalSize;
-                OverallWidth = VisibleComponents.Aggregate(0.0f, (x, y) => x + y.HorizontalWidth);
-            }
             else
-            {
                 OverallWidth = totalSize;
-                OverallHeight = VisibleComponents.Aggregate(0.0f, (x, y) => x + y.VerticalHeight);
-            }
         }
 
         public void Render(Graphics g, LiveSplitState state, float width, float height, LayoutMode mode, Region clipRegion)
@@ -191,7 +185,6 @@ namespace LiveSplit.UI.Components
                     {
                         var remainingComponents = VisibleComponents.ToList();
                         crashedComponents.ForEach(x => remainingComponents.Remove(x));
-                        //crashedComponents.ForEach(x => MessageBox.Show(String.Format("The component {0} crashed.", x.ComponentName), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error));
                         VisibleComponents = remainingComponents;
                     }
                     g.Transform = transform;
@@ -202,7 +195,6 @@ namespace LiveSplit.UI.Components
                     errorInComponent = false;
                 }
             }
-            CalculateOverallHeight(mode);
         }
 
         protected void InvalidateVerticalComponent(int index, LiveSplitState state, IInvalidator invalidator, float width, float height, float scaleFactor)

--- a/LiveSplit/LiveSplit.Core/UI/Components/ComponentRenderer.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ComponentRenderer.cs
@@ -11,8 +11,7 @@ namespace LiveSplit.UI.Components
     {
         public IEnumerable<IComponent> VisibleComponents { get; set; }
 
-        public float OverallHeight = 10f;
-        public float OverallWidth = 10f;
+        public float OverallSize = 10f;
 
         public float MinimumWidth
         {
@@ -145,10 +144,7 @@ namespace LiveSplit.UI.Components
                 index++;
             }
 
-            if (mode == LayoutMode.Vertical)
-                OverallHeight = totalSize;
-            else
-                OverallWidth = totalSize;
+            OverallSize = totalSize;
         }
 
         public void Render(Graphics g, LiveSplitState state, float width, float height, LayoutMode mode, Region clipRegion)
@@ -221,8 +217,8 @@ namespace LiveSplit.UI.Components
         {
             var oldTransform = invalidator.Transform.Clone();
             var scaleFactor = mode == LayoutMode.Vertical
-                    ? height / OverallHeight
-                    : width / OverallWidth;
+                    ? height / OverallSize
+                    : width / OverallSize;
 
             for (var ind = 0; ind < VisibleComponents.Count(); ind++)
             {

--- a/LiveSplit/LiveSplit.Core/UI/Components/ComponentRendererComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ComponentRendererComponent.cs
@@ -14,7 +14,7 @@ namespace LiveSplit.UI.Components
             get
             {
                 CalculateOverallSize(LayoutMode.Vertical);
-                return OverallHeight;
+                return OverallSize;
             }
         }
         public float HorizontalWidth
@@ -22,7 +22,7 @@ namespace LiveSplit.UI.Components
             get
             {
                 CalculateOverallSize(LayoutMode.Horizontal);
-                return OverallWidth;
+                return OverallSize;
             }
         }
 

--- a/LiveSplit/LiveSplit.Core/UI/Components/ComponentRendererComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ComponentRendererComponent.cs
@@ -9,8 +9,22 @@ namespace LiveSplit.UI.Components
 {
     public class ComponentRendererComponent : ComponentRenderer, IComponent
     {
-        public float VerticalHeight { get { return OverallHeight; } }
-        public float HorizontalWidth { get { return OverallWidth; } }
+        public float VerticalHeight
+        {
+            get
+            {
+                CalculateOverallSize(LayoutMode.Vertical);
+                return OverallHeight;
+            }
+        }
+        public float HorizontalWidth
+        {
+            get
+            {
+                CalculateOverallSize(LayoutMode.Horizontal);
+                return OverallWidth;
+            }
+        }
 
         public float PaddingTop { get { return base.VisibleComponents.Count() > 0 ? base.VisibleComponents.First().PaddingTop : 0; } }
         public float PaddingLeft { get { return base.VisibleComponents.Count() > 0 ? base.VisibleComponents.First().PaddingLeft : 0; } }

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1188,8 +1188,8 @@ namespace LiveSplit.View
             ComponentRenderer.CalculateOverallSize(Layout.Mode);
 
             var scaleFactor = Layout.Mode == LayoutMode.Vertical
-                ? Height / Math.Max(ComponentRenderer.OverallHeight, 1f)
-                : Width / Math.Max(ComponentRenderer.OverallWidth, 1f);
+                ? Height / Math.Max(ComponentRenderer.OverallSize, 1f)
+                : Width / Math.Max(ComponentRenderer.OverallSize, 1f);
 
             g.ResetTransform();
             g.ScaleTransform(scaleFactor, scaleFactor);
@@ -1208,7 +1208,7 @@ namespace LiveSplit.View
 
             ComponentRenderer.Render(g, CurrentState, transformedWidth, transformedHeight, Layout.Mode, UpdateRegion);
                 
-            var currentSize = Layout.Mode == LayoutMode.Vertical ? ComponentRenderer.OverallHeight : ComponentRenderer.OverallWidth;
+            var currentSize = ComponentRenderer.OverallSize;
 
             if (OldSize >= 0)
             {
@@ -1222,9 +1222,9 @@ namespace LiveSplit.View
                 }
                 FixSize();
                 if (Layout.Mode == LayoutMode.Vertical)
-                    MinimumSize = new Size(100, (int)((ComponentRenderer.OverallHeight / 3) + 0.5f));
+                    MinimumSize = new Size(100, (int)((ComponentRenderer.OverallSize / 3) + 0.5f));
                 else
-                    MinimumSize = new Size((int)((ComponentRenderer.OverallWidth / 3) + 0.5f), 25);
+                    MinimumSize = new Size((int)((ComponentRenderer.OverallSize / 3) + 0.5f), 25);
             }
             else
             {
@@ -1818,7 +1818,7 @@ namespace LiveSplit.View
                 if (Layout.VerticalHeight == UI.Layout.InvalidSize || Layout.VerticalWidth == UI.Layout.InvalidSize)
                 {
                     Layout.VerticalWidth = 300;
-                    Layout.VerticalHeight = (int)(ComponentRenderer.OverallHeight + 0.5);
+                    Layout.VerticalHeight = (int)(ComponentRenderer.OverallSize + 0.5);
                 }
             }
             else
@@ -1827,7 +1827,7 @@ namespace LiveSplit.View
                 Layout.VerticalHeight = Size.Height;
                 if (Layout.HorizontalWidth == UI.Layout.InvalidSize || Layout.HorizontalHeight == UI.Layout.InvalidSize)
                 {
-                    Layout.HorizontalWidth = (int)(ComponentRenderer.OverallWidth + 0.5);
+                    Layout.HorizontalWidth = (int)(ComponentRenderer.OverallSize + 0.5);
                     Layout.HorizontalHeight = 45;
                 }
             }
@@ -2192,18 +2192,18 @@ namespace LiveSplit.View
 
         private void FixSize()
         {
-            var currentSize = Layout.Mode == LayoutMode.Vertical ? ComponentRenderer.OverallHeight : ComponentRenderer.OverallWidth;
+            var currentSize = ComponentRenderer.OverallSize;
             if (OldSize >= 0)
             {
                 if (Layout.Mode == LayoutMode.Vertical)
                 {
-                    var minimumWidth = ComponentRenderer.MinimumWidth * (Height / ComponentRenderer.OverallHeight);
+                    var minimumWidth = ComponentRenderer.MinimumWidth * (Height / ComponentRenderer.OverallSize);
                     if (Width < minimumWidth)
                         Height = (int)(Height / (minimumWidth / Width) + 0.5f);
                 }
                 else
                 {
-                    var minimumHeight = ComponentRenderer.MinimumHeight * (Width / ComponentRenderer.OverallWidth);
+                    var minimumHeight = ComponentRenderer.MinimumHeight * (Width / ComponentRenderer.OverallSize);
                     if (Height < minimumHeight)
                         Width = (int)(Width / (minimumHeight / Height) + 0.5f);
                 }


### PR DESCRIPTION
Lowers the required negative OldSize (which is there for components that
can't calculate their size until they're rendered) and removes
unnecessary extra invalidations whenever something like the Run changes.
Overall should speed up LiveSplit quite a bit in these situations.

Since this is a somewhat risky change, it probably needs more testing.