### PR TITLE
Load remover wasnt working

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3508,7 +3508,7 @@
       <Game>Wolfenstein II: The New Colossus</Game>
     </Games>
     <URLs>
-      <URL>https://gist.githubusercontent.com/itsjabo/d2cbf703af6a35f467522729b7f3f2ae/raw/e1de60acd81a050e6a0b3711235cecea3a169939/Wolfenstein%2520II:%2520The%2520New%2520Colossus.ASL</URL>
+      <URL>https://raw.githubusercontent.com/itsjabo/LiveSplit/master/Wolfenstein%20II%3A%20The%20New%20Colossus.asl</URL>
     </URLs>
     <Type>Script</Type>
     <Description>Load Removal is available. (By ItsJabo)</Description>


### PR DESCRIPTION
Trying new url, seems to me that my old URL seemed different to the majority of URLS on here, so i changed mine to see if it fixes the problem of the load remover not being found by LiveSplit on the edit splits section.