### PR TITLE
Fix Auto Splitter for Midnight Club 2

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4534,7 +4534,7 @@
       <Game>Midnight Club II</Game>
     </Games>
     <URLs>
-      <URL>https://github.com/LRFLEW/LiveSplit.MC2/raw/master/Components/LiveSplit.MC2.dll</URL>
+      <URL>https://raw.githubusercontent.com/LRFLEW/LiveSplit.MC2/master/Components/LiveSplit.MC2.dll</URL>
     </URLs>
     <Type>Component</Type>
     <Description>Load Remover for Midnight Club 2 for PC</Description>


### PR DESCRIPTION
I messed up my last PR apparently. The link I had used was a redirect, and it looks like LiveSplit doesn't handle the redirect correctly. I set it to the address it was redirecting *to*, so it should work this time.

Sorry. 😞 