### PR TITLE
Added Comparison Warning For Auto Splitters

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -62,6 +62,7 @@
             this.btnWebsite = new System.Windows.Forms.Button();
             this.btnSettings = new System.Windows.Forms.Button();
             this.btnActivate = new System.Windows.Forms.Button();
+            this.lblAutoSplitterCompareAgainstWarning = new System.Windows.Forms.Label();
             this.RemoveIconMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.setIconToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.downloadBoxartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -104,31 +105,30 @@
             this.tableLayoutPanel1.SetColumnSpan(this.runGrid, 9);
             this.runGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.runGrid.GridColor = System.Drawing.Color.Gainsboro;
-            this.runGrid.Location = new System.Drawing.Point(144, 170);
-            this.runGrid.Margin = new System.Windows.Forms.Padding(4, 0, 10, 10);
+            this.runGrid.Location = new System.Drawing.Point(288, 326);
+            this.runGrid.Margin = new System.Windows.Forms.Padding(8, 0, 20, 19);
             this.runGrid.Name = "runGrid";
             this.runGrid.RowHeadersVisible = false;
             this.runGrid.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
             this.tableLayoutPanel1.SetRowSpan(this.runGrid, 8);
             this.runGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-            this.runGrid.Size = new System.Drawing.Size(530, 295);
+            this.runGrid.Size = new System.Drawing.Size(1060, 569);
             this.runGrid.TabIndex = 0;
             this.runGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.runGrid_KeyDown);
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 10;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 140F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 39F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 62F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 49F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 136F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 104F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 88F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 280F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 78F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 124F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 98F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 272F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 208F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 176F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 115F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 230F));
             this.tableLayoutPanel1.Controls.Add(this.label2, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.label3, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.label1, 1, 3);
@@ -136,42 +136,44 @@
             this.tableLayoutPanel1.Controls.Add(this.cbxRunCategory, 3, 2);
             this.tableLayoutPanel1.Controls.Add(this.tbxTimeOffset, 3, 3);
             this.tableLayoutPanel1.Controls.Add(this.picGameIcon, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.runGrid, 1, 6);
-            this.tableLayoutPanel1.Controls.Add(this.tabControl, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.runGrid, 1, 7);
+            this.tableLayoutPanel1.Controls.Add(this.tabControl, 1, 6);
             this.tableLayoutPanel1.Controls.Add(this.tbxAttempts, 6, 3);
             this.tableLayoutPanel1.Controls.Add(this.label4, 5, 3);
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 6, 14);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 6, 15);
             this.tableLayoutPanel1.Controls.Add(this.lblDescription, 1, 4);
-            this.tableLayoutPanel1.Controls.Add(this.btnInsert, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.btnAdd, 0, 7);
-            this.tableLayoutPanel1.Controls.Add(this.btnRemove, 0, 8);
-            this.tableLayoutPanel1.Controls.Add(this.btnMoveUp, 0, 9);
-            this.tableLayoutPanel1.Controls.Add(this.btnMoveDown, 0, 10);
-            this.tableLayoutPanel1.Controls.Add(this.btnAddComparison, 0, 11);
-            this.tableLayoutPanel1.Controls.Add(this.btnImportComparison, 0, 12);
-            this.tableLayoutPanel1.Controls.Add(this.btnOther, 0, 13);
+            this.tableLayoutPanel1.Controls.Add(this.btnInsert, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.btnAdd, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.btnRemove, 0, 9);
+            this.tableLayoutPanel1.Controls.Add(this.btnMoveUp, 0, 10);
+            this.tableLayoutPanel1.Controls.Add(this.btnMoveDown, 0, 11);
+            this.tableLayoutPanel1.Controls.Add(this.btnAddComparison, 0, 12);
+            this.tableLayoutPanel1.Controls.Add(this.btnImportComparison, 0, 13);
+            this.tableLayoutPanel1.Controls.Add(this.btnOther, 0, 14);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 5, 4);
+            this.tableLayoutPanel1.Controls.Add(this.lblAutoSplitterCompareAgainstWarning, 1, 5);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(6);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 15;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 5F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel1.RowCount = 16;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 67F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 67F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 67F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 67F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 0F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 48F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 56F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(684, 511);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 69F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1368, 983);
             this.tableLayoutPanel1.TabIndex = 1;
             // 
             // label2
@@ -179,10 +181,10 @@
             this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label2.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.label2, 2);
