### PR TITLE
Fix URL in Sphinx and the Cursed Mummy (PC) auto-splitter #2

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10,7 +10,7 @@
     </URLs>
     <Type>Script</Type>
     <Description>In-game time, auto-split on Set defeat, auto-start and load-removal. (By Swyter)</Description>
-    <Website>https://discord.gg/zAhnJ</Website>
+    <Website>https://discord.gg/dbnxcPJ</Website>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
Turns out that permanent Discord links have seven characters. This is getting stupid and I'm a bit embarrassed. Really sorry about that.

https://support.discordapp.com/hc/en-us/articles/208866998-Instant-Invite-101

Even if this doesn't work I'm not going to try again. Getting this right was harder than preparing the script itself. Third time's the charm.