### PR TITLE
Implemented additional key to start timer without splitting

### DIFF
--- a/LiveSplit/LiveSplit.Core/Options/HotkeyProfile.cs
+++ b/LiveSplit/LiveSplit.Core/Options/HotkeyProfile.cs
@@ -7,7 +7,8 @@ namespace LiveSplit.Options
 {
     public class HotkeyProfile : ICloneable
     {
-        public KeyOrButton SplitKey { get; set; }
+        public KeyOrButton StartKey { get; set; }
+        public KeyOrButton StartSplitKey { get; set; }
         public KeyOrButton ResetKey { get; set; }
         public KeyOrButton SkipKey { get; set; }
         public KeyOrButton UndoKey { get; set; }
@@ -27,11 +28,17 @@ namespace LiveSplit.Options
         {
             var hotkeyProfile = new HotkeyProfile();
 
-            var keyStart = element["SplitKey"];
+            var keyStart = element["StartKey"];
             if (!string.IsNullOrEmpty(keyStart.InnerText))
-                hotkeyProfile.SplitKey = new KeyOrButton(keyStart.InnerText);
+                hotkeyProfile.StartKey = new KeyOrButton(keyStart.InnerText);
             else
-                hotkeyProfile.SplitKey = null;
+                hotkeyProfile.StartKey = null;
+
+            var keyStartSplit = element["StartSplitKey"];
+            if (!string.IsNullOrEmpty(keyStartSplit.InnerText))
+                hotkeyProfile.StartSplitKey = new KeyOrButton(keyStartSplit.InnerText);
+            else
+                hotkeyProfile.StartSplitKey = null;
 
             var keyReset = element["ResetKey"];
             if (!string.IsNullOrEmpty(keyReset.InnerText))
@@ -93,10 +100,15 @@ namespace LiveSplit.Options
         {
             var parent = document.CreateElement(name);
 
-            var splitKey = document.CreateElement("SplitKey");
-            if (SplitKey != null)
-                splitKey.InnerText = SplitKey.ToString();
-            parent.AppendChild(splitKey);
+            var startKey = document.CreateElement("StartKey");
+            if (StartKey != null)
+                startKey.InnerText = StartKey.ToString();
+            parent.AppendChild(startKey);
+
+            var startSplitKey = document.CreateElement("StartSplitKey");
+            if (StartSplitKey != null)
+                startSplitKey.InnerText = StartSplitKey.ToString();
+            parent.AppendChild(startSplitKey);
 
             var resetKey = document.CreateElement("ResetKey");
             if (ResetKey != null)
@@ -145,7 +157,8 @@ namespace LiveSplit.Options
         {
             return new HotkeyProfile()
             {
-                SplitKey = SplitKey,
+                StartKey = StartKey,
+                StartSplitKey = StartSplitKey,
                 ResetKey = ResetKey,
                 SkipKey = SkipKey,
                 UndoKey = UndoKey,

--- a/LiveSplit/LiveSplit.Core/Options/ISettings.cs
+++ b/LiveSplit/LiveSplit.Core/Options/ISettings.cs
@@ -30,7 +30,8 @@ namespace LiveSplit.Options
         void UnregisterAllHotkeys(CompositeHook hook);
 
         // Deprecated properties
-        KeyOrButton SplitKey { get; set; }
+        KeyOrButton StartKey { get; set; }
+        KeyOrButton StartSplitKey { get; set; }
         KeyOrButton ResetKey { get; set; }
         KeyOrButton SkipKey { get; set; }
         KeyOrButton UndoKey { get; set; }

--- a/LiveSplit/LiveSplit.Core/Options/Settings.cs
+++ b/LiveSplit/LiveSplit.Core/Options/Settings.cs
@@ -24,9 +24,14 @@ namespace LiveSplit.Options
         public IDictionary<string, bool> ComparisonGeneratorStates { get; set; }
 
         // Deprecated properties
-        public KeyOrButton SplitKey {
-            get { return HotkeyProfiles.First().Value.SplitKey; }
-            set { HotkeyProfiles.First().Value.SplitKey = value; }
+        public KeyOrButton StartKey
+        {
+            get { return HotkeyProfiles.First().Value.StartKey; }
+            set { HotkeyProfiles.First().Value.StartKey = value; }
+        }
+        public KeyOrButton StartSplitKey {
+            get { return HotkeyProfiles.First().Value.StartSplitKey; }
+            set { HotkeyProfiles.First().Value.StartSplitKey = value; }
         }
         public KeyOrButton ResetKey {
             get { return HotkeyProfiles.First().Value.ResetKey; }
@@ -114,13 +119,24 @@ namespace LiveSplit.Options
             {
                 var hotkeyProfile = HotkeyProfiles[hotkeyProfileName];
                 var deactivateForOtherPrograms = hotkeyProfile.GlobalHotkeysEnabled && hotkeyProfile.DeactivateHotkeysForOtherPrograms;
-                if (hotkeyProfile.SplitKey != null)
+                if (hotkeyProfile.StartSplitKey != null)
                 {
                     try
                     {
-                        RegisterHotkey(hook, hotkeyProfile.SplitKey, deactivateForOtherPrograms);
+                        RegisterHotkey(hook, hotkeyProfile.StartSplitKey, deactivateForOtherPrograms);
                     }
                     catch (Exception e)
+                    {
+                        Log.Error(e);
+                    }
+                }
+                if(hotkeyProfile.StartKey != null)
+                {
+                    try
+                    {
+                        RegisterHotkey(hook, hotkeyProfile.StartKey, deactivateForOtherPrograms);
+                    }
+                    catch(Exception e)
                     {
                         Log.Error(e);
                     }

--- a/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
@@ -19,7 +19,8 @@ namespace LiveSplit.Options.SettingsFactories
                 {
                     {HotkeyProfile.DefaultHotkeyProfileName, new HotkeyProfile()
                         {
-                            SplitKey = new KeyOrButton(Keys.NumPad1),
+                            StartKey = new KeyOrButton(Keys.NumPad0),
+                            StartSplitKey = new KeyOrButton(Keys.NumPad1),
                             ResetKey = new KeyOrButton(Keys.NumPad3),
                             UndoKey = new KeyOrButton(Keys.NumPad8),
                             SkipKey = new KeyOrButton(Keys.NumPad2),

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
@@ -36,6 +36,7 @@
             this.btnLogOut = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.txtReset = new System.Windows.Forms.TextBox();
             this.chkDeactivateForOtherPrograms = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
             this.chkGlobalHotkeys = new System.Windows.Forms.CheckBox();
@@ -43,7 +44,7 @@
             this.txtStartSplit = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
-            this.txtReset = new System.Windows.Forms.TextBox();
+            this.txtStart = new System.Windows.Forms.TextBox();
             this.txtPause = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
@@ -72,6 +73,7 @@
             this.btnChooseComparisons = new System.Windows.Forms.Button();
             this.chkSimpleSOB = new System.Windows.Forms.CheckBox();
             this.chkWarnOnReset = new System.Windows.Forms.CheckBox();
+            this.label14 = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -112,14 +114,14 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(380, 572);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(380, 651);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // btnChooseRaceProvider
             // 
             this.btnChooseRaceProvider.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnChooseRaceProvider, 3);
-            this.btnChooseRaceProvider.Location = new System.Drawing.Point(187, 459);
+            this.btnChooseRaceProvider.Location = new System.Drawing.Point(187, 517);
             this.btnChooseRaceProvider.Name = "btnChooseRaceProvider";
             this.btnChooseRaceProvider.Size = new System.Drawing.Size(190, 23);
             this.btnChooseRaceProvider.TabIndex = 6;
@@ -131,9 +133,9 @@
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnOK, 2);
-            this.btnOK.Location = new System.Drawing.Point(221, 546);
+            this.btnOK.Location = new System.Drawing.Point(221, 623);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.Size = new System.Drawing.Size(75, 25);
             this.btnOK.TabIndex = 0;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -143,7 +145,7 @@
             // 
             this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 522);
+            this.label5.Location = new System.Drawing.Point(3, 580);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(178, 13);
             this.label5.TabIndex = 10;
@@ -153,7 +155,7 @@
             // 
             this.btnLogOut.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnLogOut, 3);
-            this.btnLogOut.Location = new System.Drawing.Point(187, 517);
+            this.btnLogOut.Location = new System.Drawing.Point(187, 575);
             this.btnLogOut.Name = "btnLogOut";
             this.btnLogOut.Size = new System.Drawing.Size(190, 23);
             this.btnLogOut.TabIndex = 8;
@@ -168,7 +170,7 @@
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(3, 3);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(374, 392);
+            this.groupBox1.Size = new System.Drawing.Size(374, 450);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Hotkeys";
@@ -179,32 +181,34 @@
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 178F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 56F));
-            this.tableLayoutPanel2.Controls.Add(this.chkDeactivateForOtherPrograms, 1, 8);
+            this.tableLayoutPanel2.Controls.Add(this.txtReset, 1, 2);
+            this.tableLayoutPanel2.Controls.Add(this.chkDeactivateForOtherPrograms, 1, 9);
             this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.chkGlobalHotkeys, 0, 8);
-            this.tableLayoutPanel2.Controls.Add(this.chkDoubleTap, 0, 9);
+            this.tableLayoutPanel2.Controls.Add(this.chkGlobalHotkeys, 0, 9);
+            this.tableLayoutPanel2.Controls.Add(this.chkDoubleTap, 0, 10);
             this.tableLayoutPanel2.Controls.Add(this.txtStartSplit, 1, 0);
-            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.label6, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.txtReset, 1, 1);
-            this.tableLayoutPanel2.Controls.Add(this.txtPause, 1, 4);
-            this.tableLayoutPanel2.Controls.Add(this.label3, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.txtSkip, 1, 3);
-            this.tableLayoutPanel2.Controls.Add(this.txtUndo, 1, 2);
-            this.tableLayoutPanel2.Controls.Add(this.label7, 0, 7);
-            this.tableLayoutPanel2.Controls.Add(this.txtToggle, 1, 7);
-            this.tableLayoutPanel2.Controls.Add(this.label8, 0, 5);
-            this.tableLayoutPanel2.Controls.Add(this.label9, 0, 6);
-            this.tableLayoutPanel2.Controls.Add(this.txtSwitchPrevious, 1, 5);
-            this.tableLayoutPanel2.Controls.Add(this.txtSwitchNext, 1, 6);
-            this.tableLayoutPanel2.Controls.Add(this.label10, 1, 9);
-            this.tableLayoutPanel2.Controls.Add(this.txtDelay, 2, 9);
-            this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 10);
+            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.label6, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this.txtStart, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.txtPause, 1, 5);
+            this.tableLayoutPanel2.Controls.Add(this.label3, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.txtSkip, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.txtUndo, 1, 3);
+            this.tableLayoutPanel2.Controls.Add(this.label7, 0, 8);
+            this.tableLayoutPanel2.Controls.Add(this.txtToggle, 1, 8);
+            this.tableLayoutPanel2.Controls.Add(this.label8, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.label9, 0, 7);
+            this.tableLayoutPanel2.Controls.Add(this.txtSwitchPrevious, 1, 6);
+            this.tableLayoutPanel2.Controls.Add(this.txtSwitchNext, 1, 7);
+            this.tableLayoutPanel2.Controls.Add(this.label10, 1, 10);
+            this.tableLayoutPanel2.Controls.Add(this.txtDelay, 2, 10);
+            this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 11);
+            this.tableLayoutPanel2.Controls.Add(this.label14, 0, 1);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 11;
+            this.tableLayoutPanel2.RowCount = 12;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
@@ -215,9 +219,25 @@
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 373);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 31F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 72F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 431);
             this.tableLayoutPanel2.TabIndex = 0;
