### PR TITLE
Adding game name for autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3048,6 +3048,8 @@
     <Games>
       <Game>Yooka-Laylee</Game>
       <Game>Yooka Laylee</Game>
+      <Game>Yooka-Laylee Category Extensions</Game>
+      <Game>Yooka Laylee Category Extensions</Game>
     </Games>
     <URLs>
       <URL>https://raw.githubusercontent.com/DerKO9/SpeedRunningStuff/master/YookaLaylee/YookaLaylee.asl</URL>


### PR DESCRIPTION
Enabling the autosplitter for the "Yooka Laylee Category Extensions" game/leaderboard.