### PR TITLE
Remove ff9 auto splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7110,16 +7110,6 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
-      <Game>Final Fantasy IX</Game>
-    </Games>
-    <URLs>
-      <URL>https://raw.githubusercontent.com/fhelwanger/ff9-auto-splitter/master/ff9.asl</URL>
-    </URLs>
-    <Type>Script</Type>
-    <Description>Auto start, auto split, load remover and encounter counter (by fhelwanger)</Description>
-  </AutoSplitter>
-  <AutoSplitter>
-    <Games>
       <Game>Frog Detective 2: The Case of the Invisible Wizard</Game>
     </Games>
     <URLs>


### PR DESCRIPTION
Pointers are sometimes bugged, might add back when everything is solved