+            // 
+            // txtReset
+            // 
+            this.txtReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtReset, 2);
+            this.txtReset.Location = new System.Drawing.Point(181, 62);
+            this.txtReset.Name = "txtReset";
+            this.txtReset.ReadOnly = true;
+            this.txtReset.Size = new System.Drawing.Size(184, 20);
+            this.txtReset.TabIndex = 17;
+            this.txtReset.Enter += new System.EventHandler(this.Toggle_Set_Enter);
             // 
             // chkDeactivateForOtherPrograms
             // 
@@ -225,7 +245,7 @@
             | System.Windows.Forms.AnchorStyles.Left)));
             this.chkDeactivateForOtherPrograms.AutoSize = true;
             this.tableLayoutPanel2.SetColumnSpan(this.chkDeactivateForOtherPrograms, 2);
-            this.chkDeactivateForOtherPrograms.Location = new System.Drawing.Point(185, 235);
+            this.chkDeactivateForOtherPrograms.Location = new System.Drawing.Point(185, 264);
             this.chkDeactivateForOtherPrograms.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkDeactivateForOtherPrograms.Name = "chkDeactivateForOtherPrograms";
             this.chkDeactivateForOtherPrograms.Size = new System.Drawing.Size(172, 23);
@@ -248,7 +268,7 @@
             this.chkGlobalHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.chkGlobalHotkeys.AutoSize = true;
