### PR TITLE
Removed Little Nightmares auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2653,16 +2653,6 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
-      <Game>Little Nightmares</Game>
-    </Games>
-    <URLs>
-      <URL>https://raw.githubusercontent.com/StreamingFire/Livesplit/master/Little%20Nightmares/LittleNightmares.asl</URL>
-    </URLs>
-    <Type>Script</Type>
-    <Description>Load Removal is available. (By StreamingFire and Timbouton)</Description>
-  </AutoSplitter>
-  <AutoSplitter>
-    <Games>
       <Game>Turok 2: Seeds of Evil</Game>
     </Games>
     <URLs>


### PR DESCRIPTION
Can't find correct pointer (anymore), so that makes this autosplitter obsolete. It's not used in the speedruns.