### PR TITLE
Redone Titanfall 2 autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -957,11 +957,11 @@
       <Game>Titanfall 2</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/drtchops/asl/master/titanfall2.asl</URL>
+      <URL>https://raw.githubusercontent.com/Fzzy2j/Titanfall-2-Autosplitter/master/titanfall2.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Load Removal is available. (By DrTChops)</Description>
-    <Website>https://github.com/drtchops/asl/blob/master/README.md</Website>
+    <Description>Autosplitter is available. (By Fzzy2j)</Description>
+    <Website>https://github.com/Fzzy2j/Titanfall-2-Autosplitter/blob/master/README.md</Website>
   </AutoSplitter>
   <AutoSplitter>
     <Games>


### PR DESCRIPTION
The old autosplitter was known to be very bare bones and even broken in some places, this one doesnt have those problems and has more features.