### PR TITLE
Update Final Fantasy X Autosplitter URLs

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2919,8 +2919,8 @@
       <Game>Final Fantasy X</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/BitPatty/LiveSplit.FFX/blob/master/Components/LiveSplit.FFX.dll</URL>
-      <URL>https://github.com/BitPatty/LiveSplit.FFX/blob/master/LiveSplit.FFX.UI/Components/LiveSplit.FFX.UI.dll</URL>
+      <URL>https://raw.githubusercontent.com/BitPatty/LiveSplit.FFX/master/Components/LiveSplit.FFX.dll</URL>
+      <URL>https://raw.githubusercontent.com/BitPatty/LiveSplit.FFX/master/LiveSplit.FFX.UI/Components/LiveSplit.FFX.UI.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>Load Removal, Auto Start/Reset and Encounter Count are available (PC). (By Psychonauter and Flobberworm4)</Description>


### PR DESCRIPTION
Using the blob url causes weird behaviour.

Trying to download the splitter with these URLs 404s or causes it to download LiveSplit.FFX twice with one named LiveSplit.FFX.UI.