### PR TITLE
Add Empathy AutoSplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5211,6 +5211,18 @@
   </AutoSplitter>
   <AutoSplitter>
     <Games>
+      <Game>Empathy: Path of Whispers</Game>
+      <Game>Empathy</Game>
+    </Games>
+    <URLs>
+      <URL>https://raw.githubusercontent.com/LRFLEW/LiveSplit.Empathy/master/Components/LiveSplit.Empathy.dll</URL>
+    </URLs>
+    <Type>Component</Type>
+    <Description>Autosplitter and Load Remover for Empathy: Path of Whispers</Description>
+    <Website>https://github.com/LRFLEW/LiveSplit.Empathy</Website>
+  </AutoSplitter>
+  <AutoSplitter>
+    <Games>
       <Game>FEAR</Game>
       <Game>FEAR: First Encounter Assault Recon</Game>
       <Game>F.E.A.R.</Game>


### PR DESCRIPTION
Adds the AutoSplitter and Load Remover I wrote for [Empathy: Path of Whispers](https://store.steampowered.com/app/291690/Empathy_Path_of_Whispers/).

The second name of just "Empathy" comes from confusion due to a last minute name change. The game was announced as simply "Empathy", and right before release, they added the subtitle. Many lists never updated for the new name. GiantBomb's database didn't update until I submitted the change, and Twitch still has it under the old name. I have the autosplitter registered under both the old and new names, as they're both associated with the game.