### PR TITLE
Changing Wizard of Legend auto-splitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4815,7 +4815,7 @@
       <Game>Wizard of Legend</Game>
     </Games>
     <URLs>
-      <URL>https://raw.githubusercontent.com/Phxntxm/WoL-Autosplitter/master/WoL-Autosplitter.asl</URL>
+      <URL>https://raw.githubusercontent.com/QunurZ/WoL-Autosplitter/master/WoL_AutoSplitter.asl</URL>
     </URLs>
     <Type>Script</Type>
     <Description>Autosplitting and In-Game Time are available. (Original by TheFuncannon; updated by Phantom)</Description>


### PR DESCRIPTION
Previous auto splitter for Wizard of Legend has been broken for a long time since an update came out.
Finally had time and fixed it.