-            this.label2.Location = new System.Drawing.Point(140, 16);
-            this.label2.Margin = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.label2.Location = new System.Drawing.Point(280, 31);
+            this.label2.Margin = new System.Windows.Forms.Padding(0, 0, 10, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(69, 13);
+            this.label2.Size = new System.Drawing.Size(137, 25);
             this.label2.TabIndex = 3;
             this.label2.Text = "Game Name:";
             // 
@@ -191,10 +193,10 @@
             this.label3.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label3.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.label3, 2);
-            this.label3.Location = new System.Drawing.Point(140, 51);
-            this.label3.Margin = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.label3.Location = new System.Drawing.Point(280, 98);
+            this.label3.Margin = new System.Windows.Forms.Padding(0, 0, 10, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(75, 13);
+            this.label3.Size = new System.Drawing.Size(150, 25);
             this.label3.TabIndex = 4;
             this.label3.Text = "Run Category:";
             // 
@@ -203,10 +205,10 @@
             this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label1.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.label1, 2);
-            this.label1.Location = new System.Drawing.Point(140, 86);
-            this.label1.Margin = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.label1.Location = new System.Drawing.Point(280, 165);
+            this.label1.Margin = new System.Windows.Forms.Padding(0, 0, 10, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(73, 13);
+            this.label1.Size = new System.Drawing.Size(147, 25);
             this.label1.TabIndex = 9;
             this.label1.Text = "Start Timer at:";
             // 
@@ -215,10 +217,11 @@
             this.cbxGameName.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.cbxGameName, 5);
             this.cbxGameName.GetAllItemsForText = null;
-            this.cbxGameName.Location = new System.Drawing.Point(246, 12);
-            this.cbxGameName.Margin = new System.Windows.Forms.Padding(5, 0, 10, 0);
+            this.cbxGameName.Location = new System.Drawing.Point(492, 27);
+            this.cbxGameName.Margin = new System.Windows.Forms.Padding(10, 0, 20, 0);
+            this.cbxGameName.MyAutoCompleteSource = null;
             this.cbxGameName.Name = "cbxGameName";
-            this.cbxGameName.Size = new System.Drawing.Size(427, 21);
+            this.cbxGameName.Size = new System.Drawing.Size(854, 33);
             this.cbxGameName.TabIndex = 1;
             this.cbxGameName.TextChanged += new System.EventHandler(this.cbxGameName_TextChanged);
             // 
@@ -226,20 +229,20 @@
             // 
             this.cbxRunCategory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.cbxRunCategory, 5);
-            this.cbxRunCategory.Location = new System.Drawing.Point(246, 47);
-            this.cbxRunCategory.Margin = new System.Windows.Forms.Padding(5, 0, 10, 0);
+            this.cbxRunCategory.Location = new System.Drawing.Point(492, 94);
+            this.cbxRunCategory.Margin = new System.Windows.Forms.Padding(10, 0, 20, 0);
             this.cbxRunCategory.Name = "cbxRunCategory";
-            this.cbxRunCategory.Size = new System.Drawing.Size(427, 21);
+            this.cbxRunCategory.Size = new System.Drawing.Size(854, 33);
             this.cbxRunCategory.TabIndex = 2;
             // 
             // tbxTimeOffset
             // 
             this.tbxTimeOffset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.tbxTimeOffset, 2);
-            this.tbxTimeOffset.Location = new System.Drawing.Point(246, 82);
-            this.tbxTimeOffset.Margin = new System.Windows.Forms.Padding(5, 0, 3, 0);
+            this.tbxTimeOffset.Location = new System.Drawing.Point(492, 162);
+            this.tbxTimeOffset.Margin = new System.Windows.Forms.Padding(10, 0, 6, 0);
             this.tbxTimeOffset.Name = "tbxTimeOffset";
-            this.tbxTimeOffset.Size = new System.Drawing.Size(177, 20);
+            this.tbxTimeOffset.Size = new System.Drawing.Size(354, 31);
             this.tbxTimeOffset.TabIndex = 3;
             // 
             // picGameIcon
@@ -247,12 +250,12 @@
             this.picGameIcon.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(230)))), ((int)(((byte)(230)))), ((int)(((byte)(230)))));
             this.picGameIcon.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.picGameIcon.Image = ((System.Drawing.Image)(resources.GetObject("picGameIcon.Image")));
