### PR TITLE
Timermodel updatetimes method

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
@@ -123,10 +123,7 @@ namespace LiveSplit.Model
 
             if (updateTimes)
             {
-                UpdateAttemptHistory();
-                UpdateBestSegments();
-                UpdatePBSplits();
-                UpdateSegmentHistory();
+                UpdateTimes();
             }
         }
 

--- a/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
@@ -268,6 +268,14 @@ namespace LiveSplit.Model
             }
         }
 
+        public void UpdateTimes()
+        {
+            UpdateAttemptHistory();
+            UpdateBestSegments();
+            UpdatePBSplits();
+            UpdateSegmentHistory();
+        }
+
         public void ResetAndSetAttemptAsPB()
         {
             if (CurrentState.CurrentPhase != TimerPhase.NotRunning)


### PR DESCRIPTION
@CryZe 
Added a public UpdateTimes() method that wraps the functionality of the four UpdateXxxx() methods already present. I did this because my multiruns plugin was breaking without access to these methods which were privated in the 1.7.7 update.