### PR TITLE
Implement AutoCompletion for Game Names

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -35,7 +35,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
-            this.cbxGameName = new LiveSplit.View.CustomAutoCompleteComboBox();
+            this.cbxGameName = new LiveSplit.View.CustomAutoCompleteComboBox(this);
             this.cbxRunCategory = new System.Windows.Forms.ComboBox();
             this.tbxTimeOffset = new System.Windows.Forms.TextBox();
             this.picGameIcon = new System.Windows.Forms.PictureBox();

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -35,7 +35,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
-            this.cbxGameName = new System.Windows.Forms.ComboBox();
+            this.cbxGameName = new LiveSplit.View.CustomAutoCompleteComboBox();
             this.cbxRunCategory = new System.Windows.Forms.ComboBox();
             this.tbxTimeOffset = new System.Windows.Forms.TextBox();
             this.picGameIcon = new System.Windows.Forms.PictureBox();
@@ -214,6 +214,7 @@
             // 
             this.cbxGameName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.cbxGameName, 5);
+            this.cbxGameName.GetAllItemsForText = null;
             this.cbxGameName.Location = new System.Drawing.Point(246, 12);
             this.cbxGameName.Margin = new System.Windows.Forms.Padding(5, 0, 10, 0);
             this.cbxGameName.Name = "cbxGameName";
@@ -693,7 +694,7 @@
         private System.Windows.Forms.ContextMenuStrip RemoveIconMenu;
         private System.Windows.Forms.ToolStripMenuItem removeIconToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem setIconToolStripMenuItem;
-        private System.Windows.Forms.ComboBox cbxGameName;
+        private CustomAutoCompleteComboBox cbxGameName;
         private System.Windows.Forms.ComboBox cbxRunCategory;
         private System.Windows.Forms.TextBox tbxTimeOffset;
         private System.Windows.Forms.TextBox tbxAttempts;

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1456,7 +1456,8 @@ namespace LiveSplit.View
         {
             foreach (Control childControl in control.Controls)
             {
-                SetClickEvents(childControl);
+                if (childControl is Label || childControl is TableLayoutPanel || childControl is PictureBox || childControl is FlowLayoutPanel)
+                    SetClickEvents(childControl);
             }
             control.Click += ClickControl;
         }
@@ -1504,6 +1505,13 @@ namespace LiveSplit.View
                     }
                 }
             }
+        }
+
+        protected override void OnLostFocus(EventArgs e)
+        {
+            base.OnLostFocus(e);
+            if (!_dropDown.Focused)
+                CloseDropDown();
         }
 
         public void CloseDropDown()

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1513,6 +1513,12 @@ namespace LiveSplit.View
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
+            if (e.KeyCode == Keys.Down)
+            {
+                if (_box.Items.Count > 0)
+                    SelectedItem = _box.Items[0];
+                CloseDropDown();
+            }
             if (e.KeyCode == Keys.Down || e.KeyCode == Keys.Up)
                 e.SuppressKeyPress = true;
             base.OnKeyDown(e);

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1487,24 +1487,27 @@ namespace LiveSplit.View
         protected override void OnTextChanged(EventArgs e)
         {
             base.OnTextChanged(e);
-            lock(_box)
+
+            _dropDown.AutoClose = false;
+            if (Text != "")
             {
-                _dropDown.AutoClose = false;
-                if (Text != "")
+                var legalStrings = GetAllItemsForText(Text);
+                if (legalStrings.Count() > 0 && Text != legalStrings.First())
                 {
-                    var legalStrings = GetAllItemsForText(Text);
-                    if (legalStrings.Count() > 0 && Text != legalStrings.First())
+                    lock (_box)
                     {
                         _box.Items.Clear();
                         if (string.IsNullOrEmpty(_startString) == false)
                             _box.Items.Add(_startString);
                         foreach (string str in legalStrings)
                             _box.Items.Add(str);
-                        DroppedDown = false;
-                        _dropDown.Show(this, new Point(0, Height));
                     }
+                    DroppedDown = false;
+                    _dropDown.Show(this, new Point(0, Height));
                 }
             }
+            else
+                CloseDropDown();
         }
 
         protected override void OnLostFocus(EventArgs e)

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -238,6 +238,7 @@ namespace LiveSplit.View
             RefreshCategoryAutoCompleteList();
             UpdateSegmentList();
             RefreshAutoSplittingUI();
+            SetClickEvents(this);
         }
 
         private IEnumerable<string> SearchForGameName(string name)
@@ -1445,6 +1446,21 @@ namespace LiveSplit.View
             SumOfBest.Clean(Run, callback);
             RaiseRunEdited();
         }
+
+        private void ClickControl(object sender, EventArgs e)
+        {
+            cbxGameName.CloseDropDown();
+        }
+
+        private void SetClickEvents(Control control)
+        {
+            foreach (Control childControl in control.Controls)
+            {
+                if (childControl != cbxGameName)
+                    SetClickEvents(childControl);
+            }
+            control.Click += ClickControl;
+        }
     }
 
     public class CustomAutoCompleteComboBox : ComboBox
@@ -1488,6 +1504,11 @@ namespace LiveSplit.View
                     }
                 }
             }
+        }
+
+        public void CloseDropDown()
+        {
+            _dropDown.Close();
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1456,8 +1456,7 @@ namespace LiveSplit.View
         {
             foreach (Control childControl in control.Controls)
             {
-                if (childControl != cbxGameName)
-                    SetClickEvents(childControl);
+                SetClickEvents(childControl);
             }
             control.Click += ClickControl;
         }
@@ -1500,6 +1499,7 @@ namespace LiveSplit.View
                             _box.Items.Add(_startString);
                         foreach (string str in legalStrings)
                             _box.Items.Add(str);
+                        DroppedDown = false;
                         _dropDown.Show(this, new Point(0, Height));
                     }
                 }


### PR DESCRIPTION
This uses the automatic abbreviations for game names in order to
generate suggestions in the Splits Editor.

Resolves #286 