### PR TITLE
Support importing splits from URL from live split one splits.io URLs

### DIFF
--- a/LiveSplit/LiveSplit.View/Model/RunImporters/URLRunImporter.cs
+++ b/LiveSplit/LiveSplit.View/Model/RunImporters/URLRunImporter.cs
@@ -19,6 +19,14 @@ namespace LiveSplit.Model.RunImporters
                 var runFactory = new StandardFormatsRunFactory();
                 var comparisonGeneratorsFactory = new StandardComparisonGeneratorsFactory();
 
+                // Supports opening from URLs such as https://one.livesplit.org/#/splits-io/46qh
+                int liveSplitOneSplitsIOIndex = url.IndexOf("#/splits-io/");
+                if (liveSplitOneSplitsIOIndex != -1)
+                {
+                    // 12 is the length of #/splits-io/
+                    url = "https://splits.io/" + url.Substring(liveSplitOneSplitsIOIndex + 12);
+                }
+
                 var uri = new Uri(url);
                 var host = uri.Host.ToLowerInvariant();
                 if (host == "splits.io")


### PR DESCRIPTION
I tried to emulate LiveSplitOne's handling of the URL without depending on the link actually starting with `https://one.livesplit.org`

Closes #1409 