### PR TITLE
Program: Display the exception string in the crash dialog

### DIFF
--- a/LiveSplit/LiveSplit/Program.cs
+++ b/LiveSplit/LiveSplit/Program.cs
@@ -43,7 +43,7 @@ namespace LiveSplit
             catch (Exception e)
             {
                 Log.Error(e);
-                MessageBox.Show("LiveSplit crashed due to an unknown cause.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format("LiveSplit has crashed due to the following reason:\n\n{0}", e.Message), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 #endif
             finally


### PR DESCRIPTION
Makes crash reporting from users easier, as they can now indicate what the reason for the crash is.

Github wouldn't let me re-open the previous PR, so I've opened a new one.