-            this.chkGlobalHotkeys.Location = new System.Drawing.Point(7, 235);
+            this.chkGlobalHotkeys.Location = new System.Drawing.Point(7, 264);
             this.chkGlobalHotkeys.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkGlobalHotkeys.Name = "chkGlobalHotkeys";
             this.chkGlobalHotkeys.Size = new System.Drawing.Size(98, 23);
@@ -261,7 +281,7 @@
             // 
             this.chkDoubleTap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkDoubleTap.AutoSize = true;
-            this.chkDoubleTap.Location = new System.Drawing.Point(7, 267);
+            this.chkDoubleTap.Location = new System.Drawing.Point(7, 297);
             this.chkDoubleTap.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkDoubleTap.Name = "chkDoubleTap";
             this.chkDoubleTap.Size = new System.Drawing.Size(168, 17);
@@ -278,13 +298,13 @@
             this.txtStartSplit.ReadOnly = true;
             this.txtStartSplit.Size = new System.Drawing.Size(184, 20);
             this.txtStartSplit.TabIndex = 1;
-            this.txtStartSplit.Enter += new System.EventHandler(this.Split_Set_Enter);
+            this.txtStartSplit.Enter += new System.EventHandler(this.StartSplit_Set_Enter);
             // 
             // label2
             // 
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 37);
+            this.label2.Location = new System.Drawing.Point(3, 66);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(172, 13);
             this.label2.TabIndex = 5;
@@ -294,39 +314,39 @@
             // 
             this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(3, 124);
