### PR TITLE
Blur empty categories\games in search results

### DIFF
--- a/LiveSplit/LiveSplit.View/View/BrowseSpeedrunComDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/BrowseSpeedrunComDialog.cs
@@ -108,7 +108,7 @@ namespace LiveSplit.View
                             var categories = game.FullGameCategories;
                             var timeFormatter = new AutomaticPrecisionTimeFormatter();
 
-                            var anySplitAvailableInGame = false;
+                            var anySplitsAvailableForGame = false;
                             foreach (var category in categories)
                             {
                                 var categoryNode = new TreeNode(category.Name);
@@ -116,7 +116,7 @@ namespace LiveSplit.View
                                 var leaderboard = category.Leaderboard;
                                 var records = leaderboard.Records;
 
-                                var anySplitAvailableInCategory = false;
+                                var anySplitsAvailableForCategory = false;
                                 foreach (var record in records)
                                 {
                                     var place = record.Rank.ToString(CultureInfo.InvariantCulture).PadLeft(getDigits(records.Count())) + ".   ";
@@ -128,18 +128,18 @@ namespace LiveSplit.View
                                     if (!record.SplitsAvailable)
                                         runNode.ForeColor = Color.Gray;
                                     else
-                                        anySplitAvailableInCategory = true;
+                                        anySplitsAvailableForCategory = true;
                                     categoryNode.Nodes.Add(runNode);
                                 }
 
-                                if (!anySplitAvailableInCategory)
+                                if (!anySplitsAvailableForCategory)
                                     categoryNode.ForeColor = Color.Gray;
                                 else 
-                                    anySplitAvailableInGame = true;
+                                    anySplitsAvailableForGame = true;
 
                                 gameNode.Nodes.Add(categoryNode);
                             }
-                            if (!anySplitAvailableInGame)
+                            if (!anySplitsAvailableForGame)
                                 gameNode.ForeColor = Color.Gray;
                             splitsTreeView.Nodes.Add(gameNode);
                         }
@@ -158,7 +158,7 @@ namespace LiveSplit.View
                             var recordsGroupedByGames = SpeedrunCom.Client.Users.GetPersonalBests(user.ID, embeds: new RunEmbeds(embedGame: true, embedCategory: true))
                                 .GroupBy(x => x.Game.Name);
 
-                            var anySplitAvailableInGames = false;
+                            var anySplitsAvailableForUser = false;
                             foreach (var recordsForGame in recordsGroupedByGames)
                             {
                                 var gameName = recordsForGame.Key;
@@ -167,7 +167,7 @@ namespace LiveSplit.View
                                 var timeFormatter = new AutomaticPrecisionTimeFormatter();
                                 gameNode.Tag = game.WebLink;
 
-                                var anySplitAvailableInCategory = false;
+                                var anySplitsAvailableForGame = false;
                                 foreach (var record in recordsForGame)
                                 {
                                     var categoryName = record.Category.Name;
@@ -181,17 +181,17 @@ namespace LiveSplit.View
                                     if (!record.SplitsAvailable)
                                         recordNode.ForeColor = Color.Gray;
                                     else
-                                        anySplitAvailableInCategory = true;
+                                        anySplitsAvailableForGame = true;
                                     gameNode.Nodes.Add(recordNode);
                                 }
 
-                                if (!anySplitAvailableInCategory)
+                                if (!anySplitsAvailableForGame)
                                     gameNode.ForeColor = Color.Gray;
                                 else
-                                    anySplitAvailableInGames = true;
+                                    anySplitsAvailableForUser = true;
                                 userNode.Nodes.Add(gameNode);
                             }
-                            if (!anySplitAvailableInGames)
+                            if (!anySplitsAvailableForUser)
                                 userNode.ForeColor = Color.Gray;
                             splitsTreeView.Nodes.Add(userNode);
                         }

--- a/LiveSplit/LiveSplit.View/View/BrowseSpeedrunComDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/BrowseSpeedrunComDialog.cs
@@ -108,6 +108,7 @@ namespace LiveSplit.View
                             var categories = game.FullGameCategories;
                             var timeFormatter = new AutomaticPrecisionTimeFormatter();
 
+                            var anySplitAvailableInGame = false;
                             foreach (var category in categories)
                             {
                                 var categoryNode = new TreeNode(category.Name);
@@ -115,6 +116,7 @@ namespace LiveSplit.View
                                 var leaderboard = category.Leaderboard;
                                 var records = leaderboard.Records;
 
+                                var anySplitAvailableInCategory = false;
                                 foreach (var record in records)
                                 {
                                     var place = record.Rank.ToString(CultureInfo.InvariantCulture).PadLeft(getDigits(records.Count())) + ".   ";
@@ -125,10 +127,20 @@ namespace LiveSplit.View
                                     runNode.Tag = record;
                                     if (!record.SplitsAvailable)
                                         runNode.ForeColor = Color.Gray;
+                                    else
+                                        anySplitAvailableInCategory = true;
                                     categoryNode.Nodes.Add(runNode);
                                 }
+
+                                if (!anySplitAvailableInCategory)
+                                    categoryNode.ForeColor = Color.Gray;
+                                else 
+                                    anySplitAvailableInGame = true;
+
                                 gameNode.Nodes.Add(categoryNode);
                             }
+                            if (!anySplitAvailableInGame)
+                                gameNode.ForeColor = Color.Gray;
                             splitsTreeView.Nodes.Add(gameNode);
                         }
                     }
@@ -146,6 +158,7 @@ namespace LiveSplit.View
                             var recordsGroupedByGames = SpeedrunCom.Client.Users.GetPersonalBests(user.ID, embeds: new RunEmbeds(embedGame: true, embedCategory: true))
                                 .GroupBy(x => x.Game.Name);
 
+                            var anySplitAvailableInGames = false;
                             foreach (var recordsForGame in recordsGroupedByGames)
                             {
                                 var gameName = recordsForGame.Key;
@@ -154,6 +167,7 @@ namespace LiveSplit.View
                                 var timeFormatter = new AutomaticPrecisionTimeFormatter();
                                 gameNode.Tag = game.WebLink;
 
+                                var anySplitAvailableInCategory = false;
                                 foreach (var record in recordsForGame)
                                 {
                                     var categoryName = record.Category.Name;
@@ -166,10 +180,19 @@ namespace LiveSplit.View
                                     recordNode.Tag = record;
                                     if (!record.SplitsAvailable)
                                         recordNode.ForeColor = Color.Gray;
+                                    else
+                                        anySplitAvailableInCategory = true;
                                     gameNode.Nodes.Add(recordNode);
                                 }
+
+                                if (!anySplitAvailableInCategory)
+                                    gameNode.ForeColor = Color.Gray;
+                                else
+                                    anySplitAvailableInGames = true;
                                 userNode.Nodes.Add(gameNode);
                             }
+                            if (!anySplitAvailableInGames)
+                                userNode.ForeColor = Color.Gray;
                             splitsTreeView.Nodes.Add(userNode);
                         }
                     }


### PR DESCRIPTION
If it's impossible to download any split in category blur that category. Same goes for game, if games doesn't have any categories that can be downloaded, blur it too. Changes made for game and user searches.

How it looks now:
![bygame](https://user-images.githubusercontent.com/7883111/46556576-bbe6bc80-c8ef-11e8-8f25-ce8e630e2b97.JPG)
![byuser](https://user-images.githubusercontent.com/7883111/46556577-bd17e980-c8ef-11e8-903f-63bdcdec836d.JPG)
