### PR TITLE
Program: Display the crash dialog in Release mode

### DIFF
--- a/LiveSplit/LiveSplit/Program.cs
+++ b/LiveSplit/LiveSplit/Program.cs
@@ -39,15 +39,10 @@ namespace LiveSplit
                 if (Twitch.Instance != null)
                     Twitch.Instance.CloseAllChatConnections();
             }
-#if !DEBUG
             catch (Exception e)
             {
                 Log.Error(e);
-                MessageBox.Show("LiveSplit crashed due to an unknown cause.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-#endif
-            finally
-            {
+                MessageBox.Show(string.Format("LiveSplit has crashed due to the following reason:\n\n{0}", e.Message), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
     }


### PR DESCRIPTION
Makes crash reporting from users easier, as they can now indicate (and moreover, actually see) what the reason for a crash is.