### PR TITLE
Fix description for Into the Breach Autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5498,7 +5498,7 @@
       <URL>https://raw.githubusercontent.com/R30hedron/Into-the-Breach-Autosplitter/master/ItB.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Supports auto starts, splits, and resets; add'l option to disable island splits for multi-game runs (which disables auto resets).</Description>
+    <Description>Supports auto starts, splits, and resets. Check settings if running multi-game runs. (by R30hedron)</Description>
     <Website>https://github.com/R30hedron/Into-the-Breach-Autosplitter</Website>
   </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Shortened to prevent the desc. from being cut off in the splits edit dialog.
Added author so that the List of ASL scripts doesn't have a '?' in the author column.