### PR TITLE
Fix blocking icons files on change

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -625,30 +625,31 @@ namespace LiveSplit.View
         {
             try
             {
-                var image = Image.FromFile(fileName).ScaleIcon();
-
-                if (!multiEdit)
+                using (var image = new Bitmap(fileName).ScaleIcon())
                 {
-                    var oldImage = (Image)runGrid.Rows[rowIndex].Cells[ICONINDEX].Value;
-                    if (oldImage != null)
-                        ImagesToDispose.Add(oldImage);
-
-                    Run[rowIndex].Icon = image;
-                    runGrid.NotifyCurrentCellDirty(true);
-                }
-                else
-                {
-                    foreach (DataGridViewCell cell in runGrid.SelectedCells)
+                    if (!multiEdit)
                     {
-                        if (cell.ColumnIndex != ICONINDEX)
-                            continue;
-
-                        var oldImage = (Image)cell.Value;
+                        var oldImage = (Image) runGrid.Rows[rowIndex].Cells[ICONINDEX].Value;
                         if (oldImage != null)
                             ImagesToDispose.Add(oldImage);
 
-                        Run[cell.RowIndex].Icon = (Image)image.Clone();
-                        runGrid.UpdateCellValue(ICONINDEX, cell.RowIndex);
+                        Run[rowIndex].Icon = new Bitmap(image);
+                        runGrid.NotifyCurrentCellDirty(true);
+                    }
+                    else
+                    {
+                        foreach (DataGridViewCell cell in runGrid.SelectedCells)
+                        {
+                            if (cell.ColumnIndex != ICONINDEX)
+                                continue;
+
+                            var oldImage = (Image) cell.Value;
+                            if (oldImage != null)
+                                ImagesToDispose.Add(oldImage);
+
+                            Run[cell.RowIndex].Icon = new Bitmap(image);
+                            runGrid.UpdateCellValue(ICONINDEX, cell.RowIndex);
+                        }
                     }
                 }
 

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -629,11 +630,14 @@ namespace LiveSplit.View
 
                 if (!multiEdit)
                 {
+                    MemoryStream memoryStream = new MemoryStream();
                     var oldImage = (Image)runGrid.Rows[rowIndex].Cells[ICONINDEX].Value;
                     if (oldImage != null)
                         ImagesToDispose.Add(oldImage);
 
-                    Run[rowIndex].Icon = image;
+                    image.Save(memoryStream, System.Drawing.Imaging.ImageFormat.Png);
+
+                    Run[rowIndex].Icon = Image.FromStream(memoryStream);
                     runGrid.NotifyCurrentCellDirty(true);
                 }
                 else

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -630,14 +629,11 @@ namespace LiveSplit.View
 
                 if (!multiEdit)
                 {
-                    MemoryStream memoryStream = new MemoryStream();
                     var oldImage = (Image)runGrid.Rows[rowIndex].Cells[ICONINDEX].Value;
                     if (oldImage != null)
                         ImagesToDispose.Add(oldImage);
 
-                    image.Save(memoryStream, System.Drawing.Imaging.ImageFormat.Png);
-
-                    Run[rowIndex].Icon = Image.FromStream(memoryStream);
+                    Run[rowIndex].Icon = image;
                     runGrid.NotifyCurrentCellDirty(true);
                 }
                 else


### PR DESCRIPTION
This fix should prevent blocking file when we use it as an icon, if LiveSplit is not closed