### PR TITLE
Click through window

### DIFF
--- a/LiveSplit/LiveSplit.Core/Options/HotkeyProfile.cs
+++ b/LiveSplit/LiveSplit.Core/Options/HotkeyProfile.cs
@@ -20,6 +20,7 @@ namespace LiveSplit.Options
         public bool GlobalHotkeysEnabled { get; set; }
         public bool DeactivateHotkeysForOtherPrograms { get; set; }
         public bool DoubleTapPrevention { get; set; }
+        public bool ClickThrough { get; set; }
 
         public const string DefaultHotkeyProfileName = "Default";
 

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
@@ -611,13 +611,15 @@
             // 
             this.chkClickThrough.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkClickThrough.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.chkClickThrough, 2);
             this.chkClickThrough.Location = new System.Drawing.Point(7, 296);
             this.chkClickThrough.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkClickThrough.Name = "chkClickThrough";
-            this.chkClickThrough.Size = new System.Drawing.Size(168, 17);
+            this.chkClickThrough.Size = new System.Drawing.Size(302, 17);
             this.chkClickThrough.TabIndex = 10;
-            this.chkClickThrough.Text = "Click Through On Run";
+            this.chkClickThrough.Text = "Click Through On Run (Require Global Hotkeys !)";
             this.chkClickThrough.UseVisualStyleBackColor = true;
+            this.chkClickThrough.CheckedChanged += new System.EventHandler(this.chkClickThrough_CheckedChanged);
             // 
             // SettingsDialog
             // 

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
@@ -31,6 +31,8 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.btnOK = new System.Windows.Forms.Button();
+            this.label5 = new System.Windows.Forms.Label();
+            this.btnLogOut = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.chkDeactivateForOtherPrograms = new System.Windows.Forms.CheckBox();
@@ -64,12 +66,11 @@
             this.btnCancel = new System.Windows.Forms.Button();
             this.cbxRaceViewer = new System.Windows.Forms.ComboBox();
             this.label11 = new System.Windows.Forms.Label();
+            this.label12 = new System.Windows.Forms.Label();
             this.btnChooseComparisons = new System.Windows.Forms.Button();
             this.chkSimpleSOB = new System.Windows.Forms.CheckBox();
             this.chkWarnOnReset = new System.Windows.Forms.CheckBox();
-            this.btnLogOut = new System.Windows.Forms.Button();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label12 = new System.Windows.Forms.Label();
+            this.chkClickThrough = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -105,20 +106,42 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(380, 543);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(380, 572);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnOK, 2);
-            this.btnOK.Location = new System.Drawing.Point(221, 517);
+            this.btnOK.Location = new System.Drawing.Point(221, 546);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
             this.btnOK.TabIndex = 6;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // label5
+            // 
+            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(3, 522);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(178, 13);
+            this.label5.TabIndex = 10;
+            this.label5.Text = "Saved Accounts:";
+            // 
+            // btnLogOut
+            // 
+            this.btnLogOut.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.SetColumnSpan(this.btnLogOut, 3);
+            this.btnLogOut.Location = new System.Drawing.Point(187, 517);
+            this.btnLogOut.Name = "btnLogOut";
+            this.btnLogOut.Size = new System.Drawing.Size(190, 23);
+            this.btnLogOut.TabIndex = 5;
+            this.btnLogOut.Text = "Log Out of All Accounts";
+            this.btnLogOut.UseVisualStyleBackColor = true;
+            this.btnLogOut.Click += new System.EventHandler(this.btnLogOut_Click);
             // 
             // groupBox1
             // 
@@ -127,7 +150,7 @@
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(3, 3);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(374, 392);
+            this.groupBox1.Size = new System.Drawing.Size(374, 421);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Hotkeys";
@@ -159,11 +182,13 @@
             this.tableLayoutPanel2.Controls.Add(this.txtSwitchNext, 1, 6);
             this.tableLayoutPanel2.Controls.Add(this.label10, 1, 9);
             this.tableLayoutPanel2.Controls.Add(this.txtDelay, 2, 9);
