### PR TITLE
GetExtendedCategoryName now ignores blank/unset variables

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/IRun.cs
+++ b/LiveSplit/LiveSplit.Core/Model/IRun.cs
@@ -405,6 +405,10 @@ namespace LiveSplit.Model
                     {
                         var name = variable.TrimEnd('?');
                         var variableValue = run.Metadata.VariableValueNames[variable];
+                        if (string.IsNullOrWhiteSpace(variableValue))
+                        {
+                            continue; //Ignore blank/unset variables
+                        }
                         var valueLower = variableValue.ToLowerInvariant();
 
                         if (valueLower == "yes")


### PR DESCRIPTION
Having variables deliberately unset in your splits creates weird extended category names in the Title component.

Old behaviour (title component)
![image](https://user-images.githubusercontent.com/7827560/88134415-89847d00-cbb2-11ea-9696-920bf73330c8.png)

New behaviour with this modification:
![image](https://user-images.githubusercontent.com/7827560/88134589-09124c00-cbb3-11ea-9478-f1f5ca485684.png)
