### PR TITLE
Update SWTFU2 load remover file

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1447,10 +1447,10 @@
       <Game>SWTFU 2</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/PackSciences/SWTFU2-Autosplitter/master/SWTFU2.asl</URL>
+      <URL>https://gist.githubusercontent.com/Zuzurr/da2e16ed6eb561a7baca69a97d20a4fe/raw/043d98f72ee481a75be177050f76fdab7732f1e1/SWFTU2loads.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Load Removal is available. (Beta) (By PackSciences and SatsuiBird)</Description>
+    <Description>Load Removal is available. (By Zuzur)</Description>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
I have recently made a new and improved load remover for Star Wars: The Force Unleashed 2. It works better than the old one, and works on more systems than the old ones.

Raw file destination: https://gist.githubusercontent.com/Zuzurr/da2e16ed6eb561a7baca69a97d20a4fe/raw/043d98f72ee481a75be177050f76fdab7732f1e1/SWFTU2loads.asl

