### PR TITLE
Removed Sonic 1 autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2404,21 +2404,6 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
-      <Game>Sonic the Hedgehog</Game>
-      <Game>Sonic 1</Game>
-      <Game>Sonic the Hedgehog (Genesis)</Game>
-      <Game>Sonic the Hedgehog (Mega Drive)</Game>
-      <Game>Sonic the Hedgehog (Genesis / Mega Drive)</Game>
-    </Games>
-    <URLs>
-      <URL>https://raw.githubusercontent.com/tenebrae101/Sonic1AutoSplitter/master/Sonic1.asl</URL>
-    </URLs>
-    <Type>Script</Type>
-    <Description>Game Time and Auto Start/Split/Reset are available for Steam. (By Tenebrae)</Description>
-    <Website>https://github.com/tenebrae101/Sonic1AutoSplitter</Website>
-  </AutoSplitter>
-  <AutoSplitter>
-    <Games>
       <Game>Watch_Dogs 2</Game>
       <Game>Watch Dogs 2</Game>
       <Game>WatchDogs 2</Game>


### PR DESCRIPTION
Removed this autosplitter, because there's a better one using a different timing method coming soon.