### PR TITLE
Removed Pony Island Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4564,16 +4564,6 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
-      <Game>Pony Island</Game>
-    </Games>
-    <URLs>
-      <URL>https://raw.githubusercontent.com/Avasam/Pony-Island-AutoSplitter/master/PonyIsland.asl</URL>
-    </URLs>
-    <Type>Script</Type>
-    <Description>Auto Splitting, Start, and Reset are available. (By Avasam)</Description>
-  </AutoSplitter>
-  <AutoSplitter>
-    <Games>
       <Game>Cryostasis</Game>
       <Game>Cryostasis: Sleep of Reason</Game>
     </Games>


### PR DESCRIPTION
The Autosplitter has issues. It's also leading to confusion and not really worth using. My autosplitter doesn't have a level of quality that belongs here and should be removed for now to avoid further issues.