### PR TITLE
Replace Slay The Spire Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3930,10 +3930,10 @@
       <Game>Slay the Spire</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/Phxntxm/Slay-The-Spire-Autosplitter/master/StS%20autosplitter.asl</URL>
+      <URL>https://raw.githubusercontent.com/ClownFiesta/AutoSplitters/master/LiveSplit.SlayTheSpire.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Auto splitter/resetter/starter. (By Phantom)</Description>
+    <Description>Auto Splitting, Start and Reset currently supported (By FresherDenimAll)</Description>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
Replace the autosplitter with a different one that uses fewer resources and that runs faster.

Basically, it tails the log file instead of rereading it. Instead of reading the complete log file in the start method, reset method and split method, it reads the portion of the log it didn't read yet (if any new lines are added to it) in the update method.