-            this.picGameIcon.Location = new System.Drawing.Point(10, 15);
-            this.picGameIcon.Margin = new System.Windows.Forms.Padding(10);
+            this.picGameIcon.Location = new System.Drawing.Point(20, 29);
+            this.picGameIcon.Margin = new System.Windows.Forms.Padding(20, 19, 20, 19);
             this.picGameIcon.Name = "picGameIcon";
-            this.picGameIcon.Padding = new System.Windows.Forms.Padding(10);
+            this.picGameIcon.Padding = new System.Windows.Forms.Padding(20, 19, 20, 19);
             this.tableLayoutPanel1.SetRowSpan(this.picGameIcon, 4);
-            this.picGameIcon.Size = new System.Drawing.Size(120, 120);
+            this.picGameIcon.Size = new System.Drawing.Size(236, 227);
             this.picGameIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.picGameIcon.TabIndex = 1;
             this.picGameIcon.TabStop = false;
@@ -266,30 +269,32 @@
             this.tabControl.Controls.Add(this.GameTime);
             this.tabControl.Controls.Add(this.Metadata);
             this.tabControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl.Location = new System.Drawing.Point(144, 148);
-            this.tabControl.Margin = new System.Windows.Forms.Padding(4, 3, 10, 0);
+            this.tabControl.Location = new System.Drawing.Point(288, 284);
+            this.tabControl.Margin = new System.Windows.Forms.Padding(8, 6, 20, 0);
             this.tabControl.Name = "tabControl";
             this.tabControl.SelectedIndex = 0;
-            this.tabControl.Size = new System.Drawing.Size(530, 22);
+            this.tabControl.Size = new System.Drawing.Size(1060, 42);
             this.tabControl.TabIndex = 7;
             this.tabControl.Selected += new System.Windows.Forms.TabControlEventHandler(this.TabSelected);
             // 
             // RealTime
             // 
-            this.RealTime.Location = new System.Drawing.Point(4, 22);
+            this.RealTime.Location = new System.Drawing.Point(8, 39);
+            this.RealTime.Margin = new System.Windows.Forms.Padding(6);
             this.RealTime.Name = "RealTime";
-            this.RealTime.Padding = new System.Windows.Forms.Padding(3);
-            this.RealTime.Size = new System.Drawing.Size(522, 0);
+            this.RealTime.Padding = new System.Windows.Forms.Padding(6);
+            this.RealTime.Size = new System.Drawing.Size(1044, 0);
             this.RealTime.TabIndex = 0;
             this.RealTime.Text = "Real Time";
             this.RealTime.UseVisualStyleBackColor = true;
             // 
             // GameTime
             // 
-            this.GameTime.Location = new System.Drawing.Point(4, 22);
+            this.GameTime.Location = new System.Drawing.Point(8, 39);
+            this.GameTime.Margin = new System.Windows.Forms.Padding(6);
             this.GameTime.Name = "GameTime";
-            this.GameTime.Padding = new System.Windows.Forms.Padding(3);
-            this.GameTime.Size = new System.Drawing.Size(522, 0);
+            this.GameTime.Padding = new System.Windows.Forms.Padding(6);
+            this.GameTime.Size = new System.Drawing.Size(1044, 0);
             this.GameTime.TabIndex = 1;
             this.GameTime.Text = "Game Time";
             this.GameTime.UseVisualStyleBackColor = true;
@@ -297,9 +302,10 @@
             // Metadata
             // 
             this.Metadata.Controls.Add(this.metadataControl);
-            this.Metadata.Location = new System.Drawing.Point(4, 22);
+            this.Metadata.Location = new System.Drawing.Point(8, 39);
+            this.Metadata.Margin = new System.Windows.Forms.Padding(6);
             this.Metadata.Name = "Metadata";
-            this.Metadata.Size = new System.Drawing.Size(522, 0);
+            this.Metadata.Size = new System.Drawing.Size(1044, 0);
             this.Metadata.TabIndex = 2;
             this.Metadata.Text = "Additional Info";
             this.Metadata.UseVisualStyleBackColor = true;
@@ -308,29 +314,31 @@
             // 
             this.metadataControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.metadataControl.Location = new System.Drawing.Point(0, 0);
+            this.metadataControl.Margin = new System.Windows.Forms.Padding(12);
             this.metadataControl.Metadata = null;
             this.metadataControl.Name = "metadataControl";
-            this.metadataControl.Padding = new System.Windows.Forms.Padding(7);
-            this.metadataControl.Size = new System.Drawing.Size(522, 0);
+            this.metadataControl.Padding = new System.Windows.Forms.Padding(14, 13, 14, 13);
+            this.metadataControl.Size = new System.Drawing.Size(1044, 0);
             this.metadataControl.TabIndex = 0;
             // 
             // tbxAttempts
             // 
             this.tbxAttempts.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.tbxAttempts, 2);
