### PR TITLE
Updated Resident Evil 5 ASL

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -964,10 +964,10 @@
       <Game>RE5</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/JMaynard24/ASL/master/RE5.asl</URL>
+      <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/RE5SteamFullGameIGT.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Auto Splitting and Load Removal are available. (By Dread)</Description>
+    <Description>Auto Splitting and Load Removal are available. (By Auddy)</Description>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
Updated Resident Evil 5 ASL file as it was not working correctly in 1-1 and did not add up the IGT correctly at the end of the run.