### PR TITLE
Fixed autosplitter urls

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -788,7 +788,7 @@
       <Game>Quake</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/kugelrund/LiveSplit.Quake/blob/master/Components/LiveSplit.Quake.dll</URL>
+      <URL>https://github.com/kugelrund/LiveSplit.Quake/raw/master/Components/LiveSplit.Quake.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>For joequake-gl with qdqstats. Game Time is available. (By Sphere)</Description>
@@ -799,7 +799,7 @@
       <Game>Quake II</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/kugelrund/LiveSplit.Quake2/blob/master/Components/LiveSplit.Quake2.dll</URL>
+      <URL>https://github.com/kugelrund/LiveSplit.Quake2/raw/master/Components/LiveSplit.Quake2.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>For q2pro. Load removal is available. (By Sphere)</Description>
@@ -809,7 +809,7 @@
       <Game>Star Trek: Voyager - Elite Force</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/kugelrund/LiveSplit.StVoyEf/blob/master/Components/LiveSplit.StVoyEf.dll</URL>
+      <URL>https://github.com/kugelrund/LiveSplit.StVoyEf/raw/master/Components/LiveSplit.StVoyEf.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>Load removal is available. (By Sphere)</Description>
@@ -820,7 +820,7 @@
       <Game>Star Trek: Elite Force II</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/kugelrund/LiveSplit.StEf2/blob/master/Components/LiveSplit.StEf2.dll</URL>
+      <URL>https://github.com/kugelrund/LiveSplit.StEf2/raw/master/Components/LiveSplit.StEf2.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>Load removal is available. (By Sphere)</Description>


### PR DESCRIPTION
accidentally used the blob instead of the raw github url