-            this.tbxAttempts.Location = new System.Drawing.Point(496, 82);
-            this.tbxAttempts.Margin = new System.Windows.Forms.Padding(5, 0, 10, 0);
+            this.tbxAttempts.Location = new System.Drawing.Point(992, 162);
+            this.tbxAttempts.Margin = new System.Windows.Forms.Padding(10, 0, 20, 0);
             this.tbxAttempts.Name = "tbxAttempts";
-            this.tbxAttempts.Size = new System.Drawing.Size(177, 20);
+            this.tbxAttempts.Size = new System.Drawing.Size(354, 31);
             this.tbxAttempts.TabIndex = 4;
             // 
             // label4
             // 
             this.label4.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(429, 86);
+            this.label4.Location = new System.Drawing.Point(858, 165);
+            this.label4.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(51, 13);
+            this.label4.Size = new System.Drawing.Size(102, 25);
             this.label4.TabIndex = 10;
             this.label4.Text = "Attempts:";
             // 
@@ -340,25 +348,25 @@
             this.tableLayoutPanel2.ColumnCount = 2;
             this.tableLayoutPanel1.SetColumnSpan(this.tableLayoutPanel2, 4);
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 90F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 180F));
             this.tableLayoutPanel2.Controls.Add(this.btnCancel, 1, 0);
             this.tableLayoutPanel2.Controls.Add(this.btnOK, 0, 0);
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(491, 475);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(982, 914);
             this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(193, 36);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(386, 69);
             this.tableLayoutPanel2.TabIndex = 16;
             // 
             // btnCancel
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(108, 3);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(3, 3, 10, 10);
+            this.btnCancel.Location = new System.Drawing.Point(216, 6);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(6, 6, 20, 19);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Size = new System.Drawing.Size(150, 44);
             this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -367,10 +375,10 @@
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOK.Location = new System.Drawing.Point(25, 3);
-            this.btnOK.Margin = new System.Windows.Forms.Padding(3, 3, 3, 10);
+            this.btnOK.Location = new System.Drawing.Point(50, 6);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(6, 6, 6, 19);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.Size = new System.Drawing.Size(150, 44);
             this.btnOK.TabIndex = 0;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -381,20 +389,20 @@
             this.lblDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.lblDescription.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.lblDescription, 4);
-            this.lblDescription.Location = new System.Drawing.Point(140, 121);
-            this.lblDescription.Margin = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.lblDescription.Location = new System.Drawing.Point(280, 232);
+            this.lblDescription.Margin = new System.Windows.Forms.Padding(0, 0, 10, 0);
             this.lblDescription.Name = "lblDescription";
-            this.lblDescription.Size = new System.Drawing.Size(281, 13);
+            this.lblDescription.Size = new System.Drawing.Size(562, 25);
             this.lblDescription.TabIndex = 13;
             this.lblDescription.Text = "Description";
             // 
             // btnInsert
             // 
             this.btnInsert.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnInsert.Location = new System.Drawing.Point(10, 173);
-            this.btnInsert.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnInsert.Location = new System.Drawing.Point(20, 332);
+            this.btnInsert.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnInsert.Name = "btnInsert";
-            this.btnInsert.Size = new System.Drawing.Size(120, 23);
+            this.btnInsert.Size = new System.Drawing.Size(240, 44);
             this.btnInsert.TabIndex = 8;
             this.btnInsert.Text = "Insert Above";
             this.btnInsert.UseVisualStyleBackColor = true;
@@ -403,10 +411,10 @@
             // btnAdd
             // 
             this.btnAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnAdd.Location = new System.Drawing.Point(10, 202);
-            this.btnAdd.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnAdd.Location = new System.Drawing.Point(20, 388);
+            this.btnAdd.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnAdd.Name = "btnAdd";
-            this.btnAdd.Size = new System.Drawing.Size(120, 23);
+            this.btnAdd.Size = new System.Drawing.Size(240, 44);
             this.btnAdd.TabIndex = 9;
             this.btnAdd.Text = "Insert Below";
             this.btnAdd.UseVisualStyleBackColor = true;
@@ -415,10 +423,10 @@
             // btnRemove
             // 
             this.btnRemove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnRemove.Location = new System.Drawing.Point(10, 231);
