### PR TITLE
Fix divide-by-zero causing weird scaling on startup.

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1194,11 +1194,14 @@ namespace LiveSplit.View
             {
                 if (OldSize != currentSize)
                 {
-                    MinimumSize = new Size(0, 0);
-                    if (Layout.Mode == LayoutMode.Vertical)
-                        Height = (int)((currentSize / (double)OldSize) * Height + 0.5);
-                    else
-                        Width = (int)((currentSize / (double)OldSize) * Width + 0.5);
+                    if (OldSize != 0.0)
+                    {
+                        MinimumSize = new Size(0, 0);
+                        if (Layout.Mode == LayoutMode.Vertical)
+                            Height = (int)((currentSize / (double)OldSize) * Height + 0.5);
+                        else
+                            Width = (int)((currentSize / (double)OldSize) * Width + 0.5);
+                    }
                     OldSize = currentSize;
                 }
                 var minSize = (int)(currentSize / 5 + 0.5f);


### PR DESCRIPTION
With certain layout dimensions, LiveSplit will rescale the saved dimensions in weird ways on startup, such as this layout:

![rightsize](https://user-images.githubusercontent.com/5988870/35358106-679bea9a-010a-11e8-9aac-b8416c7a5d43.png)

looking like this instead once the program is closed and re-opened:

![wrongsize](https://user-images.githubusercontent.com/5988870/35358127-74d8651c-010a-11e8-9b67-d8ed5a3edd23.png)

This seems to be due to a divide-by-zero error on startup, when OldSize == 0 in TimerForm.cs