### PR TITLE
Fix URL in Sphinx and the Cursed Mummy (PC) auto-splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10,7 +10,7 @@
     </URLs>
     <Type>Script</Type>
     <Description>In-game time, auto-split on Set defeat, auto-start and load-removal. (By Swyter)</Description>
-    <Website>https://discord.gg/3zh6v</Website>
+    <Website>https://discord.gg/zAhnJ</Website>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
Looks like the Discord link I originally provided was broken or revoked. Should have checked it twice before submitting, now it should be okay. Sorry about the pull request spam!