### PR TITLE
Display median comparison

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
@@ -25,6 +25,7 @@ namespace LiveSplit.Model.Comparisons
             yield return new BestSegmentsComparisonGenerator(run);
             yield return new BestSplitTimesComparisonGenerator(run);
             yield return new AverageSegmentsComparisonGenerator(run);
+            yield return new MedianSegmentsComparisonGenerator(run);
             yield return new WorstSegmentsComparisonGenerator(run);
             yield return new PercentileComparisonGenerator(run);
             yield return new LatestRunComparisonGenerator(run);

--- a/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
@@ -42,6 +42,7 @@ namespace LiveSplit.Options.SettingsFactories
                     { BestSegmentsComparisonGenerator.ComparisonName, true },
                     { BestSplitTimesComparisonGenerator.ComparisonName, false },
                     { AverageSegmentsComparisonGenerator.ComparisonName, true },
+                    { MedianSegmentsComparisonGenerator.ComparisonName, false },
                     { WorstSegmentsComparisonGenerator.ComparisonName, false},
                     { PercentileComparisonGenerator.ComparisonName, false },
                     { LatestRunComparisonGenerator.ComparisonName, false },

--- a/LiveSplit/LiveSplit.View/View/ChooseComparisonsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ChooseComparisonsDialog.cs
@@ -19,6 +19,7 @@ namespace LiveSplit.View
                 BestSegmentsComparisonGenerator.ComparisonName,
                 BestSplitTimesComparisonGenerator.ComparisonName,
                 AverageSegmentsComparisonGenerator.ComparisonName,
+                MedianSegmentsComparisonGenerator.ComparisonName,
                 WorstSegmentsComparisonGenerator.ComparisonName,
                 PercentileComparisonGenerator.ComparisonName,
                 LatestRunComparisonGenerator.ComparisonName,


### PR DESCRIPTION
Median comparison exists in core code, but is not present in UI. I couldn't find any information on why is this feature not displayed. I know at least one runner who need this useful feature, so I decided to add it to interface.