### PR TITLE
Create GitInfo directory before on prebuild

### DIFF
--- a/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
@@ -371,7 +371,8 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>where git
+    <PreBuildEvent>mkdir $(ProjectDir)Updates\GitInfo\
+where git
 if %25ERRORLEVEL%25 == 0 (
 git describe --dirty --always --long --tags &gt; "$(ProjectDir)Updates\GitInfo\version.txt"
 git rev-parse --abbrev-ref HEAD &gt; "$(ProjectDir)Updates\GitInfo\branch.txt"


### PR DESCRIPTION
Without this, there's an error about the folder not being found during the prebuild action. The fix makes sure that the folder is created if it doesn't exist, similar to the CI script.