### PR TITLE
Replacing pop: ww autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4896,10 +4896,10 @@
       <Game>Prince of Persia Warrior Within</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/samabam/Sands-of-Time-Autosplitter/master/POPWarriorWithin_v1.ASL</URL>
+      <URL>https://raw.githubusercontent.com/Cred1Tor/Autosplitters/master/POPWarriorWithin_v2.ASL</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Auto Splitting (with sub/category detection) is available. (By Samabam)</Description>
+    <Description>Auto splitting, auto starting, auto resetting (with sub/category detection) are available. (By Creditor)</Description>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
This is an alternative autosplitter for prince of persia: warrior within that fixes some issues with the old one (where some splits either don't work or inconsistent). Also it's more optimized and easier to edit