### PR TITLE
Add Splitter for Hyperdimension Neptunia Re;Birth 1

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3280,6 +3280,16 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
+      <Game>Hyperdimension Neptunia Re;Birth1</Game>
+    </Games>
+    <URLs>
+      <URL>https://raw.githubusercontent.com/Dabomstew/AutoSplitters/master/rebirth1.asl</URL>
+    </URLs>
+    <Type>Script</Type>
+    <Description>Auto-Split on Cutscenes and certain Events. (By Dabomstew and Marenthyu)</Description>
+  </AutoSplitter>
+  <AutoSplitter>
+    <Games>
       <Game>Star Wars Battlefront II</Game>
     </Games>
     <URLs>


### PR DESCRIPTION
Along the same lines as the Rebirth 2 splitter by @Marenthyu - supports splitting on certain events (mainly cutscenes) and starting on New Game selection or NG+ file load.