### PR TITLE
Add a TMNF and TMUF autosplitter

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4102,6 +4102,17 @@
         <Type>Script</Type>
         <Description>Load remover and auto splitting options are available. (By NeKz)</Description>
     </AutoSplitter>
+        <AutoSplitter>
+        <Games>
+            <Game>TrackMania Nations Forever</Game>
+            <Game>TrackMania United Forever</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/donadigo/AutoSplitters/master/Trackmania%20Forever.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Simple script that implements game time for TMNF and TMUF (By donadigo)</Description>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>The Legend of Zelda: A Link to the Past</Game>


### PR DESCRIPTION
Adds a simple autosplitter for TMNF and TMUF that supports game time splits.