+            this.label6.Location = new System.Drawing.Point(3, 153);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(172, 13);
             this.label6.TabIndex = 8;
             this.label6.Text = "Pause:";
             // 
-            // txtReset
+            // txtStart
             // 
-            this.txtReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtReset, 2);
-            this.txtReset.Location = new System.Drawing.Point(181, 33);
-            this.txtReset.Name = "txtReset";
-            this.txtReset.ReadOnly = true;
-            this.txtReset.Size = new System.Drawing.Size(184, 20);
-            this.txtReset.TabIndex = 2;
-            this.txtReset.Enter += new System.EventHandler(this.Reset_Set_Enter);
+            this.txtStart.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtStart, 2);
+            this.txtStart.Location = new System.Drawing.Point(181, 33);
+            this.txtStart.Name = "txtStart";
+            this.txtStart.ReadOnly = true;
+            this.txtStart.Size = new System.Drawing.Size(184, 20);
+            this.txtStart.TabIndex = 2;
+            this.txtStart.Enter += new System.EventHandler(this.Start_Set_Enter);
             // 
             // txtPause
             // 
             this.txtPause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtPause, 2);
-            this.txtPause.Location = new System.Drawing.Point(181, 120);
+            this.txtPause.Location = new System.Drawing.Point(181, 149);
             this.txtPause.Name = "txtPause";
             this.txtPause.ReadOnly = true;
             this.txtPause.Size = new System.Drawing.Size(184, 20);
             this.txtPause.TabIndex = 5;
-            this.txtPause.Enter += new System.EventHandler(this.Pause_Set_Enter);
+            this.txtPause.Enter += new System.EventHandler(this.Skip_Set_Enter);
             // 
             // label3
             // 
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 95);
+            this.label3.Location = new System.Drawing.Point(3, 124);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(172, 13);
             this.label3.TabIndex = 6;
@@ -336,7 +356,7 @@
             // 
             this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 66);
+            this.label4.Location = new System.Drawing.Point(3, 95);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(172, 13);
             this.label4.TabIndex = 7;
@@ -346,29 +366,29 @@
             // 
             this.txtSkip.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtSkip, 2);
-            this.txtSkip.Location = new System.Drawing.Point(181, 91);
+            this.txtSkip.Location = new System.Drawing.Point(181, 120);
             this.txtSkip.Name = "txtSkip";
             this.txtSkip.ReadOnly = true;
             this.txtSkip.Size = new System.Drawing.Size(184, 20);
             this.txtSkip.TabIndex = 4;
-            this.txtSkip.Enter += new System.EventHandler(this.Skip_Set_Enter);
+            this.txtSkip.Enter += new System.EventHandler(this.Undo_Set_Enter);
             // 
             // txtUndo
             // 
             this.txtUndo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtUndo, 2);
-            this.txtUndo.Location = new System.Drawing.Point(181, 62);
+            this.txtUndo.Location = new System.Drawing.Point(181, 91);
             this.txtUndo.Name = "txtUndo";
             this.txtUndo.ReadOnly = true;
             this.txtUndo.Size = new System.Drawing.Size(184, 20);
             this.txtUndo.TabIndex = 3;
-            this.txtUndo.Enter += new System.EventHandler(this.Undo_Set_Enter);
+            this.txtUndo.Enter += new System.EventHandler(this.Reset_Set_Enter);
             // 
             // label7
             // 
             this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 211);
+            this.label7.Location = new System.Drawing.Point(3, 240);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(172, 13);
             this.label7.TabIndex = 9;
@@ -378,18 +398,18 @@
             // 
             this.txtToggle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtToggle, 2);
-            this.txtToggle.Location = new System.Drawing.Point(181, 207);
+            this.txtToggle.Location = new System.Drawing.Point(181, 236);
             this.txtToggle.Name = "txtToggle";
             this.txtToggle.ReadOnly = true;
             this.txtToggle.Size = new System.Drawing.Size(184, 20);
             this.txtToggle.TabIndex = 8;
-            this.txtToggle.Enter += new System.EventHandler(this.Toggle_Set_Enter);
+            this.txtToggle.Enter += new System.EventHandler(this.Switch_Next_Set_Enter);
             // 
             // label8
             // 
             this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(3, 153);
+            this.label8.Location = new System.Drawing.Point(3, 182);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(172, 13);
             this.label8.TabIndex = 10;
@@ -399,7 +419,7 @@
             // 
             this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(3, 182);
+            this.label9.Location = new System.Drawing.Point(3, 211);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(172, 13);
             this.label9.TabIndex = 12;
@@ -409,29 +429,29 @@
             // 
             this.txtSwitchPrevious.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchPrevious, 2);
-            this.txtSwitchPrevious.Location = new System.Drawing.Point(181, 149);
+            this.txtSwitchPrevious.Location = new System.Drawing.Point(181, 178);
             this.txtSwitchPrevious.Name = "txtSwitchPrevious";
             this.txtSwitchPrevious.ReadOnly = true;
             this.txtSwitchPrevious.Size = new System.Drawing.Size(184, 20);
             this.txtSwitchPrevious.TabIndex = 6;
