### PR TITLE
Fix state being updated before reset when saving a non-PB run as a PB

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/DoubleTapPrevention.cs
+++ b/LiveSplit/LiveSplit.Core/Model/DoubleTapPrevention.cs
@@ -129,5 +129,7 @@ namespace LiveSplit.Model
         public void SwitchComparisonNext() => InternalModel.SwitchComparisonNext();
 
         public void InitializeGameTime() => InternalModel.InitializeGameTime();
+
+        public void ResetAndSetAttemptAsPB() => InternalModel.ResetAndSetAttemptAsPB();
     }
 }

--- a/LiveSplit/LiveSplit.Core/Model/ITimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/ITimerModel.cs
@@ -27,6 +27,7 @@ namespace LiveSplit.Model
         void UndoSplit();
         void Reset();
         void Reset(bool updateSplits);
+        void ResetAndSetAttemptAsPB();
         void Pause();
         void UndoAllPauses();
         void ScrollUp();

--- a/LiveSplit/LiveSplit.View/View/ShareRunDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ShareRunDialog.cs
@@ -29,8 +29,7 @@ namespace LiveSplit.View
             {
                 var model = new TimerModel();
                 model.CurrentState = State;
-                model.SetRunAsPB();
-                model.UpdateAttemptHistory();
+                model.ResetAndSetAttemptAsPB();
                 Run = State.Run;
             }
             ScreenShotFunction = screenShotFunction;

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1808,9 +1808,6 @@ namespace LiveSplit.View
 
             CurrentState.Run.FixSplits();
 
-            var stateCopy = CurrentState.Clone() as LiveSplitState;
-            var modelCopy = new TimerModel();
-            modelCopy.CurrentState = stateCopy;
             var result = DialogResult.No;
 
             if (promptPBMessage && ((CurrentState.CurrentPhase == TimerPhase.Ended
@@ -1824,21 +1821,20 @@ namespace LiveSplit.View
                 DontRedraw = false;
                 if (result == DialogResult.Yes)
                 {
-                    Model.Reset();
-                    modelCopy.SetRunAsPB();
-                    modelCopy.UpdateAttemptHistory();
-                    modelCopy.UpdateBestSegments();
-                    modelCopy.UpdateSegmentHistory();
-                    SetRun(stateCopy.Run);
+                    Model.ResetAndSetAttemptAsPB();
                 }
                 else if (result == DialogResult.Cancel)
                     return;
             }
 
-            if (result == DialogResult.Yes)
-                modelCopy.Reset(false);
-            else
+            var stateCopy = CurrentState;
+            if (result == DialogResult.No)
+            {
+                var modelCopy = new TimerModel();
+                stateCopy = CurrentState.Clone() as LiveSplitState;
+                modelCopy.CurrentState = stateCopy;
                 modelCopy.Reset();
+            }
 
             try
             {


### PR DESCRIPTION
Issue #1077 shows that the Attempt Ended time can sometimes be the
default value instead of the proper time. This is caused by saving a run
as a PB before the run has finished.

Still need to update the livesplit-core DLLs and update that submodule version.