### PR TITLE
Fix only after parsing cells when pasting

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -721,54 +721,29 @@ namespace LiveSplit.View
             SegmentTimeList.Clear();
             foreach (var curSeg in Run)
             {
-                if (curSeg == null)
-                    SegmentTimeList.Add(null);
-                else
-                {
-                    if (curSeg.PersonalBestSplitTime[SelectedMethod] == null)
-                        SegmentTimeList.Add(null);
-                    else
-                    {
-                        SegmentTimeList.Add(curSeg.PersonalBestSplitTime[SelectedMethod] - previousTime);
-                        previousTime = curSeg.PersonalBestSplitTime[SelectedMethod].Value;
-                    }
-                }
+                var splitTime = curSeg.PersonalBestSplitTime[SelectedMethod];
+
+                SegmentTimeList.Add(splitTime - previousTime);
+
+                if (splitTime != null)
+                    previousTime = splitTime.Value;
             }
         }
 
         private void FixSplitsFromSegments()
         {
             var previousTime = TimeSpan.Zero;
-            var index = 0;
-            var decrement = TimeSpan.Zero;
-            foreach (var curSeg in Run)
+            for (var index = 0; index < Run.Count; index++)
             {
-                if (curSeg != null)
-                {
-                    if (SegmentTimeList[index] != null)
-                    {
-                        if (curSeg.PersonalBestSplitTime[SelectedMethod] == null && index < SegmentTimeList.Count - 1)
-                            decrement = SegmentTimeList[index].Value;
-                        else
-                        {
-                            SegmentTimeList[index] -= decrement;
-                            decrement = TimeSpan.Zero;
-                        }
-                        var time = new Time(curSeg.PersonalBestSplitTime);
-                        time[SelectedMethod] = previousTime + SegmentTimeList[index].Value;
-                        curSeg.PersonalBestSplitTime = time;
-                        previousTime = curSeg.PersonalBestSplitTime[SelectedMethod].Value;
-                    }
-                    else
-                    {
-                        if (curSeg.PersonalBestSplitTime[SelectedMethod] != null)
-                            previousTime = curSeg.PersonalBestSplitTime[SelectedMethod].Value;
-                        var time = new Time(curSeg.PersonalBestSplitTime);
-                        time[SelectedMethod] = null;
-                        curSeg.PersonalBestSplitTime = time;
-                    }
-                }
-                index++;
+                var curSegment = Run[index];
+                var curSegTime = SegmentTimeList[index];
+
+                var time = new Time(curSegment.PersonalBestSplitTime);
+                time[SelectedMethod] = previousTime + curSegTime;
+                curSegment.PersonalBestSplitTime = time;
+
+                if (curSegTime != null)
+                    previousTime = curSegment.PersonalBestSplitTime[SelectedMethod].Value;
             }
         }
 


### PR DESCRIPTION
- If the segment times are modified while the split times are not, then we want to adjust the splits times based on the segment times. 
- If the split times are modified (regardless of whether the segment times are modified), then we want to adjust the segment times based on the split times.
- If anything besides an icon or segment name is modified, then we want to do general fixing.

We also want to change how doing this affects the bottom segment:

![livesplit_2017-09-25_21-39-05](https://user-images.githubusercontent.com/8262173/30840353-5b49ff48-a23c-11e7-867b-f05bbd0f8d19.png)

Old Result: 11, 6
New Result: 15, 10
