### PR TITLE
Fixed Golf It! autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -161,10 +161,10 @@
       <Game>Golf It!</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/sflofty/autosplitters/master/golf_it/golf_it.asl</URL>
+      <URL>https://raw.githubusercontent.com/esseivan/autosplitters/master/golf_it/golf_it.asl</URL>
     </URLs>
     <Type>Script</Type>
-    <Description>Auto-splitting, start, and game timer are available.</Description>
+    <Description>Auto-splitting, start, and game timer are available (By sflofty, edited by EsseivaN)</Description>
 </AutoSplitter>
 <AutoSplitter>
 	<Games>


### PR DESCRIPTION
Added a setting to bypass the compensation of loading time, which used a variable with an invalid pointer