-            this.txtSwitchPrevious.Enter += new System.EventHandler(this.Switch_Previous_Set_Enter);
+            this.txtSwitchPrevious.Enter += new System.EventHandler(this.Pause_Set_Enter);
             // 
             // txtSwitchNext
             // 
             this.txtSwitchNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchNext, 2);
-            this.txtSwitchNext.Location = new System.Drawing.Point(181, 178);
+            this.txtSwitchNext.Location = new System.Drawing.Point(181, 207);
             this.txtSwitchNext.Name = "txtSwitchNext";
             this.txtSwitchNext.ReadOnly = true;
             this.txtSwitchNext.Size = new System.Drawing.Size(184, 20);
             this.txtSwitchNext.TabIndex = 7;
-            this.txtSwitchNext.Enter += new System.EventHandler(this.Switch_Next_Set_Enter);
+            this.txtSwitchNext.Enter += new System.EventHandler(this.Switch_Previous_Set_Enter);
             // 
             // label10
             // 
             this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(181, 269);
+            this.label10.Location = new System.Drawing.Point(181, 299);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(128, 13);
             this.label10.TabIndex = 14;
@@ -440,7 +460,7 @@
             // txtDelay
             // 
             this.txtDelay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtDelay.Location = new System.Drawing.Point(315, 265);
+            this.txtDelay.Location = new System.Drawing.Point(315, 295);
             this.txtDelay.Name = "txtDelay";
             this.txtDelay.Size = new System.Drawing.Size(50, 20);
             this.txtDelay.TabIndex = 12;
@@ -451,9 +471,9 @@
             this.tableLayoutPanel2.SetColumnSpan(this.grpHotkeyProfiles, 3);
             this.grpHotkeyProfiles.Controls.Add(this.tableLayoutPanel3);
             this.grpHotkeyProfiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 293);
+            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 324);
             this.grpHotkeyProfiles.Name = "grpHotkeyProfiles";
-            this.grpHotkeyProfiles.Size = new System.Drawing.Size(362, 77);
+            this.grpHotkeyProfiles.Size = new System.Drawing.Size(362, 104);
             this.grpHotkeyProfiles.TabIndex = 13;
             this.grpHotkeyProfiles.TabStop = false;
             this.grpHotkeyProfiles.Text = "Hotkey Profiles";
@@ -474,16 +494,27 @@
             this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 2;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(356, 58);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 37F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 58F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(356, 85);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // lblProfile
             // 
             this.lblProfile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.lblProfile.AutoSize = true;
-            this.lblProfile.Location = new System.Drawing.Point(3, 8);
+            this.lblProfile.Location = new System.Drawing.Point(3, 12);
             this.lblProfile.Name = "lblProfile";
             this.lblProfile.Size = new System.Drawing.Size(166, 13);
             this.lblProfile.TabIndex = 0;
@@ -495,7 +526,7 @@
             this.tableLayoutPanel3.SetColumnSpan(this.cmbHotkeyProfiles, 3);
             this.cmbHotkeyProfiles.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbHotkeyProfiles.FormattingEnabled = true;
-            this.cmbHotkeyProfiles.Location = new System.Drawing.Point(175, 4);
+            this.cmbHotkeyProfiles.Location = new System.Drawing.Point(175, 8);
             this.cmbHotkeyProfiles.Name = "cmbHotkeyProfiles";
             this.cmbHotkeyProfiles.Size = new System.Drawing.Size(178, 21);
             this.cmbHotkeyProfiles.TabIndex = 0;
@@ -504,7 +535,7 @@
             // btnRemoveProfile
             // 
             this.btnRemoveProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnRemoveProfile.Location = new System.Drawing.Point(278, 32);
+            this.btnRemoveProfile.Location = new System.Drawing.Point(278, 54);
             this.btnRemoveProfile.Name = "btnRemoveProfile";
             this.btnRemoveProfile.Size = new System.Drawing.Size(75, 23);
             this.btnRemoveProfile.TabIndex = 3;
@@ -515,7 +546,7 @@
             // btnRenameProfile
             // 
             this.btnRenameProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnRenameProfile.Location = new System.Drawing.Point(196, 32);
+            this.btnRenameProfile.Location = new System.Drawing.Point(196, 54);
             this.btnRenameProfile.Name = "btnRenameProfile";
             this.btnRenameProfile.Size = new System.Drawing.Size(75, 23);
             this.btnRenameProfile.TabIndex = 2;
@@ -527,7 +558,7 @@
             // 
             this.btnNewProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.tableLayoutPanel3.SetColumnSpan(this.btnNewProfile, 2);
