### PR TITLE
Updated RE5

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1085,7 +1085,7 @@
       <Game>RE5</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/RE5SteamFullGameIGT.asl</URL>
+      <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/RE5FullGameIGT.asl</URL>
     </URLs>
     <Type>Script</Type>
     <Description>Auto Splitting and Load Removal are available. (By Auddy)</Description>


### PR DESCRIPTION
Updated Resident Evil 5's autosplitter to include both the Steam and Games For Windows Live versions.