### PR TITLE
Updated game titles for KotOR and KotOR 2

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -504,6 +504,7 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
+      <Game>Star Wars: Knights of the Old Republic</Game>
       <Game>Knights of the Old Republic</Game>
       <Game>KotOR</Game>
     </Games>
@@ -515,6 +516,8 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
+      <Game>Star Wars: Knights of the Old Republic II</Game>
+      <Game>Star Wars: Knights of the Old Republic 2</Game>
       <Game>Knights of the Old Republic II</Game>
       <Game>Knights of the Old Republic 2</Game>
       <Game>KotOR II</Game>


### PR DESCRIPTION
Added the option to include "Star Wars: " in the long form title of both games.