### PR TITLE
Simplify and centralize time formatters

### DIFF
--- a/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
@@ -161,6 +161,8 @@
     <Compile Include="Server\ScriptFactory.cs" />
     <Compile Include="Server\CommandServer.cs" />
     <Compile Include="TimeFormatters\AutomaticPrecisionTimeFormatter.cs" />
+    <Compile Include="TimeFormatters\NullFormat.cs" />
+    <Compile Include="TimeFormatters\GeneralTimeFormatter.cs" />
     <Compile Include="TimeFormatters\PossibleTimeSaveFormatter.cs" />
     <Compile Include="TimeFormatters\TimeFormat.cs" />
     <Compile Include="TimeFormatters\TimeAccuracy.cs" />

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/AutomaticPrecisionTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/AutomaticPrecisionTimeFormatter.cs
@@ -2,29 +2,16 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    public class AutomaticPrecisionTimeFormatter : ITimeFormatter
+    public class AutomaticPrecisionTimeFormatter : GeneralTimeFormatter
     {
-        RegularTimeFormatter InternalFormatter;
-
         public AutomaticPrecisionTimeFormatter()
         {
-            InternalFormatter = new RegularTimeFormatter();
+            NullFormat = NullFormat.ZeroWithAccuracy;
+            DigitsFormat = DigitsFormat.SingleDigitMinutes;
+            Accuracy = TimeAccuracy.Hundredths;
+            AutomaticPrecision = true;
+            NullFormat = NullFormat.ZeroWithAccuracy;
         }
 
-        public string Format(TimeSpan? time)
-        {
-            if (time.HasValue)
-            {
-                var totalSeconds = time.Value.TotalSeconds;
-                if (totalSeconds % 1 == 0)
-                    InternalFormatter.Accuracy = TimeAccuracy.Seconds;
-                else if ((10 * totalSeconds) % 1 == 0)
-                    InternalFormatter.Accuracy = TimeAccuracy.Tenths;
-                else
-                    InternalFormatter.Accuracy = TimeAccuracy.Hundredths;
-            }
-
-            return InternalFormatter.Format(time);
-        }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/DeltaTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/DeltaTimeFormatter.cs
@@ -3,44 +3,14 @@ using System.Globalization;
 
 namespace LiveSplit.TimeFormatters
 {
-    public class DeltaTimeFormatter : ITimeFormatter
+    public class DeltaTimeFormatter : GeneralTimeFormatter
     {
-        public TimeAccuracy Accuracy { get; set; }
-        public bool DropDecimals { get; set; }
 
-        public DeltaTimeFormatter()
+        public DeltaTimeFormatter() : base()
         {
             Accuracy = TimeAccuracy.Tenths;
             DropDecimals = true;
-        }
-
-        public string Format(TimeSpan? time)
-        {
-            if (time.HasValue)
-            {
-                string minusString = "+";
-                var totalString = "";
-                if (time.Value < TimeSpan.Zero)
-                {
-                    minusString = TimeFormatConstants.MINUS;
-                    time = TimeSpan.Zero-time;
-                }
-                if (time.Value.TotalDays >= 1)
-                    totalString = minusString + (int)(time.Value.TotalHours) + time.Value.ToString(@"\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                else if (time.Value.TotalHours >= 1)
-                    totalString = minusString+time.Value.ToString(@"h\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                else if (time.Value.TotalMinutes >= 1)
-                    totalString = minusString+time.Value.ToString(@"m\:ss\.ff", CultureInfo.InvariantCulture);
-                else
-                    totalString = minusString+time.Value.ToString(@"s\.ff", CultureInfo.InvariantCulture);
-                if ((DropDecimals && time.Value.TotalMinutes >= 1) || Accuracy == TimeAccuracy.Seconds)
-                    return totalString.Substring(0, totalString.Length - 3);
-                else if (Accuracy == TimeAccuracy.Tenths)
-                    return totalString.Substring(0, totalString.Length - 1);
-                return totalString;
-            }
-
-            return TimeFormatConstants.DASH;
+            ShowPlus = true;
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/DeltaTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/DeltaTimeFormatter.cs
@@ -5,8 +5,7 @@ namespace LiveSplit.TimeFormatters
 {
     public class DeltaTimeFormatter : GeneralTimeFormatter
     {
-
-        public DeltaTimeFormatter() : base()
+        public DeltaTimeFormatter()
         {
             Accuracy = TimeAccuracy.Tenths;
             DropDecimals = true;

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
@@ -105,7 +105,7 @@ namespace LiveSplit.TimeFormatters {
             if (time.TotalDays >= 1)
             {
                 if (ShowDays)
-                    formatted = minusString + time.ToString(@"d\d\ h\:mm\:ss" + decimalFormat, ic);
+                    formatted = minusString + time.ToString(@"d\d\ " + (DigitsFormat == DigitsFormat.DoubleDigitHours ? "hh" : "h") + @"\:mm\:ss" + decimalFormat, ic);
                 else
                     formatted = minusString + (int)time.TotalHours + time.ToString(@"\:mm\:ss" + decimalFormat, ic);
             }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
@@ -49,13 +49,10 @@ namespace LiveSplit.TimeFormatters {
             if (isNull) {
                 if (NullFormat == NullFormat.Dash) {
                     return TimeFormatConstants.DASH;
-
                 } else if (NullFormat == NullFormat.ZeroWithAccuracy) {
                     return ZeroWithAccuracy();
-
                 } else if (NullFormat == NullFormat.ZeroDotZeroZero) {
                     return "0.00";
-
                 } else if (NullFormat == NullFormat.ZeroValue || NullFormat == NullFormat.Dashes) {
                     timeNullable = TimeSpan.Zero;
                 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Globalization;
+
+namespace LiveSplit.TimeFormatters {
+    public class GeneralTimeFormatter : ITimeFormatter {
+        static readonly private CultureInfo ic = CultureInfo.InvariantCulture;
+
+        public TimeAccuracy Accuracy { get; set; }
+
+        //TODO: add enum: BigMinutes (for issue #1336)
+        //TODO: add enum: SingleMinutes (for RegularTimeFormatter, e.g. 0:12)
+        public TimeFormat TimeFormat { get; set; }
+
+        /// <summary>
+        /// How to display null times
+        /// </summary>
+        public NullFormat NullFormat { get; set; }
+
+        /// <summary>
+        /// If true, for example show "1d 23:59:10" instead of "47:59:10". For durations of 24 hours or more, 
+        /// </summary>
+        public bool ShowDays { get; set; }
+
+        /// <summary>
+        /// If true, include a "+" for positive times (excluding zero)
+        /// </summary>
+        public bool ShowPlus { get; set; }
+
+        /// <summary>
+        /// If true, don't display decimals if absolute time is 1 minute or more
+        /// </summary>
+        public bool DropDecimals { get; set; }
+
+        /// <summary>
+        /// If true, don't display trailing zero demical places
+        /// </summary>
+        public bool AutomaticPrecision { get; set; } = false;
+
+        public GeneralTimeFormatter()
+        {
+            TimeFormat = TimeFormat.Seconds;
+            NullFormat = NullFormat.Dash;
+        }
+
+        public string Format(TimeSpan? timeNullable)
+        {
+            bool isNull = (!timeNullable.HasValue);
+            if (isNull) {
+                if (NullFormat == NullFormat.Dash) {
+                    return TimeFormatConstants.DASH;
+
+                } else if (NullFormat == NullFormat.ZeroWithAccuracy) {
+                    return ZeroWithAccuracy();
+
+                } else if (NullFormat == NullFormat.ZeroDotZeroZero) {
+                    return "0.00";
+
+                } else if (NullFormat == NullFormat.ZeroValue || NullFormat == NullFormat.Dashes) {
+                    timeNullable = TimeSpan.Zero;
+                }
+            }
+
+            TimeSpan time = timeNullable.Value;
+
+            string minusString;
+            if (time < TimeSpan.Zero)
+            {
+                minusString = TimeFormatConstants.MINUS;
+                time = -time;
+            }
+            else
+            {
+                minusString = (ShowPlus ? "+" : "");
+            }
+
+            string decimalFormat = "";
+            if (DropDecimals && time.TotalMinutes >= 1) 
+                decimalFormat = "";
+            else if (Accuracy == TimeAccuracy.Seconds)
+                decimalFormat = "";
+            else if (Accuracy == TimeAccuracy.Tenths) 
+                decimalFormat = @"\.f";
+            else if (Accuracy == TimeAccuracy.Hundredths)
+                decimalFormat = @"\.ff";
+
+            if (AutomaticPrecision)
+                decimalFormat.Replace('f', 'F');
+
+            string formatted;
+            if (time.TotalDays >= 1)
+            {
+                if (ShowDays)
+                    formatted = minusString + time.ToString(@"d\d\ h\:mm\:ss" + decimalFormat, ic);
+                else
+                    formatted = minusString + (int)time.TotalHours + time.ToString(@"\:mm\:ss" + decimalFormat, ic);
+            }
+            else if (TimeFormat == TimeFormat.TenHours)
+            {
+                formatted = minusString + time.ToString(@"hh\:mm\:ss" + decimalFormat, ic);
+            }
+            else if (time.TotalHours >= 1 || TimeFormat == TimeFormat.Hours)
+            {
+                formatted = minusString + time.ToString(@"h\:mm\:ss" + decimalFormat, ic);
+            }
+            else if (TimeFormat == TimeFormat.Minutes)
+            {
+                formatted = minusString + time.ToString(@"mm\:ss" + decimalFormat, ic);
+            }
+            else if (time.TotalMinutes >= 1 || TimeFormat == TimeFormat.SingleMinutes)
+            {
+                formatted = minusString + time.ToString(@"m\:ss" + decimalFormat, ic);
+            }
+            else
+            {
+                formatted = minusString + time.ToString(@"%s" + decimalFormat, ic);
+            }
+
+            if (isNull && NullFormat == NullFormat.Dashes)
+                formatted = formatted.Replace('0', '-');
+
+            return formatted;
+        }
+
+        private string ZeroWithAccuracy()
+        {
+            if (Accuracy == TimeAccuracy.Seconds)
+                return "0";
+            else if (Accuracy == TimeAccuracy.Tenths)
+                return "0.0";
+            else
+                return "0.00";
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/NullFormat.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/NullFormat.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LiveSplit.TimeFormatters
+{
+    public enum NullFormat
+    {
+        Dash, // "-"
+        ZeroWithAccuracy, // "0", "0.0" or "0.00" (dependant on TimeAccuracy; not affected by AutomaticPrecision nor TimeFormat)
+        ZeroDotZeroZero, // always "0.00" (used by ShortTimeFormatter)
+        ZeroValue, // format the null value the same as TimeSpan.Zero
+        Dashes // e.g. "-:--" (like ZeroValue but zeros replaced with dashes)
+    }
+}

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
@@ -2,27 +2,12 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    public class PossibleTimeSaveFormatter : ITimeFormatter
+    public class PossibleTimeSaveFormatter : GeneralTimeFormatter
     {
-        public TimeAccuracy Accuracy { get; set; }
-
-        public string Format(TimeSpan? time)
+        public PossibleTimeSaveFormatter() : base()
         {
-            var formatter = new ShortTimeFormatter();
-            if (time == null)
-                return TimeFormatConstants.DASH;
-            else
-            {
-                var timeString = formatter.Format(time);
-                if (Accuracy == TimeAccuracy.Hundredths)
-                    return timeString;
-                else if (Accuracy == TimeAccuracy.Tenths)
-                    return timeString.Substring(0, timeString.Length - 1);
-                else
-                    return timeString.Substring(0, timeString.Length - 3);
-
-            }
-                
+            Accuracy = TimeAccuracy.Hundredths;
+            NullFormat = NullFormat.Dash;
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
@@ -4,7 +4,7 @@ namespace LiveSplit.TimeFormatters
 {
     public class PossibleTimeSaveFormatter : GeneralTimeFormatter
     {
-        public PossibleTimeSaveFormatter() : base()
+        public PossibleTimeSaveFormatter()
         {
             Accuracy = TimeAccuracy.Seconds;
             NullFormat = NullFormat.Dash;

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
@@ -6,7 +6,7 @@ namespace LiveSplit.TimeFormatters
     {
         public PossibleTimeSaveFormatter() : base()
         {
-            Accuracy = TimeAccuracy.Hundredths;
+            Accuracy = TimeAccuracy.Seconds;
             NullFormat = NullFormat.Dash;
         }
     }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/RegularTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/RegularTimeFormatter.cs
@@ -9,7 +9,7 @@ namespace LiveSplit.TimeFormatters
         {
             Accuracy = accuracy;
             NullFormat = NullFormat.ZeroWithAccuracy;
-            TimeFormat = TimeFormat.SingleMinutes;
+            DigitsFormat = DigitsFormat.SingleDigitMinutes;
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/RegularTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/RegularTimeFormatter.cs
@@ -3,49 +3,13 @@ using System.Globalization;
 
 namespace LiveSplit.TimeFormatters
 {
-    public class RegularTimeFormatter : ITimeFormatter
+    public class RegularTimeFormatter : GeneralTimeFormatter
     {
-        public TimeAccuracy Accuracy { get; set; }
-
         public RegularTimeFormatter(TimeAccuracy accuracy = TimeAccuracy.Seconds)
         {
             Accuracy = accuracy;
-        }
-
-        public string Format(TimeSpan? time)
-        {
-            if (time.HasValue)
-            {
-                if (Accuracy == TimeAccuracy.Hundredths)
-                {
-                    if (time.Value.TotalDays >= 1)
-                        return (int)(time.Value.TotalHours) + time.Value.ToString(@"\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                    else if (time.Value.TotalHours >= 1)
-                        return time.Value.ToString(@"h\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                    return time.Value.ToString(@"m\:ss\.ff", CultureInfo.InvariantCulture);
-                }
-                else if (Accuracy == TimeAccuracy.Seconds)
-                {
-                    if (time.Value.TotalDays >= 1)
-                        return (int)(time.Value.TotalHours) + time.Value.ToString(@"\:mm\:ss", CultureInfo.InvariantCulture);
-                    else if (time.Value.TotalHours >= 1)
-                        return time.Value.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture);
-                    return time.Value.ToString(@"m\:ss", CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    if (time.Value.TotalDays >= 1)
-                        return (int)(time.Value.TotalHours) + time.Value.ToString(@"\:mm\:ss\.f", CultureInfo.InvariantCulture);
-                    else if (time.Value.TotalHours >= 1)
-                        return time.Value.ToString(@"h\:mm\:ss\.f", CultureInfo.InvariantCulture);
-                    return time.Value.ToString(@"m\:ss\.f", CultureInfo.InvariantCulture);
-                }
-            }
-            if (Accuracy == TimeAccuracy.Seconds)
-                return "0";
-            if (Accuracy == TimeAccuracy.Tenths)
-                return "0.0";
-            return "0.00";
+            NullFormat = NullFormat.ZeroWithAccuracy;
+            TimeFormat = TimeFormat.SingleMinutes;
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/RegularTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/RegularTimeFormatter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 
 namespace LiveSplit.TimeFormatters
 {

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace LiveSplit.TimeFormatters
 {
-    public class ShortTimeFormatter : GeneralTimeFormatter // ITimeFormatter
+    public class ShortTimeFormatter : GeneralTimeFormatter
     {
 
         public ShortTimeFormatter() : base()

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
@@ -5,8 +5,7 @@ namespace LiveSplit.TimeFormatters
 {
     public class ShortTimeFormatter : GeneralTimeFormatter
     {
-
-        public ShortTimeFormatter() : base()
+        public ShortTimeFormatter()
         {
             Accuracy = TimeAccuracy.Hundredths;
             NullFormat = NullFormat.ZeroWithAccuracy;

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
@@ -3,62 +3,24 @@ using System.Globalization;
 
 namespace LiveSplit.TimeFormatters
 {
-    public class ShortTimeFormatter : ITimeFormatter
+    public class ShortTimeFormatter : GeneralTimeFormatter // ITimeFormatter
     {
-        public string Format(TimeSpan? time)
+
+        public ShortTimeFormatter() : base()
         {
-            if (time.HasValue)
-            {
-                string minusString = "";
-                if (time.Value < TimeSpan.Zero)
-                {
-                    minusString = TimeFormatConstants.MINUS;
-                    time = TimeSpan.Zero - time;
-                }
-                if (time.Value.TotalDays >= 1)
-                    return minusString + (int)(time.Value.TotalHours) + time.Value.ToString(@"\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                else if (time.Value.TotalHours >= 1)
-                    return minusString+time.Value.ToString(@"h\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                else if (time.Value.Minutes >= 1)
-                    return minusString+time.Value.ToString(@"m\:ss\.ff", CultureInfo.InvariantCulture);
-                return minusString+time.Value.ToString(@"s\.ff", CultureInfo.InvariantCulture);
-            }
-            return "0.00";
+            Accuracy = TimeAccuracy.Hundredths;
+            NullFormat = NullFormat.ZeroWithAccuracy;
         }
 
         public string Format(TimeSpan? time, TimeFormat format)
         {
-            if (time.HasValue)
-            {
-                string minusString = "";
-                if (time.Value < TimeSpan.Zero)
-                {
-                    minusString = TimeFormatConstants.MINUS;
-                    time = TimeSpan.Zero - time;
-                }
-                if (time.Value.TotalDays >= 1)
-                {
-                    return minusString + (int)(time.Value.TotalHours) + time.Value.ToString(@"\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                }
-                else if (format == TimeFormat.TenHours)
-                {
-                    return minusString + time.Value.ToString(@"hh\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                }
-                else if (time.Value.TotalHours >= 1 || format == TimeFormat.Hours)
-                {
-                    return minusString + time.Value.ToString(@"h\:mm\:ss\.ff", CultureInfo.InvariantCulture);
-                }
-                else if (format == TimeFormat.Minutes)
-                {
-                    return minusString + time.Value.ToString(@"mm\:ss\.ff", CultureInfo.InvariantCulture);
-                }
-                else if (time.Value.Minutes >= 1)
-                {
-                    return minusString + time.Value.ToString(@"m\:ss\.ff", CultureInfo.InvariantCulture);
-                }
-                return minusString + time.Value.ToString(@"s\.ff", CultureInfo.InvariantCulture);
-            }
-            return "0.00";
+            var formatRequest = new GeneralTimeFormatter {
+                Accuracy = TimeAccuracy.Hundredths,
+                NullFormat = NullFormat.ZeroWithAccuracy,
+                TimeFormat = format
+            };
+
+            return formatRequest.Format(time);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/TimeAccuracy.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/TimeAccuracy.cs
@@ -2,6 +2,6 @@
 {
     public enum TimeAccuracy
     {
-        Seconds, Tenths, Hundredths
+        Seconds, Tenths, Hundredths, Milliseconds
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/TimeFormat.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/TimeFormat.cs
@@ -1,7 +1,46 @@
-﻿namespace LiveSplit.TimeFormatters
+﻿using System;
+
+namespace LiveSplit.TimeFormatters
 {
+    [Obsolete("Switch over to DigitsFormat")]
     public enum TimeFormat
     {
-        TenHours, Hours, Minutes, Seconds, SingleMinutes
+        TenHours,
+        Hours,
+        Minutes,
+        Seconds
+    }
+
+    public enum DigitsFormat
+    {
+        /// `1`
+        SingleDigitSeconds,
+        /// `01`
+        DoubleDigitSeconds,
+        /// `0:01`
+        SingleDigitMinutes,
+        /// `00:01`
+        DoubleDigitMinutes,
+        /// `0:00:01`
+        SingleDigitHours,
+        /// `00:00:01`
+        DoubleDigitHours,
+    }
+
+    static class FormatUtils
+    {
+        public static DigitsFormat ToDigitsFormat(this TimeFormat timeFormat)
+        {
+            if (timeFormat == TimeFormat.Seconds)
+                return DigitsFormat.SingleDigitSeconds;
+            else if (timeFormat == TimeFormat.Minutes)
+                return DigitsFormat.DoubleDigitMinutes;
+            else if (timeFormat == TimeFormat.Hours)
+                return DigitsFormat.SingleDigitHours;
+            else if (timeFormat == TimeFormat.TenHours)
+                return DigitsFormat.DoubleDigitHours;
+
+            return DigitsFormat.SingleDigitSeconds;
+        }
     }
 }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/TimeFormat.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/TimeFormat.cs
@@ -2,6 +2,6 @@
 {
     public enum TimeFormat
     {
-        TenHours, Hours, Minutes, Seconds
+        TenHours, Hours, Minutes, Seconds, SingleMinutes
     }
 }

--- a/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -52,7 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoSplitterTests\AutoSplitterXML.cs" />
+    <Compile Include="TimeFormatTests\DigitsFormatTests.cs" />
     <Compile Include="TimeFormatTests\DaysTimeFormatterTests.cs" />
+    <Compile Include="TimeFormatTests\TimeAccuracyTests.cs" />
     <Compile Include="TimeFormatTests\ShortTimeFormatterTests.cs" />
     <Compile Include="TimeFormatTests\RegularTimeFormattersTests.cs" />
     <Compile Include="TimeFormatTests\DeltaTimeFormattersTests.cs" />

--- a/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoSplitterTests\AutoSplitterXML.cs" />
+    <Compile Include="TimeFormatTests\ShowDaysTests.cs" />
     <Compile Include="TimeFormatTests\DigitsFormatTests.cs" />
     <Compile Include="TimeFormatTests\DaysTimeFormatterTests.cs" />
     <Compile Include="TimeFormatTests\TimeAccuracyTests.cs" />

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DaysTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DaysTimeFormatterTests.cs
@@ -8,7 +8,6 @@ namespace LiveSplit.Tests.TimeFormatterTests
     [TestClass]
     public class DaysTimeFormatterTests
     {
-
         // These tests cover DaysTimeFormatter, which (is/was not) based on any other TimeFormatter implementation
 
         [TestMethod]

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DeltaTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DeltaTimeFormattersTests.cs
@@ -7,15 +7,11 @@ namespace LiveSplit.Tests.TimeFormatterTests
     [TestClass]
     public class DeltaTimeFormattersTests 
     {
-
         // All these formatters (currently) give identical output:
-
-        //new DeltaTimeFormatter();
-        //new DeltaComponentFormatter(timeAccuracy, dropDecimals);
-        //new DeltaSplitTimeFormatter(timeAccuracy, dropDecimals);
-        //new PreciseDeltaFormatter(timeAccuracy); // no dropDecimals
-
-        // PreciseDeltaFormatter differs only in that it that dropDecimals is always false.
+        // - new DeltaTimeFormatter(timeAccuracy, dropDecimals);
+        // - new DeltaComponentFormatter(timeAccuracy, dropDecimals);
+        // - new DeltaSplitTimeFormatter(timeAccuracy, dropDecimals);
+        // - new PreciseDeltaFormatter(timeAccuracy); // dropDecimals is always false
 
         // note: dash (-) is used for null, and minus (−) for negatives
 
@@ -103,7 +99,6 @@ namespace LiveSplit.Tests.TimeFormatterTests
             Assert.AreEqual(expected, formatted);
         }
 
-
         [TestMethod]
         [DataRow(null, TimeAccuracy.Hundredths, "-")]
         [DataRow("00:00:00", TimeAccuracy.Seconds, "+0")]
@@ -129,6 +124,5 @@ namespace LiveSplit.Tests.TimeFormatterTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
@@ -7,7 +7,6 @@ namespace LiveSplit.Tests.TimeFormatTests
     [TestClass]
     public class DigitsFormatTests
     {
-
         [TestMethod]
         [DataRow("00:00:00", "0", DigitsFormat.SingleDigitSeconds)]
         [DataRow("00:00:00", "00", DigitsFormat.DoubleDigitSeconds)]
@@ -77,6 +76,5 @@ namespace LiveSplit.Tests.TimeFormatTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using LiveSplit.TimeFormatters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LiveSplit.Tests.TimeFormatTests
+{
+    [TestClass]
+    public class DigitsFormatTests
+    {
+
+        [TestMethod]
+        [DataRow("00:00:00", "0", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("00:00:00", "00", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("00:00:00", "0:00", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("00:00:00", "00:00", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("00:00:00", "0:00:00", DigitsFormat.SingleDigitHours)]
+        [DataRow("00:00:00", "00:00:00", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
+        [DataRow("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("00:00:12", "12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("00:00:34", "34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("00:00:56", "0:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("00:00:23", "00:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("00:00:45", "0:00:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("00:00:51", "00:00:51", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("00:01:12", "1:12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("00:02:34", "2:34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("00:03:56", "3:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("00:04:23", "04:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("00:05:45", "0:05:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("00:06:51", "00:06:51", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("00:51:12", "51:12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("00:42:34", "42:34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("00:33:56", "33:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("00:24:23", "24:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("00:15:45", "0:15:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("00:56:51", "00:56:51", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("02:51:12", "2:51:12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("03:42:34", "3:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("04:33:56", "4:33:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("05:24:23", "5:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("01:15:45", "1:15:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("02:56:51", "02:56:51", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("22:51:12", "22:51:12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("23:42:34", "23:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("14:33:56", "14:33:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("15:24:23", "15:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("21:15:45", "21:15:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("22:56:51", "22:56:51", DigitsFormat.DoubleDigitHours)]
+        
+        [DataRow("1:22:51:12", "46:51:12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("1:23:42:34", "47:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("1:14:33:56", "38:33:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("1:15:24:23", "39:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("1:21:15:45", "45:15:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("1:22:56:51", "46:56:51", DigitsFormat.DoubleDigitHours)]
+        public void TestDigitsFormat(string timespanText, string expected, DigitsFormat format)
+        {
+            var formatter = new GeneralTimeFormatter();
+            formatter.DigitsFormat = format;
+            formatter.Accuracy = TimeAccuracy.Seconds;
+
+            TimeSpan? time = null;
+            if (timespanText != null)
+                time = TimeSpan.Parse(timespanText);
+
+            string formatted = formatter.Format(time);
+            Assert.AreEqual(expected, formatted);
+        }
+
+    }
+}

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
@@ -137,11 +137,15 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [DataRow(null, "0")]
         [DataRow("00:00:00", "0:00")]
         [DataRow("00:00:01", "0:01")]
+        [DataRow("00:00:02.0", "0:02")]
+        [DataRow("00:00:03.00", "0:03")]
         [DataRow("00:00:01.2", "0:01.2")]
+        [DataRow("00:00:01.20", "0:01.2")]
+        [DataRow("00:00:01.200", "0:01.2")]
         [DataRow("00:00:01.23", "0:01.23")]
         [DataRow("00:00:01.234", "0:01.23")]
         [DataRow("00:00:01.2345", "0:01.23")]
-        [DataRow("00:00:01.20", "0:01.2")]
+        [DataRow("00:00:01.2000", "0:01.2")]
         [DataRow("00:00:01.204", "0:01.20")]
         [DataRow("00:00:01.2005", "0:01.20")]
         [DataRow("00:05:01.999", "5:01.99")]
@@ -159,11 +163,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
             Assert.AreEqual(expected, formatted);
         }
 
-        /*
-        // These tests will fail until changes are made. 
-        // Currently:
-        // - negative TimeSpans are displayed as positive
-        // - negative days are not displayed
+        
         [TestMethod]
         [DataRow("-00:00:00.05", TimeAccuracy.Hundredths, "−0:00.05")] // Actual:<0:00.05> [Fail]
         [DataRow("-00:00:01.009", TimeAccuracy.Tenths, "−0:01.0")] // Actual:<0:01.0> [Fail]
@@ -181,7 +181,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-        */
+        
 
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
@@ -8,7 +8,6 @@ namespace LiveSplit.Tests.TimeFormatterTests
     [TestClass]
     public class RegularTimeFormattersTests
     {
-
         // These tests cover the following, which are/were all based on RegularTimeFormatter:
         //new RegularTimeFormatter(timeAccuracy);
         //new RegularSplitTimeFormatter(timeAccuracy); // dash for null values
@@ -181,7 +180,5 @@ namespace LiveSplit.Tests.TimeFormatterTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-        
-
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
@@ -8,7 +8,6 @@ namespace LiveSplit.Tests.TimeFormatterTests
     [TestClass]
     public class ShortTimeFormatterTests
     {
-
         // These tests cover the following, which are/were all based on ShortTimeFormatter 
         // new ShortTimeFormatter(); // Format() accepts a TimeFormat
         // new PossibleTimeSaveFormatter(); // ShortTimeFormatter with Accuracy
@@ -40,10 +39,10 @@ namespace LiveSplit.Tests.TimeFormatterTests
         }
 
         [TestMethod]
-        [DataRow(null, TimeFormat.Seconds,  "0.00")] //        0.00 ?
-        [DataRow(null, TimeFormat.Minutes,  "0.00")] //    00:00.00 ?
-        [DataRow(null, TimeFormat.Hours,    "0.00")] //  0:00:00:00 ?
-        [DataRow(null, TimeFormat.TenHours, "0.00")] // 00:00:00.00 ?
+        [DataRow(null, TimeFormat.Seconds,  "0.00")] 
+        [DataRow(null, TimeFormat.Minutes,  "0.00")]
+        [DataRow(null, TimeFormat.Hours,    "0.00")]
+        [DataRow(null, TimeFormat.TenHours, "0.00")]
 
         [DataRow("00:00:00", TimeFormat.Seconds,         "0.00")]
         [DataRow("00:00:00", TimeFormat.Minutes,     "00:00.00")]
@@ -74,7 +73,6 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [DataRow("1.07:05:01.03", TimeFormat.Minutes,  "31:05:01.03")]
         [DataRow("1.07:05:01.03", TimeFormat.Hours,    "31:05:01.03")]
         [DataRow("1.07:05:01.03", TimeFormat.TenHours, "31:05:01.03")]
-
         public void TestShortTimeFormatterWithTimeFormat(string timespanText, TimeFormat format, string expected)
         {
             var formatter = new ShortTimeFormatter();
@@ -181,6 +179,5 @@ namespace LiveSplit.Tests.TimeFormatterTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
@@ -30,8 +30,6 @@ namespace LiveSplit.Tests.TimeFormatTests
 
         [DataRow("-5:01:15:45", "−5d 1:15:45", DigitsFormat.SingleDigitHours)]
         [DataRow("-6:02:56:51", "−6d 02:56:51", DigitsFormat.DoubleDigitHours)]
-
-
         public void TestShowDays(string timespanText, string expected, DigitsFormat format)
         {
             var formatter = new GeneralTimeFormatter();
@@ -46,6 +44,5 @@ namespace LiveSplit.Tests.TimeFormatTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using LiveSplit.TimeFormatters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LiveSplit.Tests.TimeFormatTests
+{
+    [TestClass]
+    public class ShowDaysTests
+    {
+        [TestMethod]
+        [DataRow("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
+        [DataRow("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("1:02:51:12", "1d 2:51:12", DigitsFormat.SingleDigitSeconds)]
+        [DataRow("1:03:42:34", "1d 3:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [DataRow("1:04:33:56", "1d 4:33:56", DigitsFormat.SingleDigitMinutes)]
+        [DataRow("1:05:24:23", "1d 5:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [DataRow("1:01:15:45", "1d 1:15:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("1:02:56:51", "1d 02:56:51", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("1:00:00:00", "1d 0:00:00", DigitsFormat.SingleDigitHours)]
+        [DataRow("3:00:00:00", "3d 00:00:00", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("2:00:00:23", "2d 0:00:23", DigitsFormat.SingleDigitHours)]
+        [DataRow("4:00:00:23", "4d 00:00:23", DigitsFormat.DoubleDigitHours)]
+
+        [DataRow("-5:01:15:45", "−5d 1:15:45", DigitsFormat.SingleDigitHours)]
+        [DataRow("-6:02:56:51", "−6d 02:56:51", DigitsFormat.DoubleDigitHours)]
+
+
+        public void TestShowDays(string timespanText, string expected, DigitsFormat format)
+        {
+            var formatter = new GeneralTimeFormatter();
+            formatter.DigitsFormat = format;
+            formatter.ShowDays = true;
+            formatter.Accuracy = TimeAccuracy.Seconds;
+
+            TimeSpan? time = null;
+            if (timespanText != null)
+                time = TimeSpan.Parse(timespanText);
+
+            string formatted = formatter.Format(time);
+            Assert.AreEqual(expected, formatted);
+        }
+
+    }
+}

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
@@ -29,7 +29,6 @@ namespace LiveSplit.Tests.TimeFormatTests
             formatter.DigitsFormat = DigitsFormat.SingleDigitMinutes;
             formatter.Accuracy = accuracy;
 
-
             TimeSpan? time = null;
             if (timespanText != null)
                 time = TimeSpan.Parse(timespanText);
@@ -37,6 +36,5 @@ namespace LiveSplit.Tests.TimeFormatTests
             string formatted = formatter.Format(time);
             Assert.AreEqual(expected, formatted);
         }
-
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using LiveSplit.TimeFormatters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LiveSplit.Tests.TimeFormatTests
+{
+    [TestClass]
+    public class TimeAccuracyTests
+    {
+        [TestMethod]
+        [DataRow("00:00:00", "0:00", TimeAccuracy.Seconds)]
+        [DataRow("00:00:01", "0:01.0", TimeAccuracy.Tenths)]
+        [DataRow("00:00:02", "0:02.00", TimeAccuracy.Hundredths)]
+        [DataRow("00:00:03", "0:03.000", TimeAccuracy.Milliseconds)]
+
+        [DataRow("00:00:04", "0:04", TimeAccuracy.Seconds)]
+        [DataRow("00:00:05.2", "0:05.2", TimeAccuracy.Tenths)]
+        [DataRow("00:00:06.22", "0:06.22", TimeAccuracy.Hundredths)]
+        [DataRow("00:00:07.222", "0:07.222", TimeAccuracy.Milliseconds)]
+
+        [DataRow("00:00:08.8888888", "0:08", TimeAccuracy.Seconds)]
+        [DataRow("00:00:09.8888888", "0:09.8", TimeAccuracy.Tenths)]
+        [DataRow("00:00:10.8888888", "0:10.88", TimeAccuracy.Hundredths)]
+        [DataRow("00:00:11.8888888", "0:11.888", TimeAccuracy.Milliseconds)]
+
+        public void TestTimeAccuracy(string timespanText, string expected, TimeAccuracy accuracy)
+        {
+            var formatter = new GeneralTimeFormatter();
+            formatter.DigitsFormat = DigitsFormat.SingleDigitMinutes;
+            formatter.Accuracy = accuracy;
+
+
+            TimeSpan? time = null;
+            if (timespanText != null)
+                time = TimeSpan.Parse(timespanText);
+
+            string formatted = formatter.Format(time);
+            Assert.AreEqual(expected, formatted);
+        }
+
+    }
+}


### PR DESCRIPTION
This creates a "GeneralTimeFormatter" class, which is capable of formatting a TimeSpan in all the ways all the existing ITimeFormatter classes do. This reduces duplicate code, keeps things consistent more easily, makes future changes to time formatting possible, and reduces minor bugs (e.g. negative TimeSpans are always handled correctly now without dropping the hours, which a couple of formats did previously)

This is purely a refactoring. There are no user-facing changes (or API changes).

This PR also updates all the Time Formatters that are in this repo to inherit from GeneralTimeFormatter and reduces their code to a few lines each. The unit tests all still pass. 

The time formatters in the submodules can get similar treatment but I haven't committed those yet. Those ones still work with these changes, even when they're calling formatters in the main repo (because the Format() methods of all refactored classes still give the same output).

Some notable code changes:

* added "SingleMinutes" to the TimeFormat enum. This is for time formats like "0:12" (for 0m12s), which is used by the RegularTimeFormatter classes. I've added it to the enum but it remains hidden in the UI so users can't select it for components that didn't have it before.

* created a [NullFormat enum](https://github.com/LiveSplit/LiveSplit/commit/cd4f4771c8365ccb535e89227a0f958dc2994db8#diff-9cce6fc4df1fb15b5f1ad90a37cc370b), to choose how null `TimeSpan?` values are displayed (typically a dash or some sort of zero value). I've kept all the Time Formatters returning exactly what they did before. Someone might want to change them about in future for nicer/more appropriate display (e.g. might want to display null times from speedrun.com as `-:--` instead of as `0.00`; and many probably never format null values regardless) But in this PR the output is the same.