### PR TITLE
adding support for saving and loading custom data for a run

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -27,6 +27,8 @@ namespace LiveSplit.Model
 
         RunMetadata Metadata { get; }
 
+        Dictionary<string, string> CustomData { get; }
+
         bool HasChanged { get; set; }
         string FilePath { get; set; }
     }

--- a/LiveSplit/LiveSplit.Core/Model/Run.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Run.cs
@@ -84,6 +84,8 @@ namespace LiveSplit.Model
 
         public RunMetadata Metadata { get; private set; }
 
+        public Dictionary<string, string> CustomData { get; private set; } = new Dictionary<string, string>();
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void TriggerPropertyChanged(string propertyName)

--- a/LiveSplit/LiveSplit.Core/Model/RunFactories/XMLRunFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunFactories/XMLRunFactory.cs
@@ -74,6 +74,16 @@ namespace LiveSplit.Model.RunFactories
                 }
             }
 
+            var customData = parent["CustomData"];
+            if(customData != null)
+            {
+                var DataNodes = customData.SelectNodes("Data");
+                foreach(XmlElement node in DataNodes)
+                {
+                    run.CustomData[node["Name"].InnerText] = node["Data"].InnerText;
+                }
+            }
+
             run.GameIcon = GetImageFromElement(parent["GameIcon"]);
             run.GameName = ParseString(parent["GameName"]);
             run.CategoryName = ParseString(parent["CategoryName"]);

--- a/LiveSplit/LiveSplit.Core/Model/RunSavers/XMLRunSaver.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunSavers/XMLRunSaver.cs
@@ -44,6 +44,20 @@ namespace LiveSplit.Model.RunSavers
             metadata.AppendChild(variables);
             parent.AppendChild(metadata);
 
+            var customData = document.CreateElement("CustomData");
+            foreach(var kv in run.CustomData)
+            {
+                var dataElement = document.CreateElement("Data");
+                var dataName = document.CreateElement("Name");
+                dataName.InnerText = kv.Key;
+                var dataData = document.CreateElement("Data");
+                dataData.InnerText = kv.Value;
+                dataElement.AppendChild(dataName);
+                dataElement.AppendChild(dataData);
+                customData.AppendChild(dataElement);
+            }
+            parent.AppendChild(customData);
+
             CreateSetting(document, parent, "Offset", run.Offset);
             CreateSetting(document, parent, "AttemptCount", run.AttemptCount);
 


### PR DESCRIPTION
i know this one will be scrapped soon, but i still need that feature for a plugin atm, and it seemed like an easy fix.

its adding a dictionary to the Run class so plugins can store custom data in there that can be saved and loaded with the run. i implemented saving and loading only for xml. i tried json, but got confused for what loader i should implement the loading logic, so i just scratched that.