-            this.btnRemove.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnRemove.Location = new System.Drawing.Point(20, 444);
+            this.btnRemove.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnRemove.Name = "btnRemove";
-            this.btnRemove.Size = new System.Drawing.Size(120, 23);
+            this.btnRemove.Size = new System.Drawing.Size(240, 44);
             this.btnRemove.TabIndex = 10;
             this.btnRemove.Text = "Remove Segment";
             this.btnRemove.UseVisualStyleBackColor = true;
@@ -427,10 +435,10 @@
             // btnMoveUp
             // 
             this.btnMoveUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnMoveUp.Location = new System.Drawing.Point(10, 260);
-            this.btnMoveUp.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnMoveUp.Location = new System.Drawing.Point(20, 500);
+            this.btnMoveUp.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnMoveUp.Name = "btnMoveUp";
-            this.btnMoveUp.Size = new System.Drawing.Size(120, 23);
+            this.btnMoveUp.Size = new System.Drawing.Size(240, 44);
             this.btnMoveUp.TabIndex = 11;
             this.btnMoveUp.Text = "Move Up";
             this.btnMoveUp.UseVisualStyleBackColor = true;
@@ -439,10 +447,10 @@
             // btnMoveDown
             // 
             this.btnMoveDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnMoveDown.Location = new System.Drawing.Point(10, 289);
-            this.btnMoveDown.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnMoveDown.Location = new System.Drawing.Point(20, 556);
+            this.btnMoveDown.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnMoveDown.Name = "btnMoveDown";
-            this.btnMoveDown.Size = new System.Drawing.Size(120, 23);
+            this.btnMoveDown.Size = new System.Drawing.Size(240, 44);
             this.btnMoveDown.TabIndex = 12;
             this.btnMoveDown.Text = "Move Down";
             this.btnMoveDown.UseVisualStyleBackColor = true;
@@ -451,10 +459,10 @@
             // btnAddComparison
             // 
             this.btnAddComparison.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnAddComparison.Location = new System.Drawing.Point(10, 318);
-            this.btnAddComparison.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnAddComparison.Location = new System.Drawing.Point(20, 612);
+            this.btnAddComparison.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnAddComparison.Name = "btnAddComparison";
-            this.btnAddComparison.Size = new System.Drawing.Size(120, 23);
+            this.btnAddComparison.Size = new System.Drawing.Size(240, 44);
             this.btnAddComparison.TabIndex = 13;
             this.btnAddComparison.Text = "Add Comparison";
             this.btnAddComparison.UseVisualStyleBackColor = true;
@@ -464,10 +472,10 @@
             // 
             this.btnImportComparison.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnImportComparison.Location = new System.Drawing.Point(10, 347);
-            this.btnImportComparison.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnImportComparison.Location = new System.Drawing.Point(20, 668);
+            this.btnImportComparison.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnImportComparison.Name = "btnImportComparison";
-            this.btnImportComparison.Size = new System.Drawing.Size(120, 23);
+            this.btnImportComparison.Size = new System.Drawing.Size(240, 44);
             this.btnImportComparison.TabIndex = 14;
             this.btnImportComparison.Text = "Import Comparison...";
             this.btnImportComparison.UseVisualStyleBackColor = true;
@@ -477,10 +485,10 @@
             // 
             this.btnOther.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOther.Location = new System.Drawing.Point(10, 376);
-            this.btnOther.Margin = new System.Windows.Forms.Padding(10, 3, 10, 3);
+            this.btnOther.Location = new System.Drawing.Point(20, 724);
+            this.btnOther.Margin = new System.Windows.Forms.Padding(20, 6, 20, 6);
             this.btnOther.Name = "btnOther";
-            this.btnOther.Size = new System.Drawing.Size(120, 23);
+            this.btnOther.Size = new System.Drawing.Size(240, 44);
             this.btnOther.TabIndex = 15;
             this.btnOther.Text = "Other...";
             this.btnOther.UseVisualStyleBackColor = true;
@@ -493,18 +501,19 @@
             this.flowLayoutPanel1.Controls.Add(this.btnSettings);
             this.flowLayoutPanel1.Controls.Add(this.btnActivate);
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(429, 113);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 3, 7, 3);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(858, 217);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(6, 6, 14, 6);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(247, 29);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(494, 55);
             this.flowLayoutPanel1.TabIndex = 18;
             // 
             // btnWebsite
             // 
             this.btnWebsite.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.btnWebsite.Location = new System.Drawing.Point(169, 3);