-            this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 10);
+            this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 11);
+            this.tableLayoutPanel2.Controls.Add(this.chkClickThrough, 0, 10);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 11;
+            this.tableLayoutPanel2.RowCount = 12;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
@@ -175,7 +200,7 @@
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 373);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 402);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // chkDeactivateForOtherPrograms
@@ -410,7 +435,7 @@
             this.tableLayoutPanel2.SetColumnSpan(this.grpHotkeyProfiles, 3);
             this.grpHotkeyProfiles.Controls.Add(this.tableLayoutPanel3);
             this.grpHotkeyProfiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 293);
+            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 322);
             this.grpHotkeyProfiles.Name = "grpHotkeyProfiles";
             this.grpHotkeyProfiles.Size = new System.Drawing.Size(362, 77);
             this.grpHotkeyProfiles.TabIndex = 12;
@@ -500,7 +525,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnCancel, 2);
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(302, 517);
+            this.btnCancel.Location = new System.Drawing.Point(302, 546);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 7;
@@ -519,7 +544,7 @@
             "MultiTwitch",
             "Kadgar",
             "Speedrun.tv"});
-            this.cbxRaceViewer.Location = new System.Drawing.Point(187, 431);
+            this.cbxRaceViewer.Location = new System.Drawing.Point(187, 460);
             this.cbxRaceViewer.Name = "cbxRaceViewer";
             this.cbxRaceViewer.Size = new System.Drawing.Size(190, 21);
             this.cbxRaceViewer.TabIndex = 3;
@@ -528,17 +553,27 @@
             // 
             this.label11.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(3, 435);
+            this.label11.Location = new System.Drawing.Point(3, 464);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(178, 13);
             this.label11.TabIndex = 15;
             this.label11.Text = "Race Viewer:";
             // 
+            // label12
+            // 
+            this.label12.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label12.AutoSize = true;
+            this.label12.Location = new System.Drawing.Point(3, 493);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(178, 13);
+            this.label12.TabIndex = 17;
+            this.label12.Text = "Active Comparisons:";
+            // 
             // btnChooseComparisons
             // 
             this.btnChooseComparisons.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnChooseComparisons, 3);
-            this.btnChooseComparisons.Location = new System.Drawing.Point(187, 459);
+            this.btnChooseComparisons.Location = new System.Drawing.Point(187, 488);
             this.btnChooseComparisons.Name = "btnChooseComparisons";
             this.btnChooseComparisons.Size = new System.Drawing.Size(190, 23);
             this.btnChooseComparisons.TabIndex = 4;
@@ -550,7 +585,7 @@
             // 
             this.chkSimpleSOB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkSimpleSOB.AutoSize = true;
-            this.chkSimpleSOB.Location = new System.Drawing.Point(7, 404);
+            this.chkSimpleSOB.Location = new System.Drawing.Point(7, 433);
             this.chkSimpleSOB.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkSimpleSOB.Name = "chkSimpleSOB";
             this.chkSimpleSOB.Size = new System.Drawing.Size(174, 17);
@@ -564,7 +599,7 @@
             this.chkWarnOnReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkWarnOnReset.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.chkWarnOnReset, 3);
-            this.chkWarnOnReset.Location = new System.Drawing.Point(191, 404);
+            this.chkWarnOnReset.Location = new System.Drawing.Point(191, 433);
             this.chkWarnOnReset.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkWarnOnReset.Name = "chkWarnOnReset";
             this.chkWarnOnReset.Size = new System.Drawing.Size(186, 17);
@@ -572,43 +607,23 @@
             this.chkWarnOnReset.Text = "Warn On Reset If Better Times";
             this.chkWarnOnReset.UseVisualStyleBackColor = true;
             // 
-            // btnLogOut
+            // chkClickThrough
             // 
