### PR TITLE
Replace Super Meat Boy autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -248,10 +248,10 @@
       <Game>Super Meat Boy</Game>
     </Games>
     <URLs>
-      <URL>http://livesplit.org/update/Components/LiveSplit.SuperMeatBoy.dll</URL>
+      <URL>https://raw.githubusercontent.com/negative-seven/Livesplit_ASL/master/LiveSplit.SuperMeatBoy.asl</URL>
     </URLs>
-    <Type>Component</Type>
-    <Description>Auto Splitting is available. (By CryZe)</Description>
+    <Type>Script</Type>
+    <Description>Auto Splitting is available. (By -7)</Description>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
The previously listed autosplitter is not being kept up to date and did not comply with the split timings of the community. The proposed alternative will soon be updated to also remove load times, hopefully.