### PR TITLE
Added Minecraft IGT support

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -9300,4 +9300,15 @@
     <Description>Autosplitting available (by Micrologist)</Description>
     <Website>https://github.com/Micrologist/LiveSplit.Devolverland</Website>
   </AutoSplitter>
+  <AutoSplitter>
+    <Games>
+      <Game>Minecraft: Java Edition</Game>
+    </Games>
+    <URLs>
+      <URL>https://raw.githubusercontent.com/Jorkoh/MinecraftIGT/master/MinecraftIGT.asl</URL>
+    </URLs>
+    <Type>Script</Type>
+    <Description>Game Time is available (By Jorkoh)</Description>
+    <Website>https://github.com/Jorkoh/MinecraftIGT</Website>
+  </AutoSplitter>	
 </AutoSplitters>


### PR DESCRIPTION
The already existing .asl script by CryZe doesn't work on Minecraft 1.7.2 (2013) and above. Currently there are a couple of standalone IGT timers being used by the community, this script uses the same concept to obtain the game time.