-            this.btnLogOut.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel1.SetColumnSpan(this.btnLogOut, 3);
-            this.btnLogOut.Location = new System.Drawing.Point(187, 488);
-            this.btnLogOut.Name = "btnLogOut";
-            this.btnLogOut.Size = new System.Drawing.Size(190, 23);
-            this.btnLogOut.TabIndex = 5;
-            this.btnLogOut.Text = "Log Out of All Accounts";
-            this.btnLogOut.UseVisualStyleBackColor = true;
-            this.btnLogOut.Click += new System.EventHandler(this.btnLogOut_Click);
-            // 
-            // label5
-            // 
-            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 493);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(178, 13);
-            this.label5.TabIndex = 10;
-            this.label5.Text = "Saved Accounts:";
-            // 
-            // label12
-            // 
-            this.label12.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(3, 464);
-            this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(178, 13);
-            this.label12.TabIndex = 17;
-            this.label12.Text = "Active Comparisons:";
+            this.chkClickThrough.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkClickThrough.AutoSize = true;
+            this.chkClickThrough.Location = new System.Drawing.Point(7, 296);
+            this.chkClickThrough.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkClickThrough.Name = "chkClickThrough";
+            this.chkClickThrough.Size = new System.Drawing.Size(168, 17);
+            this.chkClickThrough.TabIndex = 10;
+            this.chkClickThrough.Text = "Click Through On Run";
+            this.chkClickThrough.UseVisualStyleBackColor = true;
             // 
             // SettingsDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(394, 557);
+            this.ClientSize = new System.Drawing.Size(394, 586);
             this.Controls.Add(this.tableLayoutPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -670,5 +685,6 @@
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Button btnLogOut;
         private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.CheckBox chkClickThrough;
     }
 }

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
@@ -40,6 +40,11 @@ namespace LiveSplit.View
             get { return Settings.HotkeyProfiles[SelectedHotkeyProfile].DoubleTapPrevention; }
             set { Settings.HotkeyProfiles[SelectedHotkeyProfile].DoubleTapPrevention = value; }
         }
+        public bool ClickThrough
+        {
+            get { return Settings.HotkeyProfiles[SelectedHotkeyProfile].ClickThrough; }
+            set { Settings.HotkeyProfiles[SelectedHotkeyProfile].ClickThrough = value; }
+        }
         public bool DeactivateHotkeysForOtherPrograms
         {
             get { return Settings.HotkeyProfiles[SelectedHotkeyProfile].DeactivateHotkeysForOtherPrograms; }
@@ -64,6 +69,7 @@ namespace LiveSplit.View
             txtDelay.DataBindings.Add("Text", this, "HotkeyDelay");
             chkWarnOnReset.DataBindings.Add("Checked", Settings, "WarnOnReset");
             cbxRaceViewer.DataBindings.Add("SelectedItem", this, "RaceViewer");
+            chkClickThrough.DataBindings.Add("Checked", this, "ClickThrough");
 
             UpdateDisplayedHotkeyValues();
             RefreshRemoveButton();
@@ -89,6 +95,7 @@ namespace LiveSplit.View
 
             chkGlobalHotkeys.Checked = GlobalHotkeysEnabled;
             chkDoubleTap.Checked = DoubleTapPrevention;
+            chkClickThrough.Checked = ClickThrough;
             txtDelay.Text = HotkeyDelay.ToString();
             chkDeactivateForOtherPrograms.Checked = DeactivateHotkeysForOtherPrograms;
 

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
@@ -394,5 +394,17 @@ namespace LiveSplit.View
             WebCredentials.DeleteAllCredentials();
             RefreshLogOutButton();
         }
+
+        private bool lastGlobalValue = false;
+        private void chkClickThrough_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkClickThrough.Checked)
+            {
+                lastGlobalValue = chkGlobalHotkeys.Checked;
+                chkGlobalHotkeys.Checked = true;
+            }
+            else
+                chkGlobalHotkeys.Checked = lastGlobalValue;
+        }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -301,11 +301,29 @@ namespace LiveSplit.View
 
             SizeChanged += TimerForm_SizeChanged;
 