-            this.btnNewProfile.Location = new System.Drawing.Point(115, 32);
+            this.btnNewProfile.Location = new System.Drawing.Point(115, 54);
             this.btnNewProfile.Name = "btnNewProfile";
             this.btnNewProfile.Size = new System.Drawing.Size(75, 23);
             this.btnNewProfile.TabIndex = 1;
@@ -541,9 +572,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnCancel, 2);
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(302, 546);
+            this.btnCancel.Location = new System.Drawing.Point(302, 623);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Size = new System.Drawing.Size(75, 25);
             this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -560,7 +591,7 @@
             "MultiTwitch",
             "Kadgar",
             "Speedrun.tv"});
-            this.cbxRaceViewer.Location = new System.Drawing.Point(187, 431);
+            this.cbxRaceViewer.Location = new System.Drawing.Point(187, 489);
             this.cbxRaceViewer.Name = "cbxRaceViewer";
             this.cbxRaceViewer.Size = new System.Drawing.Size(190, 21);
             this.cbxRaceViewer.TabIndex = 5;
@@ -569,7 +600,7 @@
             // 
             this.label11.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(3, 435);
+            this.label11.Location = new System.Drawing.Point(3, 493);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(178, 13);
             this.label11.TabIndex = 15;
@@ -579,7 +610,7 @@
             // 
             this.label12.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(3, 493);
+            this.label12.Location = new System.Drawing.Point(3, 551);
             this.label12.Name = "label12";
             this.label12.Size = new System.Drawing.Size(178, 13);
             this.label12.TabIndex = 17;
@@ -589,7 +620,7 @@
             // 
             this.label13.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(3, 464);
+            this.label13.Location = new System.Drawing.Point(3, 522);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(178, 13);
             this.label13.TabIndex = 18;
@@ -599,7 +630,7 @@
             // 
             this.btnChooseComparisons.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnChooseComparisons, 3);
-            this.btnChooseComparisons.Location = new System.Drawing.Point(187, 488);
+            this.btnChooseComparisons.Location = new System.Drawing.Point(187, 546);
             this.btnChooseComparisons.Name = "btnChooseComparisons";
             this.btnChooseComparisons.Size = new System.Drawing.Size(190, 23);
             this.btnChooseComparisons.TabIndex = 7;
@@ -611,7 +642,7 @@
             // 
             this.chkSimpleSOB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkSimpleSOB.AutoSize = true;
-            this.chkSimpleSOB.Location = new System.Drawing.Point(7, 404);
+            this.chkSimpleSOB.Location = new System.Drawing.Point(7, 462);
             this.chkSimpleSOB.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkSimpleSOB.Name = "chkSimpleSOB";
             this.chkSimpleSOB.Size = new System.Drawing.Size(174, 17);
@@ -625,7 +656,7 @@
             this.chkWarnOnReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkWarnOnReset.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.chkWarnOnReset, 3);
-            this.chkWarnOnReset.Location = new System.Drawing.Point(191, 404);
+            this.chkWarnOnReset.Location = new System.Drawing.Point(191, 462);
             this.chkWarnOnReset.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
             this.chkWarnOnReset.Name = "chkWarnOnReset";
             this.chkWarnOnReset.Size = new System.Drawing.Size(186, 17);
@@ -633,11 +664,21 @@
             this.chkWarnOnReset.Text = "Warn On Reset If Better Times";
             this.chkWarnOnReset.UseVisualStyleBackColor = true;
             // 
+            // label14
+            // 
+            this.label14.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(3, 37);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(172, 13);
+            this.label14.TabIndex = 16;
+            this.label14.Text = "Start:";
+            // 
             // SettingsDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(394, 586);
+            this.ClientSize = new System.Drawing.Size(394, 665);
             this.Controls.Add(this.tableLayoutPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -660,7 +701,7 @@
         #endregion
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.TextBox txtStartSplit;
-        private System.Windows.Forms.TextBox txtReset;
+        private System.Windows.Forms.TextBox txtStart;
         private System.Windows.Forms.TextBox txtSkip;
         private System.Windows.Forms.TextBox txtUndo;
         private System.Windows.Forms.Label label4;
@@ -701,5 +742,7 @@
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.Button btnChooseRaceProvider;
         private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.TextBox txtReset;
+        private System.Windows.Forms.Label label14;
     }
 }

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
@@ -19,7 +19,8 @@ namespace LiveSplit.View
         public CompositeHook Hook { get; set; }
         public string SelectedHotkeyProfile { get; set; }
 
-        public string SplitKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].SplitKey);
+        public string StartKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].StartKey);
+        public string StartSplitKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].StartSplitKey);
         public string ResetKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].ResetKey);
         public string SkipKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].SkipKey);
         public string UndoKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].UndoKey);
@@ -80,7 +81,8 @@ namespace LiveSplit.View
 
         private void UpdateDisplayedHotkeyValues()
         {
-            txtStartSplit.Text = SplitKey;
+            txtStart.Text = StartKey;
+            txtStartSplit.Text = StartSplitKey;
             txtReset.Text = ResetKey;
             txtSkip.Text = SkipKey;
             txtUndo.Text = UndoKey;
@@ -215,11 +217,20 @@ namespace LiveSplit.View
             txtBox.Leave += leaveHandler;
             Hook.AnyGamepadButtonPressed += gamepadButtonPressed;
         }