+            this.btnWebsite.Location = new System.Drawing.Point(338, 6);
+            this.btnWebsite.Margin = new System.Windows.Forms.Padding(6);
             this.btnWebsite.Name = "btnWebsite";
-            this.btnWebsite.Size = new System.Drawing.Size(75, 23);
+            this.btnWebsite.Size = new System.Drawing.Size(150, 44);
             this.btnWebsite.TabIndex = 7;
             this.btnWebsite.Text = "Website";
             this.btnWebsite.UseVisualStyleBackColor = true;
@@ -514,9 +523,10 @@
             // btnSettings
             // 
             this.btnSettings.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnSettings.Location = new System.Drawing.Point(88, 3);
+            this.btnSettings.Location = new System.Drawing.Point(176, 6);
+            this.btnSettings.Margin = new System.Windows.Forms.Padding(6);
             this.btnSettings.Name = "btnSettings";
-            this.btnSettings.Size = new System.Drawing.Size(75, 23);
+            this.btnSettings.Size = new System.Drawing.Size(150, 44);
             this.btnSettings.TabIndex = 6;
             this.btnSettings.Text = "Settings";
             this.btnSettings.UseVisualStyleBackColor = true;
@@ -525,16 +535,29 @@
             // btnActivate
             // 
             this.btnActivate.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnActivate.Location = new System.Drawing.Point(7, 3);
+            this.btnActivate.Location = new System.Drawing.Point(14, 6);
+            this.btnActivate.Margin = new System.Windows.Forms.Padding(6);
             this.btnActivate.Name = "btnActivate";
-            this.btnActivate.Size = new System.Drawing.Size(75, 23);
+            this.btnActivate.Size = new System.Drawing.Size(150, 44);
             this.btnActivate.TabIndex = 5;
             this.btnActivate.Text = "Activate";
             this.btnActivate.UseVisualStyleBackColor = true;
             this.btnActivate.Click += new System.EventHandler(this.btnActivate_Click);
             // 
+            // lblAutoSplitterCompareAgainstWarning
+            // 
+            this.lblAutoSplitterCompareAgainstWarning.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.lblAutoSplitterCompareAgainstWarning, 9);
+            this.lblAutoSplitterCompareAgainstWarning.ForeColor = System.Drawing.Color.Red;
+            this.lblAutoSplitterCompareAgainstWarning.Location = new System.Drawing.Point(283, 278);
+            this.lblAutoSplitterCompareAgainstWarning.Name = "lblAutoSplitterCompareAgainstWarning";
+            this.lblAutoSplitterCompareAgainstWarning.Size = new System.Drawing.Size(1058, 1);
+            this.lblAutoSplitterCompareAgainstWarning.TabIndex = 19;
+            this.lblAutoSplitterCompareAgainstWarning.Text = resources.GetString("lblAutoSplitterCompareAgainstWarning.Text");
+            // 
             // RemoveIconMenu
             // 
+            this.RemoveIconMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.RemoveIconMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.setIconToolStripMenuItem,
             this.downloadBoxartToolStripMenuItem,
@@ -542,100 +565,102 @@
             this.openFromURLMenuItem,
             this.removeIconToolStripMenuItem});
             this.RemoveIconMenu.Name = "RemoveIconMenu";
-            this.RemoveIconMenu.Size = new System.Drawing.Size(170, 136);
+            this.RemoveIconMenu.Size = new System.Drawing.Size(308, 194);
             // 
             // setIconToolStripMenuItem
             // 
             this.setIconToolStripMenuItem.Name = "setIconToolStripMenuItem";
-            this.setIconToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.setIconToolStripMenuItem.Size = new System.Drawing.Size(307, 38);
             this.setIconToolStripMenuItem.Text = "Set Icon...";
             this.setIconToolStripMenuItem.Click += new System.EventHandler(this.toolStripMenuItem1_Click);
             // 
             // downloadBoxartToolStripMenuItem
             // 
             this.downloadBoxartToolStripMenuItem.Name = "downloadBoxartToolStripMenuItem";
-            this.downloadBoxartToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.downloadBoxartToolStripMenuItem.Size = new System.Drawing.Size(307, 38);
             this.downloadBoxartToolStripMenuItem.Text = "Download Box Art";
             this.downloadBoxartToolStripMenuItem.Click += new System.EventHandler(this.downloadBoxartToolStripMenuItem_Click);
             // 
             // downloadIconToolStripMenuItem
             // 
             this.downloadIconToolStripMenuItem.Name = "downloadIconToolStripMenuItem";
