### PR TITLE
Update LiveSplit.AutoSplitters.xml for Stardew Valley

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8912,4 +8912,15 @@
 		<Type>Script</Type>
 		<Description> DESCRIPTION </Description>
 	</AutoSplitter>
+	<AutoSplitter>
+		<Games>
+			<Game>Stardew Valley</Game>
+		</Games>
+		<URLs>
+			<URL>https://raw.githubusercontent.com/Underscore76/SDV-AutoSplit/master/sdv-script.asl</URL>
+		</URLs>
+		<Type>Script</Type>
+		<Description>Save/Load time remover for Stardew Valley</Description>
+		<Website>https://github.com/Underscore76/SDV-AutoSplit</Website>
+	</AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
Adding Stardew Valley load remover asl.

Pretty basic for now, removes time from initial game load and then on night time saves which are heavily PC dependent.