### PR TITLE
Issue #2029 - Removed hitting enter from closing the SplitEditor

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -652,7 +652,6 @@
             // 
             // RunEditorDialog
             // 
-            this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(684, 511);


### PR DESCRIPTION
Previously pressing enter in any text box in the splits editor would close the splits editor as the default accept button was "btnOK". 

Pressing enter the moment the combo box pops up after 1-2 tries would cause LiveSplit to crash in debug mode and have a weird empty box in release mode.

By removing the default accept button you can freely edit your splits and prevent the crash.

If having the default accept button was an intended mechanic another way to fix is to add some checks in the btnOK_Click method to make sure the combo box stops running and closes correctly.