-            this.downloadIconToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.downloadIconToolStripMenuItem.Size = new System.Drawing.Size(307, 38);
             this.downloadIconToolStripMenuItem.Text = "Download Icon";
             this.downloadIconToolStripMenuItem.Click += new System.EventHandler(this.downloadIconToolStripMenuItem_Click);
             // 
             // openFromURLMenuItem
             // 
             this.openFromURLMenuItem.Name = "openFromURLMenuItem";
-            this.openFromURLMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.openFromURLMenuItem.Size = new System.Drawing.Size(307, 38);
             this.openFromURLMenuItem.Text = "Open from URL...";
             this.openFromURLMenuItem.Click += new System.EventHandler(this.openFromURLMenuItem_Click);
             // 
             // removeIconToolStripMenuItem
             // 
             this.removeIconToolStripMenuItem.Name = "removeIconToolStripMenuItem";
-            this.removeIconToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.removeIconToolStripMenuItem.Size = new System.Drawing.Size(307, 38);
             this.removeIconToolStripMenuItem.Text = "Remove Icon";
             this.removeIconToolStripMenuItem.Click += new System.EventHandler(this.removeIconToolStripMenuItem_Click);
             // 
             // ImportComparisonMenu
             // 
+            this.ImportComparisonMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.ImportComparisonMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fromFileToolStripMenuItem,
             this.fromURLToolStripMenuItem,
             this.fromSpeedruncomToolStripMenuItem});
             this.ImportComparisonMenu.Name = "ImportComparisonMenu";
-            this.ImportComparisonMenu.Size = new System.Drawing.Size(192, 70);
+            this.ImportComparisonMenu.Size = new System.Drawing.Size(347, 118);
             // 
             // fromFileToolStripMenuItem
             // 
             this.fromFileToolStripMenuItem.Name = "fromFileToolStripMenuItem";
-            this.fromFileToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.fromFileToolStripMenuItem.Size = new System.Drawing.Size(346, 38);
             this.fromFileToolStripMenuItem.Text = "From File...";
             this.fromFileToolStripMenuItem.Click += new System.EventHandler(this.fromFileToolStripMenuItem_Click);
             // 
             // fromURLToolStripMenuItem
             // 
             this.fromURLToolStripMenuItem.Name = "fromURLToolStripMenuItem";
-            this.fromURLToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.fromURLToolStripMenuItem.Size = new System.Drawing.Size(346, 38);
             this.fromURLToolStripMenuItem.Text = "From URL...";
             this.fromURLToolStripMenuItem.Click += new System.EventHandler(this.fromURLToolStripMenuItem_Click);
             // 
             // fromSpeedruncomToolStripMenuItem
             // 
             this.fromSpeedruncomToolStripMenuItem.Name = "fromSpeedruncomToolStripMenuItem";
-            this.fromSpeedruncomToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.fromSpeedruncomToolStripMenuItem.Size = new System.Drawing.Size(346, 38);
             this.fromSpeedruncomToolStripMenuItem.Text = "From Speedrun.com...";
             this.fromSpeedruncomToolStripMenuItem.Click += new System.EventHandler(this.fromSpeedruncomToolStripMenuItem_Click);
             // 
             // OtherMenu
             // 
+            this.OtherMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.OtherMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.clearHistoryToolStripMenuItem,
             this.clearTimesToolStripMenuItem,
             this.cleanSumOfBestToolStripMenuItem});
             this.OtherMenu.Name = "OtherMenu";
-            this.OtherMenu.Size = new System.Drawing.Size(171, 70);
+            this.OtherMenu.Size = new System.Drawing.Size(312, 118);
             // 
             // clearHistoryToolStripMenuItem
             // 
             this.clearHistoryToolStripMenuItem.Name = "clearHistoryToolStripMenuItem";
-            this.clearHistoryToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
+            this.clearHistoryToolStripMenuItem.Size = new System.Drawing.Size(311, 38);
             this.clearHistoryToolStripMenuItem.Text = "Clear History";
             this.clearHistoryToolStripMenuItem.Click += new System.EventHandler(this.clearHistoryToolStripMenuItem_Click);
             // 
             // clearTimesToolStripMenuItem
             // 
             this.clearTimesToolStripMenuItem.Name = "clearTimesToolStripMenuItem";
