### PR TITLE
Fixed order of libraries for Pet the Pup Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3187,9 +3187,9 @@
       <Game>Pet the Pup</Game>
     </Games>
     <URLs>
-      <URL>https://dl.dotstart.tv/livesplit/pet-the-pup/LiveSplit.dotStart.Common.dll</URL>
       <URL>https://dl.dotstart.tv/livesplit/pet-the-pup/LiveSplit.dotStart.PetThePup.dll</URL>
       <URL>https://dl.dotstart.tv/livesplit/pet-the-pup/LiveSplit.dotStart.PetThePup.UI.dll</URL>
+      <URL>https://dl.dotstart.tv/livesplit/pet-the-pup/LiveSplit.dotStart.Common.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>Autosplitting is available. (By .start)</Description>


### PR DESCRIPTION
Apparently, the order of libraries within the document defines which of the libraries contain the desired splitter implementation (albeit undocumented) which causes an error to appear when loading of the component through the split editor is attempted. See https://github.com/LiveSplit/LiveSplit/blob/master/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs#L23

This issue should be noted as part of the documentation as it isn't entirely obvious how LiveSplit chooses the correct assembly (nor does there seem to be an easy way of testing for such loading issues).