### PR TITLE
Add Best Main Segments comparison

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -402,6 +402,7 @@
   <AutoSplitter>
     <Games>
       <Game>Left 4 Dead 2</Game>
+      <Game>Left 4 Dead 2 Category Extensions</Game>
     </Games>
     <URLs>
       <URL>https://raw.githubusercontent.com/SirWillian/Autosplitters/master/L4D2/L4D2v1.6.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
 <AutoSplitter>
     <Games>
+      <Game>RONIN</Game>
+    </Games>
+    <URLs>
+      <URL>https://raw.githubusercontent.com/OCircles/RONINAutosplitter/master/RoninSplitter.asl</URL>
+    </URLs>
+    <Type>Script</Type>
+    <Description>Load Remover, Autosplitting, Autostarting is available (by O_Circles)</Description>
+  </AutoSplitter>
+<AutoSplitter>
+    <Games>
       <Game>Bygg bilar med Mulle Meck</Game>
     </Games>
     <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -3143,10 +3143,10 @@
       <Game>Halo Wars: Definitive Edition</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/ROMaster2/LiveSplit.AutoSplitters/master/LiveSplit.HaloWarsDE.asl</URL>
+      <URL>https://raw.githubusercontent.com/Auddy07/ASL/master/HaloWars.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>In-game time and auto-start available. Auto-split available soon. In Beta (By ROMaster2)</Description>
+    <Description>Auto Splitting and Load Removal are available. (By Auddy)</Description>
   </AutoSplitter>
   <AutoSplitter>
     <Games>

--- a/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Model\Attempt.cs" />
     <Compile Include="Model\AutoSplitter.cs" />
     <Compile Include="Model\AutoSplitterFactory.cs" />
