### PR TITLE
Add feature to split layout into several rows/columns

### DIFF
--- a/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
@@ -85,6 +85,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
@@ -179,6 +180,14 @@
     <Compile Include="UI\Components\LogicComponent.cs" />
     <Compile Include="UI\Components\RaceProviderAPI.cs" />
     <Compile Include="UI\Components\SeparatorFactory.cs" />
+    <Compile Include="UI\Components\SplitAt\SplitAtComponentFactory.cs" />
+    <Compile Include="UI\Components\SplitAt\SplitAtComponent.cs" />
+    <Compile Include="UI\Components\SplitAt\SplitAtSettings.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UI\Components\SplitAt\SplitAtSettings.Designer.cs">
+      <DependentUpon>SplitAtSettings.cs</DependentUpon>
+    </Compile>
     <Compile Include="UI\GradientType.cs" />
     <Compile Include="UI\GraphicsCache.cs" />
     <Compile Include="UI\ImageBlur.cs" />
@@ -336,6 +345,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <CustomToolNamespace>LiveSplit</CustomToolNamespace>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\Components\SplitAt\SplitAtSettings.resx">
+      <DependentUpon>SplitAtSettings.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Updates\GitInfo.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>

--- a/LiveSplit/LiveSplit.Core/UI/Components/ComponentRenderer.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/ComponentRenderer.cs
@@ -1,15 +1,29 @@
 ﻿using LiveSplit.Model;
 using LiveSplit.Options;