-            this.clearTimesToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
+            this.clearTimesToolStripMenuItem.Size = new System.Drawing.Size(311, 38);
             this.clearTimesToolStripMenuItem.Text = "Clear Times";
             this.clearTimesToolStripMenuItem.Click += new System.EventHandler(this.clearTimesToolStripMenuItem_Click);
             // 
             // cleanSumOfBestToolStripMenuItem
             // 
             this.cleanSumOfBestToolStripMenuItem.Name = "cleanSumOfBestToolStripMenuItem";
-            this.cleanSumOfBestToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
+            this.cleanSumOfBestToolStripMenuItem.Size = new System.Drawing.Size(311, 38);
             this.cleanSumOfBestToolStripMenuItem.Text = "Clean Sum of Best";
             this.cleanSumOfBestToolStripMenuItem.Click += new System.EventHandler(this.cleanSumOfBestToolStripMenuItem_Click);
             // 
@@ -650,12 +675,13 @@
             // RunEditorDialog
             // 
             this.AcceptButton = this.btnOK;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(684, 511);
+            this.ClientSize = new System.Drawing.Size(1368, 983);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MinimumSize = new System.Drawing.Size(700, 510);
+            this.Margin = new System.Windows.Forms.Padding(6);
+            this.MinimumSize = new System.Drawing.Size(1374, 915);
             this.Name = "RunEditorDialog";
             this.Text = "Splits Editor";
             this.Load += new System.EventHandler(this.RunEditorDialog_Load);
@@ -726,5 +752,6 @@
         private System.Windows.Forms.Button btnWebsite;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.ToolStripMenuItem downloadIconToolStripMenuItem;
+        private System.Windows.Forms.Label lblAutoSplitterCompareAgainstWarning;
     }
 }

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1264,7 +1264,7 @@ namespace LiveSplit.View
             int autoSplitterComparisonWarningRow = tableLayoutPanel1.GetPositionFromControl(lblAutoSplitterCompareAgainstWarning).Row;
             lblAutoSplitterCompareAgainstWarning.Visible = showComparisonWarning;
             tableLayoutPanel1.RowStyles[autoSplitterComparisonWarningRow].Height = showComparisonWarning
-                ? lblAutoSplitterCompareAgainstWarning.PreferredHeight + 3
+                ? 60
                 : 0;
 
             if (Run.AutoSplitter != null && Run.AutoSplitter.Website == null)

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1259,6 +1259,14 @@ namespace LiveSplit.View
             btnSettings.Enabled = Run.IsAutoSplitterActive() && Run.AutoSplitter.Component.GetSettingsControl(LayoutMode.Vertical) != null;
             btnWebsite.Visible = Run.AutoSplitter != null && Run.AutoSplitter.Website != null;
 
+            //Show/Hide The AutoSplitter Comparison Warning.
+            bool showComparisonWarning = Run.IsAutoSplitterActive() && CurrentState.CurrentTimingMethod != TimingMethod.GameTime;
+            int autoSplitterComparisonWarningRow = tableLayoutPanel1.GetPositionFromControl(lblAutoSplitterCompareAgainstWarning).Row;
+            lblAutoSplitterCompareAgainstWarning.Visible = showComparisonWarning;
+            tableLayoutPanel1.RowStyles[autoSplitterComparisonWarningRow].Height = showComparisonWarning
+                ? lblAutoSplitterCompareAgainstWarning.PreferredHeight + 3
+                : 0;
+
             if (Run.AutoSplitter != null && Run.AutoSplitter.Website == null)
             {
                 tableLayoutPanel1.SetColumnSpan(lblDescription, 5);

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.resx
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.resx
@@ -964,6 +964,11 @@
         0imd0imd/hkpT57/D8KdWJUE3yYnAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="lblAutoSplitterCompareAgainstWarning.Text" xml:space="preserve">
+    <value>Warning: An Auto Splitter has been activated but LiveSplit is comparing to Real Time. Features such as Load Removal and IGT may not be shown. To switch comparison to Game Time, follow the steps below:
+
+Right Click on the main LiveSplit window &gt; Compare Against &gt; Game Time</value>
+  </data>
   <metadata name="RemoveIconMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>354, 17</value>
   </metadata>


### PR DESCRIPTION
Added comparison warning for Auto Splitters when not comparing to Game Time. Based around issue #581 with hopefully better wording.

It makes it go from:
![Before](https://i.gyazo.com/2e309b21eb50fca01f91d5db8476d340.png)
To:
![After](https://i.gyazo.com/53ee07be33c854ad87a8cd08fd498b82.png)