-        private void Split_Set_Enter(object sender, EventArgs e)
+
+        private void Start_Set_Enter(object sender, EventArgs e)
         {
             SetHotkeyHandlers((TextBox)sender, x =>
             {
-                Settings.HotkeyProfiles[SelectedHotkeyProfile].SplitKey = x;
+                Settings.HotkeyProfiles[SelectedHotkeyProfile].StartKey = x;
+            });
+        }
+
+        private void StartSplit_Set_Enter(object sender, EventArgs e)
+        {
+            SetHotkeyHandlers((TextBox)sender, x =>
+            {
+                Settings.HotkeyProfiles[SelectedHotkeyProfile].StartSplitKey = x;
             });
         }
         private void Reset_Set_Enter(object sender, EventArgs e)

--- a/LiveSplit/LiveSplit.View/View/TimerForm.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.Designer.cs
@@ -85,53 +85,59 @@
             this.aboutMenuItem,
             this.exitMenuItem});
             this.RightClickMenu.Name = "RightClickMenu";
-            this.RightClickMenu.Size = new System.Drawing.Size(167, 408);
+            this.RightClickMenu.Size = new System.Drawing.Size(181, 386);
             this.RightClickMenu.Opening += new System.ComponentModel.CancelEventHandler(this.RightClickMenu_Opening);
             // 
             // editSplitsMenuItem
             // 
             this.editSplitsMenuItem.Name = "editSplitsMenuItem";
-            this.editSplitsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.editSplitsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.editSplitsMenuItem.Text = "Edit Splits...";
             this.editSplitsMenuItem.Click += new System.EventHandler(this.editSplitsMenuItem_Click);
             // 
             // openSplitsMenuItem
             // 
             this.openSplitsMenuItem.Name = "openSplitsMenuItem";
-            this.openSplitsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.openSplitsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.openSplitsMenuItem.Text = "Open Splits";
             // 
             // saveSplitsMenuItem
             // 
             this.saveSplitsMenuItem.Name = "saveSplitsMenuItem";
-            this.saveSplitsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.saveSplitsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveSplitsMenuItem.Text = "Save Splits";
             this.saveSplitsMenuItem.Click += new System.EventHandler(this.saveSplitsMenuItem_Click);
             // 
             // saveSplitsAsMenuItem
             // 
             this.saveSplitsAsMenuItem.Name = "saveSplitsAsMenuItem";
-            this.saveSplitsAsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.saveSplitsAsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveSplitsAsMenuItem.Text = "Save Splits As...";
             this.saveSplitsAsMenuItem.Click += new System.EventHandler(this.saveAsMenuItem_Click);
             // 
             // closeSplitsMenuItem
             // 
             this.closeSplitsMenuItem.Name = "closeSplitsMenuItem";
