### PR TITLE
Added extra game names for GTA5 load remover

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -944,6 +944,11 @@
       <Game>Grand Theft Auto 5</Game>
       <Game>GTAV</Game>
       <Game>GTA5</Game>
+      <Game>Grand Theft Auto Online</Game>
+      <Game>Grand Theft Auto: Online</Game>
+      <Game>GTA Online</Game>
+      <Game>GTA: Online</Game>
+      <Game>GTAO</Game>
     </Games>
     <URLs>
       <URL>https://raw.githubusercontent.com/zoton2/LiveSplit.Scripts/master/Release/LiveSplit.GTAV.asl</URL>


### PR DESCRIPTION
"Grand Theft Auto Online" is now a game on speedrun.com so thought it would be good to add the names to this too.