### PR TITLE
Update path to Sayonara Wild Hearts autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -7612,7 +7612,7 @@
       <Game>Sayonara Wild Hearts</Game>
     </Games>
     <URLs>
-      <URL>https://gist.githubusercontent.com/boringcactus/b6590987e7e16cbb2e1b4a2fcd870241/raw/1ea10c516d096a01080118ddaffc44c7b22c0413/SayonaraWildHearts.asl</URL>
+      <URL>https://raw.githubusercontent.com/boringcactus/SayonaraWildHeartsAutosplitter/master/SWHAutoSplitter.asl</URL>
     </URLs>
     <Type>Script</Type>
     <Description>Automatic start/split/reset (by boringcactus)</Description>


### PR DESCRIPTION
apparently editing a gist gives the new file a different raw url, which is unfortunate