+    <Compile Include="Model\Comparisons\BestMainSegmentsComparisonGenerator.cs" />
     <Compile Include="Model\Comparisons\LatestRunComparisonGenerator.cs" />
     <Compile Include="Model\Comparisons\WorstSegmentsComparisonGenerator.cs" />
     <Compile Include="Model\Comparisons\MedianSegmentsComparisonGenerator.cs" />

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/BestMainSegmentsComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/BestMainSegmentsComparisonGenerator.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LiveSplit.Options;
+
+namespace LiveSplit.Model.Comparisons
+{
+    public class BestMainSegmentsComparisonGenerator : IComparisonGenerator
+    {
+        public IRun Run { get; set; }
+        public const string ComparisonName = "Best Main Segments";
+        public const string ShortComparisonName = "Mains";
+
+        public string Name => ComparisonName;
+
+        public BestMainSegmentsComparisonGenerator(IRun run)
+        {
+            Run = run;
+        }
+
+        public void Generate(ISettings settings)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/BestMainSegmentsComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/BestMainSegmentsComparisonGenerator.cs
@@ -12,7 +12,6 @@ namespace LiveSplit.Model.Comparisons
         public IRun Run { get; set; }
         public const string ComparisonName = "Best Main Segments";
         public const string ShortComparisonName = "Mains";
-
         public string Name => ComparisonName;
 
         public BestMainSegmentsComparisonGenerator(IRun run)
@@ -22,7 +21,60 @@ namespace LiveSplit.Model.Comparisons
 
         public void Generate(ISettings settings)
         {
-            throw new NotImplementedException();
+            Generate(TimingMethod.RealTime);
+            Generate(TimingMethod.GameTime);
+        }
+
+        public void Generate(TimingMethod method)
+        {
+            var mains = new List<ISegment>();
+            var mainIndices = new Dictionary<ISegment, int>();
+            var subsegments = new Dictionary<ISegment, IList<ISegment>>();
+
+            var subsegmentList = new List<ISegment>();
+            for (int segmentIndex = 0; segmentIndex < Run.Count; ++segmentIndex)
+            {
+                var segment = Run[segmentIndex];
+                subsegmentList.Add(segment);
+
+                if ((segment.Name.Length == 0) || (segment.Name[0] != '-'))
+                {
+                    mains.Add(segment);
+                    mainIndices.Add(segment, segmentIndex);
+                    subsegments.Add(segment, subsegmentList);
+                    subsegmentList = new List<ISegment>();
+                }
+            }
+
+            var attemptIndices = from attempt in Run.AttemptHistory
+                                 select attempt.Index;
+
+            // TODO: record all subsegments of the best main for the comparison
+            foreach (var attemptIndex in attemptIndices)
+            {
+                //foreach (var mainSegment in mains)
+                for (int ind = 0; ind < mains.Count; ++ind)
+                {
+                    var mainSegment = mains[ind];
+                    if (mainSegment.SegmentHistory.ContainsKey(attemptIndex))
+                    {
+                        var mainTime = TimeSpan.Zero;
+                        foreach (var subsegment in subsegments[mainSegment])
+                        {
+                            mainTime += subsegment.SegmentHistory[attemptIndex][method] ?? TimeSpan.Zero;
+                        }
+
+                        TimeSpan? comparisonTime = Run[mainIndices[mainSegment]].Comparisons[Name][method];
+                        if (ind > 0)
+                            comparisonTime -= Run[mainIndices[mains[ind-1]]].Comparisons[Name][method];
+
+                        if ((comparisonTime == null) || (mainTime < comparisonTime))
+                        {
+
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/BestMainSegmentsComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/BestMainSegmentsComparisonGenerator.cs
@@ -53,25 +53,22 @@ namespace LiveSplit.Model.Comparisons
             foreach (var attemptIndex in attemptIndices)
             {
                 //foreach (var mainSegment in mains)
-                for (int ind = 0; ind < mains.Count; ++ind)
+                for (int ind = 0; (ind < mains.Count) && (mains[ind].SegmentHistory.ContainsKey(attemptIndex)); ++ind)
                 {
                     var mainSegment = mains[ind];
-                    if (mainSegment.SegmentHistory.ContainsKey(attemptIndex))
+                    var mainTime = TimeSpan.Zero;
+                    foreach (var subsegment in subsegments[mainSegment])
                     {
-                        var mainTime = TimeSpan.Zero;
-                        foreach (var subsegment in subsegments[mainSegment])
-                        {
-                            mainTime += subsegment.SegmentHistory[attemptIndex][method] ?? TimeSpan.Zero;
-                        }
+                        mainTime += subsegment.SegmentHistory[attemptIndex][method] ?? TimeSpan.Zero;
+                    }
 
-                        TimeSpan? comparisonTime = Run[mainIndices[mainSegment]].Comparisons[Name][method];
-                        if (ind > 0)
-                            comparisonTime -= Run[mainIndices[mains[ind-1]]].Comparisons[Name][method];
+                    TimeSpan? comparisonTime = Run[mainIndices[mainSegment]].Comparisons[Name][method];
+                    if (ind > 0)
+                        comparisonTime -= Run[mainIndices[mains[ind-1]]].Comparisons[Name][method];
 
-                        if ((comparisonTime == null) || (mainTime < comparisonTime))
-                        {
+                    if ((comparisonTime == null) || (mainTime < comparisonTime))
+                    {
 
-                        }
                     }
                 }
             }

--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
@@ -13,6 +13,7 @@ namespace LiveSplit.Model.Comparisons
             AddShortComparisonName(WorstSegmentsComparisonGenerator.ComparisonName, WorstSegmentsComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(PercentileComparisonGenerator.ComparisonName, PercentileComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(LatestRunComparisonGenerator.ComparisonName, LatestRunComparisonGenerator.ShortComparisonName);
+            AddShortComparisonName(BestMainSegmentsComparisonGenerator.ComparisonName, BestMainSegmentsComparisonGenerator.ShortComparisonName);
         }
         public IEnumerable<IComparisonGenerator> Create(IRun run)
         {
@@ -28,6 +29,7 @@ namespace LiveSplit.Model.Comparisons
             yield return new WorstSegmentsComparisonGenerator(run);
             yield return new PercentileComparisonGenerator(run);
             yield return new LatestRunComparisonGenerator(run);
+            yield return new BestMainSegmentsComparisonGenerator(run);
             yield return new NoneComparisonGenerator(run);
         }
     }


### PR DESCRIPTION
Added an automatic comparison that groups subsplits under their corresponding top-level splits and finds the fastest total time for each top-level segment.
![sobm](https://user-images.githubusercontent.com/7156984/51448612-00526880-1ce5-11e9-9262-91f8364b0781.jpg)
