### PR TITLE
Modify Invalidator Calculation

### DIFF
--- a/LiveSplit/LiveSplit.Core/UI/Invalidator.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Invalidator.cs
@@ -36,13 +36,13 @@ namespace LiveSplit.UI
                 new PointF(x+width, y+height)
             };
             Transform.TransformPoints(points);
-            var roundedX = (int)Math.Ceiling(points[0].X - Offset);
-            var roundedY = (int)Math.Ceiling(points[0].Y - Offset);
+            var offsetX = points[0].X - Offset;
+            var offsetY = points[0].Y - Offset;
             var rect = new Rectangle(
-                roundedX,
-                roundedY,
-                (int)Math.Ceiling(points[1].X - roundedX - Offset),
-                (int)Math.Ceiling(points[1].Y - roundedY - Offset));
+                (int)Math.Ceiling(offsetX),
+                (int)Math.Ceiling(offsetY),
+                (int)Math.Ceiling(points[1].X - offsetX - Offset),
+                (int)Math.Ceiling(points[1].Y - offsetY - Offset));
             Form.Invalidate(rect);
         }
     }


### PR DESCRIPTION
Move the point at which the Invalidator rounds the calculated height, width, x and y to prevent improper truncating of invalidation area.

Demonstrated as such here:
![Screenshot_2418](https://user-images.githubusercontent.com/12072058/58752759-6a90cc00-8482-11e9-90b5-97c34204e8dc.png)