+            // Add event listener
+            Model.OnStart += Model_OnEvent;
+            Model.OnUndoSplit += Model_OnEvent;
+            Model.OnResume += Model_OnEvent;
+
             TopMost = Layout.Settings.AlwaysOnTop;
             BackColor = Color.Black;
 
             Server = new CommandServer(CurrentState);
             Server.Start();
+        }
+
+        private void Model_OnEvent(object sender, EventArgs e)
+        {
+            // If disabled
+            if (!Settings.HotkeyProfiles[CurrentState.CurrentHotkeyProfile].ClickThrough)
+            {
+                SetClickThrough(false);
+                return;
+            }
+
+            // Set state
+            SetClickThrough(Model.CurrentState.CurrentPhase == TimerPhase.Running);
         }
 
         void SetWindowTitle()

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -2740,5 +2740,22 @@ namespace LiveSplit.View
         {
             ResizingInitialAspectRatio = null;
         }
+
+        private void SetClickThrough(bool isClickThrough)
+        {
+            uint initialStyle = GetWindowLong(this.Handle, -20);
+            uint newStyle;
+            if (isClickThrough)
+                newStyle = initialStyle | 0x80000 | 0x20;
+            else
+            {
+                if ((initialStyle & 0x80000) > 0)
+                    initialStyle -= 0x80000;
+                if ((initialStyle & 0x20) > 0)
+                    initialStyle -= 0x20;
+                newStyle = initialStyle;
+            }
+            SetWindowLong(this.Handle, -20, newStyle);
+        }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -302,9 +302,14 @@ namespace LiveSplit.View
             SizeChanged += TimerForm_SizeChanged;
 
             // Add event listener
-            Model.OnStart += Model_OnEvent;
-            Model.OnUndoSplit += Model_OnEvent;
-            Model.OnResume += Model_OnEvent;
+            Model.OnStart += Model_OnStateChanged;
+            Model.OnSplit += Model_OnStateChanged;
+            Model.OnSkipSplit += Model_OnStateChanged;
+            Model.OnUndoSplit += Model_OnStateChanged;
+            Model.OnReset += Model_OnReset;
+            Model.OnPause += Model_OnStateChanged;
+            Model.OnResume += Model_OnStateChanged;
+            Model.OnUndoAllPauses += Model_OnStateChanged;
 
             TopMost = Layout.Settings.AlwaysOnTop;
             BackColor = Color.Black;
@@ -313,7 +318,12 @@ namespace LiveSplit.View
             Server.Start();
         }
 
-        private void Model_OnEvent(object sender, EventArgs e)
+        private void Model_OnReset(object sender, TimerPhase value)
+        {
+            Model_OnStateChanged(sender, null);
+        }
+
+        private void Model_OnStateChanged(object sender, EventArgs e)
         {
             // If disabled
             if (!Settings.HotkeyProfiles[CurrentState.CurrentHotkeyProfile].ClickThrough)


### PR DESCRIPTION
I had some problems in some games where the mouse is not visible, but sometimes get in the window of LiveSplit.
Then if I would left click, the game would not be in focus anymore :/

So I made a fix for issues like this :
I added a setting "Click through window on run"
Which means that if enabled, when the timer is running, clicking on the LiveSplit window will click through it.

The changes I made :
I added a checkbox in the settings window
I added a event listener for TimerModel for almost all events and check if the currentPhase is running or not. Whether it is running (and the setting is enabled), it calls the function SetClickThrough from TimerForm

The code for the last function (SetClickThrough) is inspired from https://stackoverflow.com/questions/2798245/click-through-in-c-sharp-form

You may notice some strange edits in SettingsDialog.Designer.cs but this is Visual Studio doing some refactoring when editing the design of the form

Edit . The game I spoke about was Golf It!  - The mouse is invisible but not stuck in the middle of the screen, so it would eventually get in the LiveSplit's window