### PR TITLE
TimerForm: Ensure the enumerator is disposed of in EditLayout()

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1880,12 +1880,13 @@ namespace LiveSplit.View
                         editor.ComponentsToDispose.Remove(component);
                     editor.ImagesToDispose.Remove(layoutCopy.Settings.BackgroundImage);
 
-                    var enumerator = componentSettings.GetEnumerator();
-                    foreach (var component in layoutCopy.Components)
+                    using (var enumerator = componentSettings.GetEnumerator())
                     {
-                        enumerator.MoveNext();
-                        if (enumerator.Current != null)
-                            component.SetSettings(enumerator.Current);
+                        foreach (var component in layoutCopy.Components)
+                        {
+                            if (enumerator.MoveNext())
+                                component.SetSettings(enumerator.Current);
+                        }
                     }
                     SetLayout(layoutCopy);
                 }


### PR DESCRIPTION
Also technically gets rid of undefined behavior as well. If MoveNext() returns false, the [Current](https://msdn.microsoft.com/en-us/library/58e146b7(v=vs.110).aspx) property is documented as being in an undefined state.