### PR TITLE
Correct Disaster Report Autosplitter link

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3258,7 +3258,7 @@
       <Game>Disaster Report</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/Souzooka/Disaster-Report-Autosplitter/edit/master/ZZT.asl</URL>
+      <URL>https://raw.githubusercontent.com/Souzooka/Disaster-Report-Autosplitter/master/ZZT.asl</URL>
     </URLs>
     <Type>Script</Type>
     <Description>Autosplitting and In-Game Time is available (PCSX2 1.4.0+). (by Souzooka)</Description>


### PR DESCRIPTION
My last commit before the PR was changing this link but it still ended up being wrong, so here's my commit of shame