+using LiveSplit.UI.Components.SplitAt;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Linq;
 
 namespace LiveSplit.UI.Components
 {
     public class ComponentRenderer
     {
+
         public IEnumerable<IComponent> VisibleComponents { get; set; }
+
+        /// <summary>
+        /// If enabled, looks for SplitAtComponent for splitting the drawing into several lines.
+        /// </summary>
+        /// <remarks>
+        /// A SplitAtComponent added to VisibleComponents will start a new line at it's position,
+        /// with the given spacing (relative to overall size) applied between the old and new line.
+        /// The word "line" in this context refers either to rows (horizontal layout) or columns
+        /// (vertical layout) and "size" would be either the height or the width.
+        /// </remarks>
+        public bool SplitAtEnabled { get; set; }
 
         public float OverallSize = 10f;
 
@@ -123,7 +137,9 @@ namespace LiveSplit.UI.Components
 
         public void CalculateOverallSize(LayoutMode mode)
         {
+            // totalSize2 remembers the longest line (or stays at 1 if no separate lines exist)
             var totalSize = 0f;
+            var totalSize2 = 1f;
             var index = 0;
             foreach (var component in VisibleComponents)
             {
@@ -132,10 +148,16 @@ namespace LiveSplit.UI.Components
                 else
                     totalSize += GetWidthHorizontal(index);
                 index++;
+                if (ShouldSplitAt(component))
+                {
+                    totalSize2 = Math.Max(totalSize2, totalSize);
+                    totalSize = 0;
+                }
             }
 
-            OverallSize = Math.Max(totalSize, 1f);
+            OverallSize = Math.Max(totalSize, totalSize2);
         }
+
 
         public void Render(Graphics g, LiveSplitState state, float width, float height, LayoutMode mode, Region clipRegion)
         {
@@ -145,17 +167,34 @@ namespace LiveSplit.UI.Components
                 {
                     var clip = g.Clip;
                     var transform = g.Transform;
+                    var orig = g.Transform.Elements;
                     var crashedComponents = new List<IComponent>();
                     var index = 0;
+
+                    float[] lineSizes;
+                    if (mode == LayoutMode.Vertical)
+                        lineSizes = GetLineSizes(width);
+                    else
+                        lineSizes = GetLineSizes(height);
+
+                    int lineIndex = 0;
                     foreach (var component in VisibleComponents)
                     {
                         try
                         {
                             g.Clip = clip;
+                            if (ShouldSplitAt(component))
+                            {
+                                lineIndex++;
+                                //Console.WriteLine("BOffset: " + g.Transform.OffsetX + " / " + g.Transform.OffsetY+" Orig: "+transform.OffsetX+" / "+transform.OffsetY);
+                                g.Transform = ChangeTransformMove(g.Transform, orig, mode, lineSizes[lineIndex - 1], width, height, component);
+                                //Console.WriteLine("AOffset: "+ g.Transform.OffsetX+" / "+g.Transform.OffsetY+" "+ sizes[lineIndex - 1]);
+                            }
+
                             if (mode == LayoutMode.Vertical)
-                                DrawVerticalComponent(index, g, state, width, height, clipRegion);
+                                DrawVerticalComponent(index, g, state, lineSizes[lineIndex], height, clipRegion);
                             else
-                                DrawHorizontalComponent(index, g, state, width, height, clipRegion);
+                                DrawHorizontalComponent(index, g, state, width, lineSizes[lineIndex], clipRegion);
                         }
                         catch (Exception e)
                         {
@@ -208,20 +247,155 @@ namespace LiveSplit.UI.Components
 
         public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
         {
+            float[] lineSizes;
+            if (mode == LayoutMode.Vertical)
+                lineSizes = GetLineSizes(width);
+            else
+                lineSizes = GetLineSizes(height);
+
             var oldTransform = invalidator.Transform.Clone();
+            var oldTransformElements = oldTransform.Elements;
             var scaleFactor = mode == LayoutMode.Vertical
                     ? height / OverallSize
                     : width / OverallSize;
 
+            int lineIndex = 0;
             for (var ind = 0; ind < VisibleComponents.Count(); ind++)
             {
                 var component = VisibleComponents.ElementAt(ind);
+                if (ShouldSplitAt(component))
+                {
+                    lineIndex++;
+                    invalidator.Transform = ChangeTransformMove(invalidator.Transform, oldTransformElements, mode, lineSizes[lineIndex-1], width, height, component);
+                }
+
                 if (mode == LayoutMode.Vertical)
-                    InvalidateVerticalComponent(ind, state, invalidator, width, height, scaleFactor);
+                    InvalidateVerticalComponent(ind, state, invalidator, lineSizes[lineIndex], height, scaleFactor);
                 else
-                    InvalidateHorizontalComponent(ind, state, invalidator, width, height, scaleFactor);
+                    InvalidateHorizontalComponent(ind, state, invalidator, width, lineSizes[lineIndex], scaleFactor);
             }
             invalidator.Transform = oldTransform;
         }
+
+        /// <summary>
+        /// Check whether to split at the current component.
+        /// </summary>
+        /// <param name="comp">The component that will be drawn</param>
+        /// <returns>Whether the following components should be drawn in the next line</returns>
+        /// <remarks>Since a SplitAtComponent should take up no space, it probably doesn't matter if the split actually is done before or after the component.</remarks>
+        private bool ShouldSplitAt(IComponent comp)
+        {
+            return SplitAtEnabled && comp is SplitAtComponent;
+        }
+
+        /// <summary>
+        /// Get the size for each line, based on the given overall <paramref name="size"/>
+        /// and the weight setting for each line.
+        /// </summary>
+        /// <param name="size">The overall size of the component</param>
+        /// <returns>The sizes of each line</returns>
+        private float[] GetLineSizes(float size)
+        {
+            if (!SplitAtEnabled)
+            {
+                return new float[] { size };
+            }
+            int lines = 1;
+            float spacing = 0;
+            // Accumulate all size weights, starting with 100 for the first line
+            int totalWeight = 1000;
+            foreach (IComponent comp in VisibleComponents)
+            {
+                var splitAtComp = comp as SplitAtComponent;
+                if (splitAtComp != null)
+                {
+                    lines++;
+                    spacing += GetSpacing(size, splitAtComp.Settings.Spacing);
+                    totalWeight += splitAtComp.Settings.Weight;
+                }
+            }
+            if (lines == 1)
+            {
+                return new float[] { size };
+            }
+            else
+            {
+                // Calculate the size of each line, relative to other lines
+                float normalizedSize = (size - spacing) / (totalWeight / 1000f);
+                float[] result = new float[lines];
+                // First line is always just be 100%
+                result[0] = normalizedSize;
+                int index = 1;
+                foreach (IComponent comp in VisibleComponents)
+                {
+                    var splitAtComp = comp as SplitAtComponent;
+                    if (splitAtComp != null)
+                    {
+                        result[index] = normalizedSize * (splitAtComp.Settings.Weight / 1000f);
+                        index++;
+                    }
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Calculate the spacing between lines relative to the overall <paramref name="size"/> of the component.
+        /// </summary>
+        /// <param name="size">The overall size of the component, used to calcuate the actual spacing</param>
+        /// <param name="spacing">The percentage (0-1000, in 1/10th steps) of the overall size of the component</param>
+        /// <returns>The spacing</returns>
+        private float GetSpacing(float size, int spacing)
+        {
+            // Relative to size because size may be scaled, so this
+            // way the spacing is automatically correctly scaled as well
+            // (maybe it could calculate from an absolute spacing using
+            // the scaleFactor, but this seems to work)
+            return spacing / 1000f * size;
+        }
+
+        /// <summary>
+        /// Returns a new Matrix that is a copy of the given <paramref name="transform"/>, except
+        /// that the x or y offset (depending on the layout) is reset to original (usually near 0)
+        /// and some offset is added (to move into the next line).
+        /// </summary>
+        /// <param name="transform">The current transform</param>
+        /// <param name="orig">The original transform elements</param>
+        /// <param name="mode">The layout mode (vertical or horizontal)</param>
+        /// <param name="move">How much to offset (previous line size)</param>
+        /// <param name="width">The overall width</param>
+        /// <param name="height">The overall height</param>
+        /// <param name="comp">The component</param>
+        /// <returns>A modified matrix</returns>
+        /// <remarks>
+        /// Directly setting the x/y offsets of a Matrix doesn't seem possible, and using the
+        /// translate function doesn't really work well for resetting to a specific value if
+        /// some other transformation (in this case usually scaling) is set (although it could
+        /// probably be solved).
+        /// 
+        /// The move/width/height is already received scaled accordingly, so the Translate
+        /// method is used.
+        /// 
+        /// The original x/y is used instead of setting to 0 since the original may not actually
+        /// be 0 (and all lines should start the same).
+        /// </remarks>
+        private Matrix ChangeTransformMove(Matrix transform, float[] orig, LayoutMode mode, float move, float width, float height, IComponent comp)
+        {
+            float[] curr = transform.Elements;
+
+            if (mode == LayoutMode.Vertical)
+            {
+                transform = new Matrix(curr[0], curr[1], curr[2], curr[3], curr[4], orig[5]);
+                transform.Translate(move + GetSpacing(width, ((SplitAtComponent)comp).Settings.Spacing), 0);
+            }
+            else
+            {
+                transform = new Matrix(curr[0], curr[1], curr[2], curr[3], orig[4], curr[5]);
+                transform.Translate(0, move + GetSpacing(height, ((SplitAtComponent)comp).Settings.Spacing));
+            }
+            return transform;
+        }
+
     }
+
 }

--- a/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtComponent.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtComponent.cs
@@ -1,0 +1,43 @@
+﻿using LiveSplit.Model;
+using System.Windows.Forms;
+using System.Xml;
+
+namespace LiveSplit.UI.Components.SplitAt
+{
+    public class SplitAtComponent : LogicComponent
+    {
+        public override string ComponentName => "-- New row/column --";
+
+        public SplitAtSettings Settings { get; set; }
+
+        public SplitAtComponent()
+        {
+            Settings = new SplitAtSettings();
+        }
+
+        public override void Dispose()
+        {
+            
+        }
+
+        public override XmlNode GetSettings(XmlDocument document)
+        {
+            return Settings.GetSettings(document);
+        }
+
+        public override Control GetSettingsControl(LayoutMode mode)
+        {
+            return Settings;
+        }
+
+        public override void SetSettings(XmlNode settings)
+        {
+            Settings.SetSettings(settings);
+        }
+
+        public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+        {
+            
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtComponentFactory.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtComponentFactory.cs
@@ -1,0 +1,36 @@
+﻿using LiveSplit.Model;
+using System;
+
+namespace LiveSplit.UI.Components.SplitAt
+{
+    public class SplitAtComponentFactory : IComponentFactory
+    {
+        public string ComponentName => "New row/column";
+
+        public string Description => "Puts the components following this into a new row/column (horizontal/vertical layout)";
+
+        public ComponentCategory Category => ComponentCategory.Other;
+
+        public IComponent Create(LiveSplitState state) => new SplitAtComponent();
+
+        public string UpdateName
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public string XMLURL
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public string UpdateURL
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public Version Version
+        {
+            get { throw new NotSupportedException(); }
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtSettings.Designer.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtSettings.Designer.cs
@@ -1,0 +1,184 @@
+﻿namespace LiveSplit.UI.Components.SplitAt
+{
+    partial class SplitAtSettings
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.trkSpacing = new System.Windows.Forms.TrackBar();
+            this.label1 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.trkWeight = new System.Windows.Forms.TrackBar();
+            this.label2 = new System.Windows.Forms.Label();
+            this.btnResetSpacing = new System.Windows.Forms.Button();
+            this.btnResetWeight = new System.Windows.Forms.Button();
+            this.txtSpacing = new System.Windows.Forms.TextBox();
+            this.txtWeight = new System.Windows.Forms.TextBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            ((System.ComponentModel.ISupportInitialize)(this.trkSpacing)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trkWeight)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // trkSpacing
+            // 
+            this.trkSpacing.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.trkSpacing.Location = new System.Drawing.Point(63, 3);
+            this.trkSpacing.Maximum = 800;
+            this.trkSpacing.Name = "trkSpacing";
+            this.trkSpacing.Size = new System.Drawing.Size(284, 24);
+            this.trkSpacing.TabIndex = 0;
+            this.trkSpacing.TickStyle = System.Windows.Forms.TickStyle.None;
+            // 
+            // label1
+            // 
+            this.label1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 8);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(49, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Spacing:";
+            this.toolTip1.SetToolTip(this.label1, "Blank space between the previous and following row/column,\r\nrelative to the overa" +
+        "ll window size.");
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 4;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 290F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 54F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 58F));
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.trkSpacing, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.trkWeight, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.btnResetSpacing, 3, 0);
+            this.tableLayoutPanel1.Controls.Add(this.btnResetWeight, 3, 1);
+            this.tableLayoutPanel1.Controls.Add(this.txtSpacing, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.txtWeight, 2, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 186);
+            this.tableLayoutPanel1.TabIndex = 2;
+            // 
+            // trkWeight
+            // 
+            this.trkWeight.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.trkWeight.Location = new System.Drawing.Point(63, 33);
+            this.trkWeight.Maximum = 4000;
+            this.trkWeight.Name = "trkWeight";
+            this.trkWeight.Size = new System.Drawing.Size(284, 24);
+            this.trkWeight.TabIndex = 2;
+            this.trkWeight.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.trkWeight.Value = 1000;
+            // 
+            // label2
+            // 
+            this.label2.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 38);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(30, 13);
+            this.label2.TabIndex = 4;
+            this.label2.Text = "Size:";
+            this.toolTip1.SetToolTip(this.label2, "Size of the following row/column, relative to other rows/columns.\r\n\r\nThe first ro" +
+        "w/column is always 100% (to make it smaller, increase the size of the others).");
+            // 
+            // btnResetSpacing
+            // 
+            this.btnResetSpacing.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnResetSpacing.Location = new System.Drawing.Point(407, 3);
+            this.btnResetSpacing.Name = "btnResetSpacing";
+            this.btnResetSpacing.Size = new System.Drawing.Size(52, 23);
+            this.btnResetSpacing.TabIndex = 6;
+            this.btnResetSpacing.Text = "Reset";
+            this.btnResetSpacing.UseVisualStyleBackColor = true;
+            // 
+            // btnResetWeight
+            // 
+            this.btnResetWeight.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnResetWeight.Location = new System.Drawing.Point(407, 33);
+            this.btnResetWeight.Name = "btnResetWeight";
+            this.btnResetWeight.Size = new System.Drawing.Size(52, 23);
+            this.btnResetWeight.TabIndex = 7;
+            this.btnResetWeight.Text = "Reset";
+            this.btnResetWeight.UseVisualStyleBackColor = true;
+            // 
+            // txtSpacing
+            // 
+            this.txtSpacing.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSpacing.Location = new System.Drawing.Point(353, 5);
+            this.txtSpacing.Name = "txtSpacing";
+            this.txtSpacing.Size = new System.Drawing.Size(48, 20);
+            this.txtSpacing.TabIndex = 8;
+            // 
+            // txtWeight
+            // 
+            this.txtWeight.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtWeight.Location = new System.Drawing.Point(353, 35);
+            this.txtWeight.Name = "txtWeight";
+            this.txtWeight.Size = new System.Drawing.Size(48, 20);
+            this.txtWeight.TabIndex = 9;
+            // 
+            // SplitAtSettings
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Name = "SplitAtSettings";
+            this.Padding = new System.Windows.Forms.Padding(7);
+            this.Size = new System.Drawing.Size(476, 200);
+            ((System.ComponentModel.ISupportInitialize)(this.trkSpacing)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trkWeight)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TrackBar trkSpacing;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TrackBar trkWeight;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button btnResetSpacing;
+        private System.Windows.Forms.Button btnResetWeight;
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.TextBox txtSpacing;
+        private System.Windows.Forms.TextBox txtWeight;
+    }
+}

--- a/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtSettings.cs
+++ b/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtSettings.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Windows.Forms;
+using System.Xml;
+
+namespace LiveSplit.UI.Components.SplitAt
+{
+    public partial class SplitAtSettings : UserControl
+    {
+
+        public int Spacing { get; set; }
+
+        public int Weight { get; set; }
+
+        public SplitAtSettings()
+        {
+            InitializeComponent();
+
+            Spacing = 0;
+            Weight = 1000;
+
+            trkSpacing.DataBindings.Add("Value", this, "Spacing", false, DataSourceUpdateMode.OnPropertyChanged);
+            trkWeight.DataBindings.Add("Value", this, "Weight", false, DataSourceUpdateMode.OnPropertyChanged);
+
+            txtSpacing.TextChanged += Spacing_UpdateValue;
+            txtWeight.TextChanged += Weight_UpdateValue;
+
+            trkSpacing.ValueChanged += Spacing_UpdateText;
+            trkWeight.ValueChanged += Weight_UpdateText;
+            txtSpacing.LostFocus += Spacing_UpdateText;
+            txtWeight.LostFocus += Weight_UpdateText;
+
+            btnResetSpacing.Click += BtnResetSpacing_Click;
+            btnResetWeight.Click += BtnResetWeight_Click;
+
+            updateText(txtSpacing, trkSpacing);
+            updateText(txtWeight, trkWeight);
+        }
+
+        private void Spacing_UpdateValue(object sender, EventArgs e)
+        {
+            updateValue(txtSpacing, trkSpacing);
+        }
+
+        private void Weight_UpdateValue(object sender, EventArgs e)
+        {
+            updateValue(txtWeight, trkWeight);
+        }
+
+        private void Spacing_UpdateText(object sender, EventArgs e)
+        {
+            updateText(txtSpacing, trkSpacing);
+        }
+
+        private void Weight_UpdateText(object sender, EventArgs e)
+        {
+            updateText(txtWeight, trkWeight);
+        }
+
+        private void updateValue(TextBox text, TrackBar track)
+        {
+            // Allow both "," and "." as separator
+            var value = text.Text.Replace(",", ".").Replace("%", "");
+            try
+            {
+                var number = float.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
+                track.Value = (int)(number * 10);
+            }
+            catch (Exception ex)
+            {
+                // Don't change
+            }
+        }
+
+        private void updateText(TextBox text, TrackBar track)
+        {
+            if (!text.Focused)
+            {
+                text.Text = String.Format("{0:P1}", track.Value / 1000f);
+            }
+        }
+
+        private void BtnResetWeight_Click(object sender, EventArgs e)
+        {
+            trkWeight.Value = 1000;
+        }
+
+        private void BtnResetSpacing_Click(object sender, EventArgs e)
+        {
+            trkSpacing.Value = 0;
+        }
+
+        public void SetSettings(XmlNode node)
+        {
+            var element = (XmlElement)node;
+            Spacing = SettingsHelper.ParseInt(element["Spacing"], 0);
+            Weight = SettingsHelper.ParseInt(element["Weight"], 1000);
+        }
+
+        public XmlNode GetSettings(XmlDocument document)
+        {
+            var parent = document.CreateElement("Settings");
+            CreateSettingsNode(document, parent);
+            return parent;
+        }
+
+        public int GetSettingsHashCode()
+        {
+            return CreateSettingsNode(null, null);
+        }
+
+        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+        {
+            return SettingsHelper.CreateSetting(document, parent, "Version", "1.0") ^
+            SettingsHelper.CreateSetting(document, parent, "Spacing", Spacing) ^
+            SettingsHelper.CreateSetting(document, parent, "Weight", Weight) ^
+            SettingsHelper.CreateSetting(document, parent, "Type", "SplitAt");
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtSettings.resx
+++ b/LiveSplit/LiveSplit.Core/UI/Components/SplitAt/SplitAtSettings.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/LiveSplit/LiveSplit.Core/UI/LayoutFactories/XMLLayoutFactory.cs
+++ b/LiveSplit/LiveSplit.Core/UI/LayoutFactories/XMLLayoutFactory.cs
@@ -1,6 +1,7 @@
 ﻿using LiveSplit.Model;
 using LiveSplit.Options;
 using LiveSplit.UI.Components;
+using LiveSplit.UI.Components.SplitAt;
 using System;
 using System.Drawing;
 using System.IO;
@@ -108,7 +109,17 @@ namespace LiveSplit.UI.LayoutFactories
                 var componentElement = componentNode as XmlElement;
                 var path = componentElement["Path"];
                 var settings = componentElement["Settings"];
-                var layoutComponent = ComponentManager.LoadLayoutComponent(path.InnerText, state);
+                ILayoutComponent layoutComponent;
+                // Since this is a "special" component, it's stored with an empty path
+                // (falls back to SeparatorComponent on older versions or if the setting wasn't found)
+                if (string.IsNullOrEmpty(path.InnerText) && settings["Type"]?.InnerText == "SplitAt")
+                {
+                    layoutComponent = new LayoutComponent("", new SplitAtComponent());
+                }
+                else
+                {
+                    layoutComponent = ComponentManager.LoadLayoutComponent(path.InnerText, state);
+                }
                 if (layoutComponent != null)
                 {
                     try

--- a/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
@@ -2,6 +2,7 @@
 using LiveSplit.Options;
 using LiveSplit.UI;
 using LiveSplit.UI.Components;
+using LiveSplit.UI.Components.SplitAt;
 using LiveSplit.Utils;
 using System;
 using System.Collections.Generic;
@@ -74,11 +75,19 @@ namespace LiveSplit.View
         {
             try
             {
-                var componentFactory = ComponentManager.ComponentFactories.FirstOrDefault(x => x.Value.ComponentName == factory.ComponentName);
-                var component = componentFactory.Value == null
-                    ? new LayoutComponent("", new SeparatorComponent())
-                    : new LayoutComponent(componentFactory.Key, componentFactory.Value.Create(CurrentState));
-
+                ILayoutComponent component;
+                if (factory is SplitAtComponentFactory)
+                {
+                    // Special component that is added to the menu similiar to SeparatorComponent
+                    component = new LayoutComponent("", new SplitAtComponent());
+                }
+                else
+                {
+                    var componentFactory = ComponentManager.ComponentFactories.FirstOrDefault(x => x.Value.ComponentName == factory.ComponentName);
+                    component = componentFactory.Value == null
+                        ? new LayoutComponent("", new SeparatorComponent())
+                        : new LayoutComponent(componentFactory.Key, componentFactory.Value.Create(CurrentState));
+                }
                 Form.InvokeIfRequired(() =>
                 {
                     try
@@ -134,10 +143,14 @@ namespace LiveSplit.View
                 var category = group.Key;
                 var componentFactories = (IEnumerable<IComponentFactory>)group;
                 if (category == ComponentCategory.Other)
-                    componentFactories = new[] { new SeparatorFactory() }.Concat(componentFactories).OrderBy(x => x.ComponentName);
+                {
+                    componentFactories = new IComponentFactory[] {
+                        new SeparatorFactory(), new SplitAtComponentFactory()
+                    }.Concat(componentFactories).OrderBy(x => x.ComponentName);
+                }
+
                 AddGroup(category, componentFactories);
             }
-
             menuAddComponents.Items.Add(new ToolStripSeparator());
             var downloadMore = new ToolStripMenuItem("Download More...");
             downloadMore.Click += (s, e) =>

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -2260,6 +2260,7 @@ namespace LiveSplit.View
                     component.Activated = true;
             }
             Layout = layout;
+            ComponentRenderer.SplitAtEnabled = true;
             ComponentRenderer.VisibleComponents = Layout.Components;
             CurrentState.LayoutSettings = layout.Settings;
             UpdateRefreshesRemaining();


### PR DESCRIPTION
I added this feature for a stream layout where two rows are required, each with it's own subsplits instance, one showing the overview of the run and the other showing the individual splits. Without this, two instances of LiveSplit are required to make it work (it would be possible to have one really wide LiveSplit instance and just split up the window capture, however it is required to be on a screen to render, so it doesn't work in every situation).

This feature modifies the ComponentRenderer to start a new line (column for vertical layout, row for horizontal layout) at every SplitAtComponent. The size (width for vertical layout, height for horizontal layout) of each line is reduced accordingly. The SplitAtComponent isn't implemented as a regular component, because it doesn't really do anything on it's own (except handling settings) and is tied into a core function, so it has some special handling for adding and loading.

For the user however, the component can simply be added like a regular component in the layout editor (in the component menu under "Other"). It also has settings to change the relative size of a line and the spacing to the previous line.

Horizontal Layout:
![LiveSplit_Lines_Example](https://user-images.githubusercontent.com/5621113/94159958-7036d000-fe84-11ea-9a4e-85a2a643fa0a.png)

Vertical Layout:
![LiveSplit_Lines_Example2](https://user-images.githubusercontent.com/5621113/94159953-6f9e3980-fe84-11ea-9a9d-ca6c755f696d.png)

Layout Editor:
![LiveSplit_Lines_Layout](https://user-images.githubusercontent.com/5621113/94159957-7036d000-fe84-11ea-9703-49a63bc936a5.png)