### PR TITLE
Add start offset parameter to core timer method

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/DoubleTapPrevention.cs
+++ b/LiveSplit/LiveSplit.Core/Model/DoubleTapPrevention.cs
@@ -65,11 +65,11 @@ namespace LiveSplit.Model
             return TimeStamp.Now - LastEvent > Delay;
         }
 
-        public void Start()
+        public void Start(TimeSpan? start = null)
         {
             if (CheckDoubleTap())
             {
-                InternalModel.Start();
+                InternalModel.Start(start);
                 LastEvent = TimeStamp.Now;
             }
         }

--- a/LiveSplit/LiveSplit.Core/Model/DoubleTapPrevention.cs
+++ b/LiveSplit/LiveSplit.Core/Model/DoubleTapPrevention.cs
@@ -65,11 +65,11 @@ namespace LiveSplit.Model
             return TimeStamp.Now - LastEvent > Delay;
         }
 
-        public void Start(TimeSpan? start = null)
+        public void Start(TimeSpan? startOffset = null)
         {
             if (CheckDoubleTap())
             {
-                InternalModel.Start(start);
+                InternalModel.Start(startOffset);
                 LastEvent = TimeStamp.Now;
             }
         }

--- a/LiveSplit/LiveSplit.Core/Model/ITimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/ITimerModel.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.Model
         event EventHandler OnSwitchComparisonPrevious;
         event EventHandler OnSwitchComparisonNext;
         
-        void Start(TimeSpan? start = null);
+        void Start(TimeSpan? startOffset = null);
         void InitializeGameTime();
         void Split();
         void SkipSplit();

--- a/LiveSplit/LiveSplit.Core/Model/ITimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/ITimerModel.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.Model
         event EventHandler OnSwitchComparisonPrevious;
         event EventHandler OnSwitchComparisonNext;
         
-        void Start();
+        void Start(TimeSpan? start = null);
         void InitializeGameTime();
         void Split();
         void SkipSplit();

--- a/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimerModel.cs
@@ -34,14 +34,21 @@ namespace LiveSplit.Model
         public event EventHandler OnSwitchComparisonPrevious;
         public event EventHandler OnSwitchComparisonNext;
 
-        public void Start()
+        public void Start(TimeSpan? startOffset = null)
         {
             if (CurrentState.CurrentPhase == TimerPhase.NotRunning)
             {
                 CurrentState.CurrentPhase = TimerPhase.Running;
                 CurrentState.CurrentSplitIndex = 0;
                 CurrentState.AttemptStarted = TimeStamp.CurrentDateTime;
-                CurrentState.AdjustedStartTime = CurrentState.StartTimeWithOffset = TimeStamp.Now - CurrentState.Run.Offset;
+
+                TimeSpan actualStartOffset = CurrentState.Run.Offset;
+                if (startOffset.HasValue)
+                {
+                    actualStartOffset += startOffset.Value;
+                }
+
+                CurrentState.AdjustedStartTime = CurrentState.StartTimeWithOffset = TimeStamp.Now - actualStartOffset;
                 CurrentState.StartTime = TimeStamp.Now;
                 CurrentState.TimePausedAt = CurrentState.Run.Offset;
                 CurrentState.IsGameTimeInitialized = false;


### PR DESCRIPTION
This is a small update to the core API to allow for a more elegant fix for the racetime.gg integration with the main timer.

This update allows the timer to be started with a supplied offset value, which can be either positive or negative. If not supplied, the behaviour of this method is unchanged (same as suppling an offset value of zero).