### PR TITLE
Showing The End Is Nigh autosplitter in the layout editor

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2968,6 +2968,7 @@
     <Type>Component</Type>
     <Description>Autosplitter for The End Is Nigh.</Description>
     <Website>https://github.com/Grimelios/LiveSplit.TheEndIsNigh</Website>
+    <ShowInLayoutEditor />
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
I forgot to include the ShowInLayoutEditor tag for the The End Is Nigh autosplitter.