### PR TITLE
Autosplitter Script/Component download change

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
+++ b/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
@@ -71,16 +71,7 @@ namespace LiveSplit.Model
                     // Download to temp file so the original file is kept if it fails downloading
                     client.DownloadFile(new Uri(url), tempLocalPath);
                     File.Copy(tempLocalPath, localPath, true);
-                    try
-                    {
-                        // This is not required to run the AutoSplitter, but should still try to clean up
-                        File.Delete(tempLocalPath);
-                    }
-                    catch (Exception)
-                    {
-                        Log.Error($"Failed to delete temp file: {tempLocalPath}");
-                    }
-                    
+
                     if (url != URLs.First())
                     {
                         var factory = ComponentManager.LoadFactory(localPath);
@@ -96,6 +87,18 @@ namespace LiveSplit.Model
                 {
                     // Catch errors of File.Copy() if necessary
                     Log.Error(ex);
+                }
+                finally
+                {
+                    try
+                    {
+                        // This is not required to run the AutoSplitter, but should still try to clean up
+                        File.Delete(tempLocalPath);
+                    }
+                    catch (Exception)
+                    {
+                        Log.Error($"Failed to delete temp file: {tempLocalPath}");
+                    }
                 }
             }
 

--- a/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
+++ b/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
@@ -62,11 +62,16 @@ namespace LiveSplit.Model
             foreach (var url in URLs)
             {
                 var fileName = url.Substring(url.LastIndexOf('/') + 1);
+                var tempFileName = fileName + "-temp";
                 var localPath = Path.GetFullPath(Path.Combine(ComponentManager.BasePath ?? "", ComponentManager.PATH_COMPONENTS, fileName));
+                var localPathTemp = Path.GetFullPath(Path.Combine(ComponentManager.BasePath ?? "", ComponentManager.PATH_COMPONENTS, tempFileName));
 
                 try
                 {
-                    client.DownloadFile(new Uri(url), localPath);
+                    // Download to temp file so the original file is kept if it fails downloading
+                    client.DownloadFile(new Uri(url), localPathTemp);
+                    File.Copy(localPathTemp, localPath, true);
+                    File.Delete(localPathTemp);
                     if (url != URLs.First())
                     {
                         var factory = ComponentManager.LoadFactory(localPath);


### PR DESCRIPTION
Download to temp file so ASL scripts don't get entirely deleted when downloading fails.