-            this.closeSplitsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.closeSplitsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.closeSplitsMenuItem.Text = "Close Splits";
             this.closeSplitsMenuItem.Click += new System.EventHandler(this.closeSplitsMenuItem_Click);
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(163, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(177, 6);
             // 
             // controlMenuItem
             // 
             this.controlMenuItem.Name = "controlMenuItem";
-            this.controlMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.controlMenuItem.Size = new System.Drawing.Size(180, 22);
             this.controlMenuItem.Text = "Control";
+            // 
+            // comparisonMenuItem
+            // 
+            this.comparisonMenuItem.Name = "comparisonMenuItem";
+            this.comparisonMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.comparisonMenuItem.Text = "Compare Against";
             // 
             // toolStripSeparator1
             // 
@@ -148,63 +154,63 @@
             // endRaceSection
             // 
             this.endRaceSection.Name = "endRaceSection";
-            this.endRaceSection.Size = new System.Drawing.Size(166, 6);
+            this.endRaceSection.Size = new System.Drawing.Size(177, 6);
             // 
             // editLayoutMenuItem
             // 
             this.editLayoutMenuItem.Name = "editLayoutMenuItem";
-            this.editLayoutMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.editLayoutMenuItem.Size = new System.Drawing.Size(180, 22);
             this.editLayoutMenuItem.Text = "Edit Layout...";
             this.editLayoutMenuItem.Click += new System.EventHandler(this.editLayoutMenuItem_Click);
             // 
             // openLayoutMenuItem
             // 
             this.openLayoutMenuItem.Name = "openLayoutMenuItem";
-            this.openLayoutMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.openLayoutMenuItem.Size = new System.Drawing.Size(180, 22);
             this.openLayoutMenuItem.Text = "Open Layout";
             // 
             // saveLayoutMenuItem
             // 
             this.saveLayoutMenuItem.Name = "saveLayoutMenuItem";
-            this.saveLayoutMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.saveLayoutMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveLayoutMenuItem.Text = "Save Layout";
             this.saveLayoutMenuItem.Click += new System.EventHandler(this.saveLayoutMenuItem_Click);
             // 
             // saveLayoutAsMenuItem
             // 
             this.saveLayoutAsMenuItem.Name = "saveLayoutAsMenuItem";
-            this.saveLayoutAsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.saveLayoutAsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveLayoutAsMenuItem.Text = "Save Layout As...";
             this.saveLayoutAsMenuItem.Click += new System.EventHandler(this.saveLayoutAsMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(163, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(177, 6);
             // 
             // settingsMenuItem
             // 
             this.settingsMenuItem.Name = "settingsMenuItem";
-            this.settingsMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.settingsMenuItem.Size = new System.Drawing.Size(180, 22);
             this.settingsMenuItem.Text = "Settings";
             this.settingsMenuItem.Click += new System.EventHandler(this.settingsMenuItem_Click);
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(163, 6);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(177, 6);
             // 
             // aboutMenuItem
             // 
             this.aboutMenuItem.Name = "aboutMenuItem";
-            this.aboutMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.aboutMenuItem.Size = new System.Drawing.Size(180, 22);
             this.aboutMenuItem.Text = "About";
             this.aboutMenuItem.Click += new System.EventHandler(this.aboutMenuItem_Click);
             // 
             // exitMenuItem
             // 
             this.exitMenuItem.Name = "exitMenuItem";
-            this.exitMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.exitMenuItem.Size = new System.Drawing.Size(180, 22);
             this.exitMenuItem.Text = "Exit";
             this.exitMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -257,17 +263,10 @@
             // 
             // hotkeysMenuItem
             // 
-            this.hotkeysMenuItem.Enabled = true;
             this.hotkeysMenuItem.Name = "hotkeysMenuItem";
             this.hotkeysMenuItem.Size = new System.Drawing.Size(152, 22);
             this.hotkeysMenuItem.Text = "Global Hotkeys";
             this.hotkeysMenuItem.Click += new System.EventHandler(this.hotkeysMenuItem_Click);
-            // 
-            // comparisonMenuItem
-            // 
-            this.comparisonMenuItem.Name = "comparisonMenuItem";
-            this.comparisonMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.comparisonMenuItem.Text = "Compare Against";
             // 
             // TimerForm
             // 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1061,6 +1061,18 @@ namespace LiveSplit.View
             }
         }
 
+        private void Start()
+        {
+            if(CurrentState.CurrentPhase == TimerPhase.Paused)
+            {
+                Model.Pause();
+            }
+            else if (CurrentState.CurrentPhase == TimerPhase.NotRunning)
+            {
+                Model.Start();
+            }
+        }
+
         void hook_KeyOrButtonPressed(object sender, KeyOrButton e)
         {
             Action action = () =>
@@ -1069,16 +1081,27 @@ namespace LiveSplit.View
 
                 if ((ActiveForm == this || hotkeyProfile.GlobalHotkeysEnabled) && !ResetMessageShown && !IsInDialogMode)
                 {
-                    if (hotkeyProfile.SplitKey == e)
+                    if (hotkeyProfile.StartSplitKey == e)
                     {
                         if (hotkeyProfile.HotkeyDelay > 0)
                         {
-                            var splitTimer = new System.Timers.Timer(hotkeyProfile.HotkeyDelay * 1000f);
-                            splitTimer.Enabled = true;
-                            splitTimer.Elapsed += splitTimer_Elapsed;
+                            var startSplitTimer = new System.Timers.Timer(hotkeyProfile.HotkeyDelay * 1000f);
+                            startSplitTimer.Enabled = true;
+                            startSplitTimer.Elapsed += startSplitTimer_Elapsed;
                         }
                         else
                             StartOrSplit();
+                    }
+                    else if (hotkeyProfile.StartKey == e)
+                    {
+                        if (hotkeyProfile.HotkeyDelay > 0)
+                        {
+                            var startTimer = new System.Timers.Timer(hotkeyProfile.HotkeyDelay * 1000f);
+                            startTimer.Enabled = true;
+                            startTimer.Elapsed += startTimer_Elapsed;
+                        }
+                        else
+                            Start();
                     }
 
                     else if (hotkeyProfile.UndoKey == e)
@@ -1141,7 +1164,13 @@ namespace LiveSplit.View
             Model.Pause();
         }
 
-        void splitTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        void startTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        {
+            ((System.Timers.Timer)sender).Stop();
+            Start();
+        }
+
+        void startSplitTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
             ((System.Timers.Timer)sender).Stop();
             StartOrSplit();

--- a/LiveSplit/LiveSplit.View/View/TimerForm.resx
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="RightClickMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>34, 8</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
#1932 
* Changed "Settings" layout to fit the new key input
* Changed name "SplitKey" to StartSplitKey to avoid name confusing
* Added "StartKey" with default shortcut "num0"
* Added Start function to TimerForm
* Changed xml settings to save the new key