### PR TITLE
Add icons drag and drop support on Splits Editor

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -94,6 +94,7 @@
             // 
             // runGrid
             // 
+            this.runGrid.AllowDrop = true;
             this.runGrid.AllowUserToAddRows = false;
             this.runGrid.AllowUserToResizeColumns = false;
             this.runGrid.AllowUserToResizeRows = false;
@@ -113,6 +114,8 @@
             this.runGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
             this.runGrid.Size = new System.Drawing.Size(530, 295);
             this.runGrid.TabIndex = 0;
+            this.runGrid.DragDrop += new System.Windows.Forms.DragEventHandler(this.runGrid_DragDrop);
+            this.runGrid.DragOver += new System.Windows.Forms.DragEventHandler(this.runGrid_DragOver);
             this.runGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.runGrid_KeyDown);
             // 
             // tableLayoutPanel1

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -616,43 +616,48 @@ namespace LiveSplit.View
                 var result = dialog.ShowDialog();
                 if (result == DialogResult.OK)
                 {
-                    try
+                    ChangeImage(e.RowIndex, dialog.FileName, multiEdit);
+                }
+            }
+        }
+
+        private void ChangeImage(int rowIndex, string fileName, bool multiEdit)
+        {
+            try
+            {
+                var image = Image.FromFile(fileName).ScaleIcon();
+
+                if (!multiEdit)
+                {
+                    var oldImage = (Image)runGrid.Rows[rowIndex].Cells[ICONINDEX].Value;
+                    if (oldImage != null)
+                        ImagesToDispose.Add(oldImage);
+
+                    Run[rowIndex].Icon = image;
+                    runGrid.NotifyCurrentCellDirty(true);
+                }
+                else
+                {
+                    foreach (DataGridViewCell cell in runGrid.SelectedCells)
                     {
-                        var image = Image.FromFile(dialog.FileName).ScaleIcon();
+                        if (cell.ColumnIndex != ICONINDEX)
+                            continue;
 
-                        if (!multiEdit)
-                        {
-                            var oldImage = (Image)runGrid.Rows[e.RowIndex].Cells[ICONINDEX].Value;
-                            if (oldImage != null)
-                                ImagesToDispose.Add(oldImage);
+                        var oldImage = (Image)cell.Value;
+                        if (oldImage != null)
+                            ImagesToDispose.Add(oldImage);
 
-                            Run[e.RowIndex].Icon = image;
-                            runGrid.NotifyCurrentCellDirty(true);
-                        }
-                        else
-                        {
-                            foreach (DataGridViewCell cell in runGrid.SelectedCells)
-                            {
-                                if (cell.ColumnIndex != ICONINDEX)
-                                    continue;
-
-                                var oldImage = (Image)cell.Value;
-                                if (oldImage != null)
-                                    ImagesToDispose.Add(oldImage);
-
-                                Run[cell.RowIndex].Icon = (Image)image.Clone();
-                                runGrid.UpdateCellValue(ICONINDEX, cell.RowIndex);
-                            }
-                        }
-
-                        RaiseRunEdited();
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex);
-                        MessageBox.Show("Could not load image!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        Run[cell.RowIndex].Icon = (Image)image.Clone();
+                        runGrid.UpdateCellValue(ICONINDEX, cell.RowIndex);
                     }
                 }
+
+                RaiseRunEdited();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex);
+                MessageBox.Show("Could not load image!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -1562,6 +1567,37 @@ namespace LiveSplit.View
                     SetClickEvents(childControl);
             }
             control.Click += ClickControl;
+        }
+
+        private void runGrid_DragDrop(object sender, DragEventArgs e)
+        {
+            if (DragIsValid(e))
+            {
+                Point dgvPos = runGrid.PointToClient(new Point(e.X, e.Y));
+                DataGridView.HitTestInfo info = runGrid.HitTest(dgvPos.X, dgvPos.Y);
+                var imagePath = (e.Data.GetData(DataFormats.FileDrop) as string[])?[0];
+                ChangeImage(info.RowIndex, imagePath, false);
+            }
+        }
+
+        private const string VALID_PICTURE_EXTENSIONS = "*.BMP;*.JPG;*.GIF;*.JPEG;*.PNG";
+
+        private void runGrid_DragOver(object sender, DragEventArgs e)
+        {
+            e.Effect = DragIsValid(e) ? DragDropEffects.Copy : DragDropEffects.None;
+        }
+
+        private bool DragIsValid(DragEventArgs e)
+        {
+            Point dgvPos = runGrid.PointToClient(new Point(e.X, e.Y));
+            DataGridView.HitTestInfo info = runGrid.HitTest(dgvPos.X, dgvPos.Y);
+            var imagePath = (e.Data.GetData(DataFormats.FileDrop) as string[])?[0];
+
+            return e.Data.GetDataPresent(DataFormats.FileDrop)
+                   && runGrid.Columns[info.ColumnIndex] is DataGridViewImageColumn
+                   && info.Type == DataGridViewHitTestType.Cell
+                   && VALID_PICTURE_EXTENSIONS.Contains(new System.IO.FileInfo(imagePath).Extension.ToUpper());
+            // The last validation will probably be deleted
         }
     }
 

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1577,6 +1577,7 @@ namespace LiveSplit.View
                 DataGridView.HitTestInfo info = runGrid.HitTest(dgvPos.X, dgvPos.Y);
                 var imagePath = (e.Data.GetData(DataFormats.FileDrop) as string[])?[0];
                 ChangeImage(info.RowIndex, imagePath, false);
+                runGrid.Refresh();
             }
         }
 
@@ -1592,6 +1593,7 @@ namespace LiveSplit.View
             var imagePath = (e.Data.GetData(DataFormats.FileDrop) as string[])?[0];
 
             return e.Data.GetDataPresent(DataFormats.FileDrop)
+                   && info.ColumnIndex != -1
                    && runGrid.Columns[info.ColumnIndex] is DataGridViewImageColumn
                    && info.Type == DataGridViewHitTestType.Cell;
         }

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1580,8 +1580,6 @@ namespace LiveSplit.View
             }
         }
 
-        private const string VALID_PICTURE_EXTENSIONS = "*.BMP;*.JPG;*.GIF;*.JPEG;*.PNG";
-
         private void runGrid_DragOver(object sender, DragEventArgs e)
         {
             e.Effect = DragIsValid(e) ? DragDropEffects.Copy : DragDropEffects.None;

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1595,9 +1595,7 @@ namespace LiveSplit.View
 
             return e.Data.GetDataPresent(DataFormats.FileDrop)
                    && runGrid.Columns[info.ColumnIndex] is DataGridViewImageColumn
-                   && info.Type == DataGridViewHitTestType.Cell
-                   && VALID_PICTURE_EXTENSIONS.Contains(new System.IO.FileInfo(imagePath).Extension.ToUpper());
-            // The last validation will probably be deleted
+                   && info.Type == DataGridViewHitTestType.Cell;
         }
     }
 


### PR DESCRIPTION
Add icons drag and drop support on Splits Editor with same validation than icon chosen from File Explorer Dialog box

![DrapNDrop](https://user-images.githubusercontent.com/25965758/59816829-8ce07180-92eb-11e9-8cac-56307dfff59b.gif)
