### PR TITLE
Fix unattached segs

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -89,7 +89,7 @@ namespace LiveSplit.Model
             int min_id = run.GetMinSegmentHistoryIndex();
 
             int unattached_id;
-            //can't use `default` keyword because repo isn't on C# 7.1 yet so we use 0 instead
+            // can't use `default` keyword because repo isn't on C# 7.1 yet so we use 0 instead
             while ((unattached_id = run
                 .Select(seg => seg.SegmentHistory.Max().Key)
                 .Where(i => i > max_id).DefaultIfEmpty()

--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -74,12 +74,38 @@ namespace LiveSplit.Model
             FixWithMethod(run, TimingMethod.RealTime);
             FixWithMethod(run, TimingMethod.GameTime);
             RemoveNullValues(run);
+            ReattachUnattachedSegmentHistoryElements(run);
         }
 
         private static void FixWithMethod(IRun run, TimingMethod method)
         {
             FixComparisonTimesAndHistory(run, method);
             RemoveDuplicates(run, method);
+        }
+
+        private static void ReattachUnattachedSegmentHistoryElements(IRun run)
+        {
+            int max_id = run.AttemptHistory.Select(x => x.Index).DefaultIfEmpty().Max();
+            int min_id = run.AttemptHistory.Select(x => x.Index).DefaultIfEmpty().Min();
+
+            int unattached_id;
+            while ((unattached_id = run
+                .Select(seg => seg.SegmentHistory.Max().Key)
+                .Where(i => i > max_id).DefaultIfEmpty()
+                .Max()) != default)
+            {
+                var reassign_id = min_id - 1;
+
+                foreach (Segment segment in run)
+                {
+                    if (segment.SegmentHistory.TryGetValue(unattached_id, out Time time))
+                    {
+                        segment.SegmentHistory.Add(reassign_id, time);
+                        segment.SegmentHistory.Remove(unattached_id);
+                    }
+                }
+                min_id = reassign_id;
+            }
         }
 
         private static void FixHistoryFromNullBestSegments(ISegment curSplit, TimingMethod method, int minIndex, int maxIndex)

--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -86,7 +86,7 @@ namespace LiveSplit.Model
         private static void ReattachUnattachedSegmentHistoryElements(IRun run)
         {
             int max_id = run.AttemptHistory.Select(x => x.Index).DefaultIfEmpty().Max();
-            int min_id = run.AttemptHistory.Select(x => x.Index).DefaultIfEmpty().Min();
+            int min_id = run.GetMinSegmentHistoryIndex();
 
             int unattached_id;
             //can't use `default` keyword because repo isn't on C# 7.1 yet so we use 0 instead

--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -89,10 +89,11 @@ namespace LiveSplit.Model
             int min_id = run.AttemptHistory.Select(x => x.Index).DefaultIfEmpty().Min();
 
             int unattached_id;
+            //can't use `default` keyword because repo isn't on C# 7.1 yet so we use 0 instead
             while ((unattached_id = run
                 .Select(seg => seg.SegmentHistory.Max().Key)
                 .Where(i => i > max_id).DefaultIfEmpty()
-                .Max()) != default)
+                .Max()) != 0)
             {
                 var reassign_id = min_id - 1;
 

--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -92,7 +92,8 @@ namespace LiveSplit.Model
             // can't use `default` keyword because repo isn't on C# 7.1 yet so we use 0 instead
             while ((unattached_id = run
                 .Select(seg => seg.SegmentHistory.Max().Key)
-                .Where(i => i > max_id).DefaultIfEmpty()
+                .Where(i => i > max_id)
+                .DefaultIfEmpty()
                 .Max()) > 0)
             {
                 var reassign_id = min_id - 1;

--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -105,6 +105,7 @@ namespace LiveSplit.Model
                         segment.SegmentHistory.Remove(unattached_id);
                     }
                 }
+
                 min_id = reassign_id;
             }
         }

--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -93,7 +93,7 @@ namespace LiveSplit.Model
             while ((unattached_id = run
                 .Select(seg => seg.SegmentHistory.Max().Key)
                 .Where(i => i > max_id).DefaultIfEmpty()
-                .Max()) != 0)
+                .Max()) > 0)
             {
                 var reassign_id = min_id - 1;
 


### PR DESCRIPTION
This PR addresses #1504. I tried to stick as close to the livesplit-core implementation as possible. I would appreciate if someone could test to make sure this works and fully resolves the issue for them.