### PR TITLE
DeepPointer: make DerefOffsets public & output final address directly

### DIFF
--- a/LiveSplit/LiveSplit.Core/ComponentUtil/DeepPointer.cs
+++ b/LiveSplit/LiveSplit.Core/ComponentUtil/DeepPointer.cs
@@ -42,10 +42,9 @@ namespace LiveSplit.ComponentUtil
 
         public bool Deref<T>(Process process, out T value) where T : struct
         {
-            OffsetT offset = _offsets[_offsets.Count - 1];
             IntPtr ptr;
             if (!DerefOffsets(process, out ptr)
-                || !process.ReadValue(ptr + offset, out value))
+                || !process.ReadValue(ptr, out value))
             {
                 value = default(T);
                 return false;
@@ -64,10 +63,9 @@ namespace LiveSplit.ComponentUtil
 
         public bool DerefBytes(Process process, int count, out byte[] value)
         {
-            OffsetT offset = _offsets[_offsets.Count - 1];
             IntPtr ptr;
             if (!DerefOffsets(process, out ptr)
-                || !process.ReadBytes(ptr + offset, count, out value))
+                || !process.ReadBytes(ptr, count, out value))
             {
                 value = null;
                 return false;
@@ -116,17 +114,16 @@ namespace LiveSplit.ComponentUtil
 
         public bool DerefString(Process process, ReadStringType type, StringBuilder sb)
         {
-            OffsetT offset = _offsets[_offsets.Count - 1];
             IntPtr ptr;
             if (!DerefOffsets(process, out ptr)
-                || !process.ReadString(ptr + offset, type, sb))
+                || !process.ReadString(ptr, type, sb))
             {
                 return false;
             }
             return true;
         }
 
-        bool DerefOffsets(Process process, out IntPtr ptr)
+        public bool DerefOffsets(Process process, out IntPtr ptr)
         {
             bool is64Bit = process.Is64Bit();
 
@@ -157,6 +154,7 @@ namespace LiveSplit.ComponentUtil
                 }
             }
 
+            ptr += _offsets[_offsets.Count - 1];
             return true;
         }
     }


### PR DESCRIPTION
I want a way to get the address of a pointer path rather than the value and this seems more straightforward than adding a function.

Is this OK? @fatalis