### PR TITLE
Update LiveSplit.AutoSplitters.xml

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -729,6 +729,7 @@
       <Game>Bio Inf</Game>
       <Game>BioShock Infinite</Game>
       <Game>BioShock Infinite (PC)</Game>
+      <Game>BioShock Infinite: Burial at Sea (DLCs)</Game>
     </Games>
     <URLs>
       <URL>https://raw.githubusercontent.com/dread2472/ASL/master/BioInf.asl</URL>


### PR DESCRIPTION
Add load-removal for BioShock Infinite: Burial at Sea (DLCs), as Dread's BioShock Infinite load remover works on the DLC too.