### PR TITLE
Xunit migration

### DIFF
--- a/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
+++ b/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
@@ -1,35 +1,34 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Xml;
 using System.Linq;
 using System.Collections.Generic;
-using LiveSplit.Model;
 using System.Text.RegularExpressions;
+using Xunit;
+using LiveSplit.Model;
 
 namespace LiveSplit.Tests.AutoSplitterTests
 {
-    [TestClass]
     public class AutoSplitterXML
     {
-        [TestMethod]
+        [Fact]
         public void TestAutoSplittersXML()
         {
             var xmlPath = Path.Combine("..", "..", "..", "..", "LiveSplit.AutoSplitters.xml");
 
-            Assert.IsTrue(File.Exists(xmlPath), "The Auto Splitters XML is missing");
+            Assert.True(File.Exists(xmlPath), "The Auto Splitters XML is missing");
 
             var document = new XmlDocument();
             document.Load(xmlPath);
 
             var autoSplitterElems = document["AutoSplitters"].ChildNodes.OfType<XmlElement>().Where(element => element != null);
-            Assert.IsTrue(autoSplitterElems.All(x => x.Name == "AutoSplitter"), "<AutoSplitters> must contain only <AutoSplitter> elements");
+            Assert.True(autoSplitterElems.All(x => x.Name == "AutoSplitter"), "<AutoSplitters> must contain only <AutoSplitter> elements");
 
             var gameElems = autoSplitterElems.SelectMany(x => x["Games"].ChildNodes.OfType<XmlElement>());
-            Assert.IsTrue(gameElems.All(x => x.Name == "Game"), "<Games> must contain only <Game> elements");
+            Assert.True(gameElems.All(x => x.Name == "Game"), "<Games> must contain only <Game> elements");
 
             var urlElems = autoSplitterElems.SelectMany(x => x["URLs"].ChildNodes.OfType<XmlElement>());
-            Assert.IsTrue(urlElems.All(x => x.Name == "URL"), "<URLs> must contain only <URL> elements");
+            Assert.True(urlElems.All(x => x.Name == "URL"), "<URLs> must contain only <URL> elements");
 
             IDictionary<string, AutoSplitter> autoSplitters = autoSplitterElems.Select(element =>
                     new AutoSplitter()
@@ -41,16 +40,16 @@ namespace LiveSplit.Tests.AutoSplitterTests
                         ShowInLayoutEditor = element["ShowInLayoutEditor"] != null
                     }).SelectMany(x => x.Games.Select(y => new KeyValuePair<string, AutoSplitter>(y, x))).ToDictionary(x => x.Key, x => x.Value);
 
-            Assert.IsTrue(!autoSplitters.Any(x => string.IsNullOrWhiteSpace(x.Key)), "Empty Game Names are not allowed");
-            Assert.IsTrue(!autoSplitters.Values.Any(x => string.IsNullOrWhiteSpace(x.Description)), "Auto Splitters need a description");
-            Assert.IsTrue(!autoSplitters.Values.Any(x => !x.URLs.Any()), "Auto Splitters need to have at least one URL");
-            Assert.IsTrue(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".asl")) && x.Type == AutoSplitterType.Component),
+            Assert.True(!autoSplitters.Any(x => string.IsNullOrWhiteSpace(x.Key)), "Empty Game Names are not allowed");
+            Assert.True(!autoSplitters.Values.Any(x => string.IsNullOrWhiteSpace(x.Description)), "Auto Splitters need a description");
+            Assert.True(!autoSplitters.Values.Any(x => !x.URLs.Any()), "Auto Splitters need to have at least one URL");
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".asl")) && x.Type == AutoSplitterType.Component),
                 "ASL Script is downloaded even though Type \"Component\" is specified");
-            Assert.IsTrue(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".dll")) && x.Type == AutoSplitterType.Script),
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".dll")) && x.Type == AutoSplitterType.Script),
                 "Component is downloaded even though Type \"Script\" is specified");
-            Assert.IsTrue(!autoSplitters.Values.Any(x => x.URLs.Any(y => !Uri.IsWellFormedUriString(y, UriKind.Absolute))),
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => !Uri.IsWellFormedUriString(y, UriKind.Absolute))),
                 "Auto Splitters need to have valid URLs");
-            Assert.IsTrue(!autoSplitters.Values.Any(x => x.URLs.Any(y => Regex.IsMatch(y, "https://github.com/[^/]*/[^/]*/blob/"))),
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => Regex.IsMatch(y, "https://github.com/[^/]*/[^/]*/blob/"))),
                 "URLs leading to GitHub should use the raw file link");
         }
     }

--- a/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,15 +41,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoSplitterTests\AutoSplitterXML.cs" />
@@ -130,14 +137,18 @@
       <Name>LiveSplit.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.4.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -140,6 +140,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DaysTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DaysTimeFormatterTests.cs
@@ -7,9 +7,16 @@ namespace LiveSplit.Tests.TimeFormatterTests
     public class DaysTimeFormatterTests
     {
         // These tests cover DaysTimeFormatter, which (is/was not) based on any other TimeFormatter implementation
+        [Fact]
+        public void FormatsTimeAsZero_WhenTimeIsNull()
+        {
+            var sut = new DaysTimeFormatter();
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal("0", formattedTime);
+        }
 
         [Theory]
-        [InlineData(null, "0")]
         [InlineData("00:00:00", "0:00")]
         [InlineData("00:00:01.03", "0:01")]
         [InlineData("00:05:01.03", "5:01")]
@@ -17,16 +24,13 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("1.07:05:01.03", "1d 7:05:01")]
         [InlineData("9.23:02:03.412", "9d 23:02:03")]
         [InlineData("272.13:04:05.612", "272d 13:04:05")]
-        public void TestDaysTimeFormatter(string timespanText, string expected)
+        public void TestDaysTimeFormatter(string timespanText, string expectedTime)
         {
-            var formatter = new DaysTimeFormatter();
+            var sut = new DaysTimeFormatter();
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
         /*

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DaysTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DaysTimeFormatterTests.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatterTests 
 {
-
-    [TestClass]
     public class DaysTimeFormatterTests
     {
         // These tests cover DaysTimeFormatter, which (is/was not) based on any other TimeFormatter implementation
 
-        [TestMethod]
-        [DataRow(null, "0")]
-        [DataRow("00:00:00", "0:00")]
-        [DataRow("00:00:01.03", "0:01")]
-        [DataRow("00:05:01.03", "5:01")]
-        [DataRow("07:05:01.03", "7:05:01")]
-        [DataRow("1.07:05:01.03", "1d 7:05:01")]
-        [DataRow("9.23:02:03.412", "9d 23:02:03")]
-        [DataRow("272.13:04:05.612", "272d 13:04:05")]
+        [Theory]
+        [InlineData(null, "0")]
+        [InlineData("00:00:00", "0:00")]
+        [InlineData("00:00:01.03", "0:01")]
+        [InlineData("00:05:01.03", "5:01")]
+        [InlineData("07:05:01.03", "7:05:01")]
+        [InlineData("1.07:05:01.03", "1d 7:05:01")]
+        [InlineData("9.23:02:03.412", "9d 23:02:03")]
+        [InlineData("272.13:04:05.612", "272d 13:04:05")]
         public void TestDaysTimeFormatter(string timespanText, string expected)
         {
             var formatter = new DaysTimeFormatter();
@@ -28,7 +26,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
         /*
@@ -36,11 +34,11 @@ namespace LiveSplit.Tests.TimeFormatterTests
         // Currently:
         // - negative TimeSpans are displayed as positive
         // - negative days + hours are not displayed
-        [TestMethod]
-        [DataRow("-00:05:01.03", "−5:01")] // Actual:<5:01> [Fail]
-        [DataRow("-1.00:00:01.999", "−1d 0:00:01")] // Actual:<0:01> [Fail]
-        [DataRow("-9.23:02:03.412", "−9d 23:02:03")] // Actual:<2:03>. [Fail]
-        [DataRow("-222.13:04:05.612", "−222d 13:04:05")] // Actual:<4:05>. [Fail]
+        [Theory]
+        [InlineData("-00:05:01.03", "−5:01")] // Actual:<5:01> [Fail]
+        [InlineData("-1.00:00:01.999", "−1d 0:00:01")] // Actual:<0:01> [Fail]
+        [InlineData("-9.23:02:03.412", "−9d 23:02:03")] // Actual:<2:03>. [Fail]
+        [InlineData("-222.13:04:05.612", "−222d 13:04:05")] // Actual:<4:05>. [Fail]
         public void NegativeTestDaysTimeFormatter(string timespanText, string expected) {
         var formatter = new DaysTimeFormatter();
 
@@ -49,7 +47,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
         */
 

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DeltaTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DeltaTimeFormattersTests.cs
@@ -14,8 +14,20 @@ namespace LiveSplit.Tests.TimeFormatterTests
 
         // note: dash (-) is used for null, and minus (−) for negatives
 
+        [Fact]
+        public void DeltaTimeFormatterFormatsTimeAsDash_WhenTimeIsNullAndAccuracyIsInHundredths()
+        {
+            var sut = new DeltaTimeFormatter
+            {
+                Accuracy = TimeAccuracy.Hundredths,
+                DropDecimals = false
+            };
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+        }
+        
         [Theory]
-        [InlineData(null, TimeAccuracy.Hundredths, false, "-")]
         [InlineData("00:00:00", TimeAccuracy.Seconds, false, "+0")]
         [InlineData("00:00:01", TimeAccuracy.Seconds, false, "+1")]
         [InlineData("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
@@ -29,23 +41,30 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
         [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
-        public void TestDeltaTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expected)
+        public void DeltaTimeFormatterFormatsTimeInGivenAccuracy_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expectedDelta)
         {
-            var formatter = new DeltaTimeFormatter {
+            var sut = new DeltaTimeFormatter
+            {
                 Accuracy = timeAccuracy,
                 DropDecimals = dropDecimals
             };
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
+            var time = TimeSpan.Parse(timespanText);
 
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedDelta = sut.Format(time);
+            Assert.Equal(expectedDelta, formattedDelta);
+        }
+
+        [Fact]
+        public void DeltaComponentFormatterFormatsTimeAsDash_WhenTimeIsNullAndAccuracyIsInHundredths()
+        {
+            var sut = new DeltaComponentFormatter(TimeAccuracy.Hundredths, false);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
         }
 
         [Theory]
-        [InlineData(null, TimeAccuracy.Hundredths, false, "-")]
         [InlineData("00:00:00", TimeAccuracy.Seconds, false, "+0")]
         [InlineData("00:00:01", TimeAccuracy.Seconds, false, "+1")]
         [InlineData("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
@@ -59,20 +78,25 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
         [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
-        public void TestDeltaComponentFormatter(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expected)
+        public void DeltaComponentFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expectedDelta)
         {
-            var formatter = new DeltaComponentFormatter(timeAccuracy, dropDecimals: dropDecimals);
+            var sut = new DeltaComponentFormatter(timeAccuracy, dropDecimals: dropDecimals);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedDelta, formattedTime);
         }
 
+        [Fact]
+        public void DeltaSplitTimeFormatterFormatsTimeAsDash_WhenTimeIsNull()
+        {
+            var sut = new DeltaSplitTimeFormatter(TimeAccuracy.Hundredths, dropDecimals: false);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+        }
+        
         [Theory]
-        [InlineData(null, TimeAccuracy.Hundredths, false, "-")]
         [InlineData("00:00:00", TimeAccuracy.Seconds, false, "+0")]
         [InlineData("00:00:01", TimeAccuracy.Seconds, false, "+1")]
         [InlineData("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
@@ -86,20 +110,25 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
         [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
-        public void TestDeltaSplitTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expected) 
+        public void DeltaSplitTimeFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expectedDelta) 
         {
-            var formatter = new DeltaSplitTimeFormatter(timeAccuracy, dropDecimals: dropDecimals);
+            var sut = new DeltaSplitTimeFormatter(timeAccuracy, dropDecimals: dropDecimals);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedDelta, formattedTime);
         }
 
+        [Fact]
+        public void PreciseDeltaFormatterFormatTimeAsDash_WhenTimeIsNull()
+        {
+            var sut = new PreciseDeltaFormatter(TimeAccuracy.Hundredths);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+        }
+        
         [Theory]
-        [InlineData(null, TimeAccuracy.Hundredths, "-")]
         [InlineData("00:00:00", TimeAccuracy.Seconds, "+0")]
         [InlineData("00:00:01", TimeAccuracy.Seconds, "+1")]
         [InlineData("00:00:00.5", TimeAccuracy.Tenths, "+0.5")]
@@ -112,16 +141,13 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "+0.05")]
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, "+227:01:01.99")]
         [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, "−227:01:01.99")]
-        public void TestPreciseDeltaFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
+        public void PreciseDeltaFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, string expectedDelta)
         {
-            var formatter = new PreciseDeltaFormatter(timeAccuracy);
+            var sut = new PreciseDeltaFormatter(timeAccuracy);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedDelta, formattedTime);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DeltaTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DeltaTimeFormattersTests.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatterTests
 {
-    [TestClass]
     public class DeltaTimeFormattersTests 
     {
         // All these formatters (currently) give identical output:
@@ -15,21 +14,21 @@ namespace LiveSplit.Tests.TimeFormatterTests
 
         // note: dash (-) is used for null, and minus (−) for negatives
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Hundredths, false, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, false, "+0")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, false, "+1")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, false, "+1.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, false, "+1.0")]
-        [DataRow("-00:00:01.009", TimeAccuracy.Tenths, false, "−1.0")]
-        [DataRow("-00:05:01.999", TimeAccuracy.Tenths, false, "−5:01.9")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, false, "+5:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, false, "+1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, false, "+0.05")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
-        [DataRow("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Hundredths, false, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, false, "+0")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, false, "+1")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, false, "+1.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, false, "+1.0")]
+        [InlineData("-00:00:01.009", TimeAccuracy.Tenths, false, "−1.0")]
+        [InlineData("-00:05:01.999", TimeAccuracy.Tenths, false, "−5:01.9")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, false, "+5:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, false, "+1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, false, "+0.05")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
+        [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
         public void TestDeltaTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expected)
         {
             var formatter = new DeltaTimeFormatter {
@@ -42,24 +41,24 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Hundredths, false, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, false, "+0")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, false, "+1")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, false, "+1.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, false, "+1.0")]
-        [DataRow("-00:00:01.009", TimeAccuracy.Tenths, false, "−1.0")]
-        [DataRow("-00:05:01.999", TimeAccuracy.Tenths, false, "−5:01.9")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, false, "+5:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, false, "+1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, false, "+0.05")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
-        [DataRow("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Hundredths, false, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, false, "+0")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, false, "+1")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, false, "+1.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, false, "+1.0")]
+        [InlineData("-00:00:01.009", TimeAccuracy.Tenths, false, "−1.0")]
+        [InlineData("-00:05:01.999", TimeAccuracy.Tenths, false, "−5:01.9")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, false, "+5:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, false, "+1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, false, "+0.05")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
+        [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
         public void TestDeltaComponentFormatter(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expected)
         {
             var formatter = new DeltaComponentFormatter(timeAccuracy, dropDecimals: dropDecimals);
@@ -69,24 +68,24 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Hundredths, false, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, false, "+0")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, false, "+1")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, false, "+1.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, false, "+1.0")]
-        [DataRow("-00:00:01.009", TimeAccuracy.Tenths, false, "−1.0")]
-        [DataRow("-00:05:01.999", TimeAccuracy.Tenths, false, "−5:01.9")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, false, "+5:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, false, "+1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, false, "+0.05")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
-        [DataRow("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Hundredths, false, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, false, "+0")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, false, "+1")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, false, "+0.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, false, "+1.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, false, "+1.0")]
+        [InlineData("-00:00:01.009", TimeAccuracy.Tenths, false, "−1.0")]
+        [InlineData("-00:05:01.999", TimeAccuracy.Tenths, false, "−5:01.9")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, false, "+5:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, false, "+1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, false, "+0.05")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, false, "+227:01:01.99")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, true, "+227:01:01")]
+        [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, false, "−227:01:01.99")]
         public void TestDeltaSplitTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, bool dropDecimals, string expected) 
         {
             var formatter = new DeltaSplitTimeFormatter(timeAccuracy, dropDecimals: dropDecimals);
@@ -96,23 +95,23 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Hundredths, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "+0")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, "+1")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, "+0.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, "+1.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, "+1.0")]
-        [DataRow("-00:00:01.009", TimeAccuracy.Tenths, "−1.0")]
-        [DataRow("-00:05:01.999", TimeAccuracy.Tenths, "−5:01.9")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, "+5:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, "+1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, "+0.05")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, "+227:01:01.99")]
-        [DataRow("-9.11:01:01.999", TimeAccuracy.Hundredths, "−227:01:01.99")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Hundredths, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "+0")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, "+1")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, "+0.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, "+1.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, "+1.0")]
+        [InlineData("-00:00:01.009", TimeAccuracy.Tenths, "−1.0")]
+        [InlineData("-00:05:01.999", TimeAccuracy.Tenths, "−5:01.9")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, "+5:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, "+1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "+0.05")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, "+227:01:01.99")]
+        [InlineData("-9.11:01:01.999", TimeAccuracy.Hundredths, "−227:01:01.99")]
         public void TestPreciseDeltaFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
         {
             var formatter = new PreciseDeltaFormatter(timeAccuracy);
@@ -122,7 +121,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
@@ -1,70 +1,70 @@
 ﻿using System;
-using LiveSplit.TimeFormatters;
 using Xunit;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.Tests.TimeFormatTests
 {
     public class DigitsFormatTests
     {
         [Theory]
-        [InlineData("00:00:00", "0", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("00:00:00", "00", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("00:00:00", "0:00", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("00:00:00", "00:00", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("00:00:00", "0:00:00", DigitsFormat.SingleDigitHours)]
-        [InlineData("00:00:00", "00:00:00", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:00:00", DigitsFormat.SingleDigitSeconds, "0")]
+        [InlineData("00:00:00", DigitsFormat.DoubleDigitSeconds, "00")]
+        [InlineData("00:00:00", DigitsFormat.SingleDigitMinutes, "0:00")]
+        [InlineData("00:00:00", DigitsFormat.DoubleDigitMinutes, "00:00")]
+        [InlineData("00:00:00", DigitsFormat.SingleDigitHours, "0:00:00")]
+        [InlineData("00:00:00", DigitsFormat.DoubleDigitHours, "00:00:00")]
 
-        [InlineData("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
-        [InlineData("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:00:01", DigitsFormat.SingleDigitSeconds, "1")]
+        [InlineData("00:00:02", DigitsFormat.DoubleDigitSeconds, "02")]
+        [InlineData("00:00:03", DigitsFormat.SingleDigitMinutes, "0:03")]
+        [InlineData("00:00:04", DigitsFormat.DoubleDigitMinutes, "00:04")]
+        [InlineData("00:00:05", DigitsFormat.SingleDigitHours, "0:00:05")]
+        [InlineData("00:00:06", DigitsFormat.DoubleDigitHours, "00:00:06")]
 
-        [InlineData("00:00:12", "12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("00:00:34", "34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("00:00:56", "0:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("00:00:23", "00:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("00:00:45", "0:00:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("00:00:51", "00:00:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:00:12", DigitsFormat.SingleDigitSeconds, "12")]
+        [InlineData("00:00:34", DigitsFormat.DoubleDigitSeconds, "34")]
+        [InlineData("00:00:56", DigitsFormat.SingleDigitMinutes, "0:56")]
+        [InlineData("00:00:23", DigitsFormat.DoubleDigitMinutes, "00:23")]
+        [InlineData("00:00:45", DigitsFormat.SingleDigitHours, "0:00:45")]
+        [InlineData("00:00:51", DigitsFormat.DoubleDigitHours, "00:00:51")]
 
-        [InlineData("00:01:12", "1:12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("00:02:34", "2:34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("00:03:56", "3:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("00:04:23", "04:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("00:05:45", "0:05:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("00:06:51", "00:06:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:01:12", DigitsFormat.SingleDigitSeconds, "1:12")]
+        [InlineData("00:02:34", DigitsFormat.DoubleDigitSeconds, "2:34")]
+        [InlineData("00:03:56", DigitsFormat.SingleDigitMinutes, "3:56")]
+        [InlineData("00:04:23", DigitsFormat.DoubleDigitMinutes, "04:23")]
+        [InlineData("00:05:45", DigitsFormat.SingleDigitHours, "0:05:45")]
+        [InlineData("00:06:51", DigitsFormat.DoubleDigitHours, "00:06:51")]
 
-        [InlineData("00:51:12", "51:12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("00:42:34", "42:34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("00:33:56", "33:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("00:24:23", "24:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("00:15:45", "0:15:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("00:56:51", "00:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:51:12", DigitsFormat.SingleDigitSeconds, "51:12")]
+        [InlineData("00:42:34", DigitsFormat.DoubleDigitSeconds, "42:34")]
+        [InlineData("00:33:56", DigitsFormat.SingleDigitMinutes, "33:56")]
+        [InlineData("00:24:23", DigitsFormat.DoubleDigitMinutes, "24:23")]
+        [InlineData("00:15:45", DigitsFormat.SingleDigitHours, "0:15:45")]
+        [InlineData("00:56:51", DigitsFormat.DoubleDigitHours, "00:56:51")]
 
-        [InlineData("02:51:12", "2:51:12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("03:42:34", "3:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("04:33:56", "4:33:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("05:24:23", "5:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("01:15:45", "1:15:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("02:56:51", "02:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("02:51:12", DigitsFormat.SingleDigitSeconds, "2:51:12")]
+        [InlineData("03:42:34", DigitsFormat.DoubleDigitSeconds, "3:42:34")]
+        [InlineData("04:33:56", DigitsFormat.SingleDigitMinutes, "4:33:56")]
+        [InlineData("05:24:23", DigitsFormat.DoubleDigitMinutes, "5:24:23")]
+        [InlineData("01:15:45", DigitsFormat.SingleDigitHours, "1:15:45")]
+        [InlineData("02:56:51", DigitsFormat.DoubleDigitHours, "02:56:51")]
 
-        [InlineData("22:51:12", "22:51:12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("23:42:34", "23:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("14:33:56", "14:33:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("15:24:23", "15:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("21:15:45", "21:15:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("22:56:51", "22:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("22:51:12", DigitsFormat.SingleDigitSeconds, "22:51:12")]
+        [InlineData("23:42:34", DigitsFormat.DoubleDigitSeconds, "23:42:34")]
+        [InlineData("14:33:56", DigitsFormat.SingleDigitMinutes, "14:33:56")]
+        [InlineData("15:24:23", DigitsFormat.DoubleDigitMinutes, "15:24:23")]
+        [InlineData("21:15:45", DigitsFormat.SingleDigitHours, "21:15:45")]
+        [InlineData("22:56:51", DigitsFormat.DoubleDigitHours, "22:56:51")]
         
-        [InlineData("1:22:51:12", "46:51:12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("1:23:42:34", "47:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("1:14:33:56", "38:33:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("1:15:24:23", "39:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("1:21:15:45", "45:15:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("1:22:56:51", "46:56:51", DigitsFormat.DoubleDigitHours)]
-        public void ConvertToExpectedValue_WhenAValidTimespanTextIsFormatted(string timespanText, string expected, DigitsFormat format)
+        [InlineData("1:22:51:12", DigitsFormat.SingleDigitSeconds, "46:51:12")]
+        [InlineData("1:23:42:34", DigitsFormat.DoubleDigitSeconds, "47:42:34")]
+        [InlineData("1:14:33:56", DigitsFormat.SingleDigitMinutes, "38:33:56")]
+        [InlineData("1:15:24:23", DigitsFormat.DoubleDigitMinutes, "39:24:23")]
+        [InlineData("1:21:15:45", DigitsFormat.SingleDigitHours, "45:15:45")]
+        [InlineData("1:22:56:51", DigitsFormat.DoubleDigitHours, "46:56:51")]
+        public void ConvertToExpectedValue_WhenAValidTimespanTextIsFormatted(string timespanText, DigitsFormat format, string expectedTime)
         {
-            var formatter = new GeneralTimeFormatter
+            var sut = new GeneralTimeFormatter
             {
                 DigitsFormat = format,
                 Accuracy = TimeAccuracy.Seconds
@@ -72,17 +72,17 @@ namespace LiveSplit.Tests.TimeFormatTests
 
             var time = TimeSpan.Parse(timespanText);
 
-            var formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
         [Fact]
         public void ReturnDash_WhenFormattingNullTime()
         {
-            var formatter = new GeneralTimeFormatter();
+            var sut = new GeneralTimeFormatter();
 
-            var formatted = formatter.Format(null);
-            Assert.Equal(TimeFormatConstants.DASH, formatted);
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
         }
 
         [Theory]
@@ -92,13 +92,13 @@ namespace LiveSplit.Tests.TimeFormatTests
         public void ReturnExpectedValues_WhenFormattingNullTimeAndDeterminedNullFormatsAreExpected(
             NullFormat nullFormat, string expectedConversion)
         {
-            var formatter = new GeneralTimeFormatter
+            var sut = new GeneralTimeFormatter
             {
                 NullFormat = nullFormat
             };
 
-            var formatted = formatter.Format(null);
-            Assert.Equal(expectedConversion, formatted);
+            var formattedTime = sut.Format(null);
+            Assert.Equal(expectedConversion, formattedTime);
         }
 
         [Theory]
@@ -109,14 +109,14 @@ namespace LiveSplit.Tests.TimeFormatTests
         public void ReturnZeroWithCorrectAmountOfDecimals_WhenZeroWithAccuracyIsExpected(
             NullFormat nullFormat, TimeAccuracy accuracy, string expectedConversion)
         {
-            var formatter = new GeneralTimeFormatter
+            var sut = new GeneralTimeFormatter
             {
                 NullFormat = nullFormat,
                 Accuracy = accuracy
             };
 
-            var formatted = formatter.Format(null);
-            Assert.Equal(expectedConversion, formatted);
+            var formattedTime = sut.Format(null);
+            Assert.Equal(expectedConversion, formattedTime);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/DigitsFormatTests.cs
@@ -1,68 +1,67 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatTests
 {
-    [TestClass]
     public class DigitsFormatTests
     {
-        [TestMethod]
-        [DataRow("00:00:00", "0", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("00:00:00", "00", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("00:00:00", "0:00", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("00:00:00", "00:00", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("00:00:00", "0:00:00", DigitsFormat.SingleDigitHours)]
-        [DataRow("00:00:00", "00:00:00", DigitsFormat.DoubleDigitHours)]
+        [Theory]
+        [InlineData("00:00:00", "0", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("00:00:00", "00", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("00:00:00", "0:00", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("00:00:00", "00:00", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("00:00:00", "0:00:00", DigitsFormat.SingleDigitHours)]
+        [InlineData("00:00:00", "00:00:00", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
-        [DataRow("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
+        [InlineData("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("00:00:12", "12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("00:00:34", "34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("00:00:56", "0:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("00:00:23", "00:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("00:00:45", "0:00:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("00:00:51", "00:00:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:00:12", "12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("00:00:34", "34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("00:00:56", "0:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("00:00:23", "00:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("00:00:45", "0:00:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("00:00:51", "00:00:51", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("00:01:12", "1:12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("00:02:34", "2:34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("00:03:56", "3:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("00:04:23", "04:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("00:05:45", "0:05:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("00:06:51", "00:06:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:01:12", "1:12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("00:02:34", "2:34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("00:03:56", "3:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("00:04:23", "04:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("00:05:45", "0:05:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("00:06:51", "00:06:51", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("00:51:12", "51:12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("00:42:34", "42:34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("00:33:56", "33:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("00:24:23", "24:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("00:15:45", "0:15:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("00:56:51", "00:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:51:12", "51:12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("00:42:34", "42:34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("00:33:56", "33:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("00:24:23", "24:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("00:15:45", "0:15:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("00:56:51", "00:56:51", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("02:51:12", "2:51:12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("03:42:34", "3:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("04:33:56", "4:33:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("05:24:23", "5:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("01:15:45", "1:15:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("02:56:51", "02:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("02:51:12", "2:51:12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("03:42:34", "3:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("04:33:56", "4:33:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("05:24:23", "5:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("01:15:45", "1:15:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("02:56:51", "02:56:51", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("22:51:12", "22:51:12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("23:42:34", "23:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("14:33:56", "14:33:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("15:24:23", "15:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("21:15:45", "21:15:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("22:56:51", "22:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("22:51:12", "22:51:12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("23:42:34", "23:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("14:33:56", "14:33:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("15:24:23", "15:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("21:15:45", "21:15:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("22:56:51", "22:56:51", DigitsFormat.DoubleDigitHours)]
         
-        [DataRow("1:22:51:12", "46:51:12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("1:23:42:34", "47:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("1:14:33:56", "38:33:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("1:15:24:23", "39:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("1:21:15:45", "45:15:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("1:22:56:51", "46:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("1:22:51:12", "46:51:12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("1:23:42:34", "47:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("1:14:33:56", "38:33:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("1:15:24:23", "39:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("1:21:15:45", "45:15:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("1:22:56:51", "46:56:51", DigitsFormat.DoubleDigitHours)]
         public void ConvertToExpectedValue_WhenAValidTimespanTextIsFormatted(string timespanText, string expected, DigitsFormat format)
         {
             var formatter = new GeneralTimeFormatter
@@ -74,22 +73,22 @@ namespace LiveSplit.Tests.TimeFormatTests
             var time = TimeSpan.Parse(timespanText);
 
             var formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
+        [Fact]
         public void ReturnDash_WhenFormattingNullTime()
         {
             var formatter = new GeneralTimeFormatter();
 
             var formatted = formatter.Format(null);
-            Assert.AreEqual(TimeFormatConstants.DASH, formatted);
+            Assert.Equal(TimeFormatConstants.DASH, formatted);
         }
 
-        [TestMethod]
-        [DataRow(NullFormat.ZeroDotZeroZero, "0.00")]
-        [DataRow(NullFormat.ZeroValue, "0")]
-        [DataRow(NullFormat.Dashes, "-")]
+        [Theory]
+        [InlineData(NullFormat.ZeroDotZeroZero, "0.00")]
+        [InlineData(NullFormat.ZeroValue, "0")]
+        [InlineData(NullFormat.Dashes, "-")]
         public void ReturnExpectedValues_WhenFormattingNullTimeAndDeterminedNullFormatsAreExpected(
             NullFormat nullFormat, string expectedConversion)
         {
@@ -99,14 +98,14 @@ namespace LiveSplit.Tests.TimeFormatTests
             };
 
             var formatted = formatter.Format(null);
-            Assert.AreEqual(expectedConversion, formatted);
+            Assert.Equal(expectedConversion, formatted);
         }
 
-        [TestMethod]
-        [DataRow(NullFormat.ZeroWithAccuracy, TimeAccuracy.Seconds, "0")]
-        [DataRow(NullFormat.ZeroWithAccuracy, TimeAccuracy.Tenths, "0.0")]
-        [DataRow(NullFormat.ZeroWithAccuracy, TimeAccuracy.Hundredths, "0.00")]
-        [DataRow(NullFormat.ZeroWithAccuracy, TimeAccuracy.Milliseconds, "0.000")]
+        [Theory]
+        [InlineData(NullFormat.ZeroWithAccuracy, TimeAccuracy.Seconds, "0")]
+        [InlineData(NullFormat.ZeroWithAccuracy, TimeAccuracy.Tenths, "0.0")]
+        [InlineData(NullFormat.ZeroWithAccuracy, TimeAccuracy.Hundredths, "0.00")]
+        [InlineData(NullFormat.ZeroWithAccuracy, TimeAccuracy.Milliseconds, "0.000")]
         public void ReturnZeroWithCorrectAmountOfDecimals_WhenZeroWithAccuracyIsExpected(
             NullFormat nullFormat, TimeAccuracy accuracy, string expectedConversion)
         {
@@ -117,7 +116,7 @@ namespace LiveSplit.Tests.TimeFormatTests
             };
 
             var formatted = formatter.Format(null);
-            Assert.AreEqual(expectedConversion, formatted);
+            Assert.Equal(expectedConversion, formatted);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
@@ -14,9 +14,18 @@ namespace LiveSplit.Tests.TimeFormatterTests
         //new AutomaticPrecisionTimeFormatter(); // -> RegularTimeFormatter with changes
 
         [Theory]
-        [InlineData(null, TimeAccuracy.Seconds, "0")]
-        [InlineData(null, TimeAccuracy.Tenths, "0.0")]
-        [InlineData(null, TimeAccuracy.Hundredths, "0.00")]
+        [InlineData(TimeAccuracy.Seconds, "0")]
+        [InlineData(TimeAccuracy.Tenths, "0.0")]
+        [InlineData(TimeAccuracy.Hundredths, "0.00")]
+        public void RegularTimeFormatterFormatsTimeCorrectlyInGivenAccuracy_WhenTimeIsNull(TimeAccuracy timeAccuracy, string expectedTime)
+        {
+            var sut = new RegularTimeFormatter(timeAccuracy);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(expectedTime, formattedTime);
+        }
+        
+        [Theory]
         [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
         [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
         [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
@@ -31,23 +40,28 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
         [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, "227:01:01.99")]
         [InlineData("1.00:00:01.999", TimeAccuracy.Hundredths, "24:00:01.99")] 
-
-        public void TestRegularTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
+        public void RegularTimeFormatterFormatsTimeCorrectlyInGivenAccuracy_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, string expectedTime)
         {
-            var formatter = new RegularTimeFormatter(timeAccuracy);
+            var sut = new RegularTimeFormatter(timeAccuracy);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
         [Theory]
-        [InlineData(null, TimeAccuracy.Seconds, "-")]
-        [InlineData(null, TimeAccuracy.Tenths, "-")]
-        [InlineData(null, TimeAccuracy.Hundredths, "-")]
+        [InlineData(TimeAccuracy.Seconds)]
+        [InlineData(TimeAccuracy.Tenths)]
+        [InlineData(TimeAccuracy.Hundredths)]
+        public void RegularSplitTimeFormatterFormatsTimeAsDash_WhenTimeIsNullRegardlessOfAccuracy(TimeAccuracy timeAccuracy)
+        {
+            var sut = new RegularSplitTimeFormatter(timeAccuracy);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+        }
+
+        [Theory]
         [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
         [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
         [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
@@ -60,23 +74,28 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
         [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
         [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
-        public void TestRegularSplitTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
+        public void RegularSplitTimeFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, string expectedTime)
         {
-            var formatter = new RegularSplitTimeFormatter(timeAccuracy);
-
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var sut = new RegularSplitTimeFormatter(timeAccuracy);
+            var time = TimeSpan.Parse(timespanText);
+            
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
+        [Theory]
+        [InlineData(TimeAccuracy.Seconds)]
+        [InlineData(TimeAccuracy.Tenths)]
+        [InlineData(TimeAccuracy.Hundredths)]
+        public void RunPredictionFormatterFormatsTimeAsDash_WhenTimeIsNullRegardlessOfAccuracy(TimeAccuracy timeAccuracy)
+        {
+            var sut = new RunPredictionFormatter(timeAccuracy);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+        }
 
         [Theory]
-        [InlineData(null, TimeAccuracy.Seconds, "-")]
-        [InlineData(null, TimeAccuracy.Tenths, "-")]
-        [InlineData(null, TimeAccuracy.Hundredths, "-")]
         [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
         [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
         [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
@@ -89,22 +108,32 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
         [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
         [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
-        public void TestRunPredictionFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
+        public void RunPredictionFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, string expectedTime)
         {
-            var formatter = new RunPredictionFormatter(timeAccuracy);
+            var sut = new RunPredictionFormatter(timeAccuracy);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
         [Theory]
-        [InlineData(null, TimeAccuracy.Seconds, "-")]
-        [InlineData(null, TimeAccuracy.Tenths, "-")]
-        [InlineData(null, TimeAccuracy.Hundredths, "-")]
+        [InlineData(TimeAccuracy.Seconds)]
+        [InlineData(TimeAccuracy.Tenths)]
+        [InlineData(TimeAccuracy.Hundredths)]
+        public void RegularSumOfBestTimeFormatterFormatsTimeAsDash_WhenTimeIsNullRegardlessOfAccuracy(TimeAccuracy timeAccuracy)
+        {
+            var sut = new RegularSumOfBestTimeFormatter
+            {
+                Accuracy = timeAccuracy
+            };
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+
+        }
+
+        [Theory]
         [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
         [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
         [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
@@ -117,21 +146,29 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
         [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
         [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
-        public void TestRegularSumOfBestTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
+        public void RegularSumOfBestTimeFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, TimeAccuracy timeAccuracy, string expectedTime)
         {
-            var formatter = new RegularSumOfBestTimeFormatter();
-            formatter.Accuracy = timeAccuracy;
+            var sut = new RegularSumOfBestTimeFormatter
+            {
+                Accuracy = timeAccuracy
+            };
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
+            var time = TimeSpan.Parse(timespanText);
 
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
+        }
+
+        [Fact]
+        public void AutomaticPrecisionTimeFormatterFormatsTimeAsZero_WhenTimeIsNull()
+        {
+            var sut = new AutomaticPrecisionTimeFormatter();
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal("0", formattedTime);
         }
 
         [Theory]
-        [InlineData(null, "0")]
         [InlineData("00:00:00", "0:00")]
         [InlineData("00:00:01", "0:01")]
         [InlineData("00:00:02.0", "0:02")]
@@ -148,35 +185,28 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("00:05:01.999", "5:01.99")]
         [InlineData("00:25:01.999", "25:01.99")]
         [InlineData("00:10:00.006", "10:00.00")]
-        public void TestAutomaticPrecisionTimeFormatter(string timespanText, string expected)
+        public void AutomaticPrecisionTimeFormatterFormatsTimeCorrectly_WhenTimeIsValid(string timespanText, string expectedTime)
         {
-            var formatter = new AutomaticPrecisionTimeFormatter();
+            var sut = new AutomaticPrecisionTimeFormatter();
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
-        
         [Theory]
         [InlineData("-00:00:00.05", TimeAccuracy.Hundredths, "−0:00.05")] // Actual:<0:00.05> [Fail]
         [InlineData("-00:00:01.009", TimeAccuracy.Tenths, "−0:01.0")] // Actual:<0:01.0> [Fail]
         [InlineData("-00:05:01.999", TimeAccuracy.Tenths, "−5:01.9")] // Actual:<5:01.9> [Fail]
         [InlineData("-9.12:09:01.999", TimeAccuracy.Hundredths, "−228:09:01.99")] // Actual:<9:01.99> [Fail]
         [InlineData("-1.00:02:01.999", TimeAccuracy.Hundredths, "−24:02:01.99")] // Actual:<0:01.99> [Fail]
-        public void NegativesTestRegularTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
+        public void NegativesTestRegularTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expectedTime)
         {
             var formatter = new RegularTimeFormatter(timeAccuracy);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+            var formattedTime = formatter.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/RegularTimeFormattersTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatterTests
 {
-
-    [TestClass]
     public class RegularTimeFormattersTests
     {
         // These tests cover the following, which are/were all based on RegularTimeFormatter:
@@ -15,24 +13,24 @@ namespace LiveSplit.Tests.TimeFormatterTests
         //new RegularSumOfBestTimeFormatter(); // (Accuracy can be set but not in constructor)
         //new AutomaticPrecisionTimeFormatter(); // -> RegularTimeFormatter with changes
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Seconds, "0")]
-        [DataRow(null, TimeAccuracy.Tenths, "0.0")]
-        [DataRow(null, TimeAccuracy.Hundredths, "0.00")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "0:00")]
-        [DataRow("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
-        [DataRow("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, "0:01")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
-        [DataRow("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
-        [DataRow("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
-        [DataRow("9.11:01:01.999", TimeAccuracy.Hundredths, "227:01:01.99")]
-        [DataRow("1.00:00:01.999", TimeAccuracy.Hundredths, "24:00:01.99")] 
+        [Theory]
+        [InlineData(null, TimeAccuracy.Seconds, "0")]
+        [InlineData(null, TimeAccuracy.Tenths, "0.0")]
+        [InlineData(null, TimeAccuracy.Hundredths, "0.00")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, "0:01")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
+        [InlineData("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
+        [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
+        [InlineData("9.11:01:01.999", TimeAccuracy.Hundredths, "227:01:01.99")]
+        [InlineData("1.00:00:01.999", TimeAccuracy.Hundredths, "24:00:01.99")] 
 
         public void TestRegularTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
         {
@@ -43,25 +41,25 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Seconds, "-")]
-        [DataRow(null, TimeAccuracy.Tenths, "-")]
-        [DataRow(null, TimeAccuracy.Hundredths, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "0:00")]
-        [DataRow("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
-        [DataRow("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, "0:01")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
-        [DataRow("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
-        [DataRow("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Seconds, "-")]
+        [InlineData(null, TimeAccuracy.Tenths, "-")]
+        [InlineData(null, TimeAccuracy.Hundredths, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, "0:01")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
+        [InlineData("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
+        [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
         public void TestRegularSplitTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
         {
             var formatter = new RegularSplitTimeFormatter(timeAccuracy);
@@ -71,26 +69,26 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Seconds, "-")]
-        [DataRow(null, TimeAccuracy.Tenths, "-")]
-        [DataRow(null, TimeAccuracy.Hundredths, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "0:00")]
-        [DataRow("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
-        [DataRow("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, "0:01")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
-        [DataRow("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
-        [DataRow("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Seconds, "-")]
+        [InlineData(null, TimeAccuracy.Tenths, "-")]
+        [InlineData(null, TimeAccuracy.Hundredths, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, "0:01")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
+        [InlineData("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
+        [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
         public void TestRunPredictionFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
         {
             var formatter = new RunPredictionFormatter(timeAccuracy);
@@ -100,25 +98,25 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Seconds, "-")]
-        [DataRow(null, TimeAccuracy.Tenths, "-")]
-        [DataRow(null, TimeAccuracy.Hundredths, "-")]
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "0:00")]
-        [DataRow("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
-        [DataRow("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
-        [DataRow("00:00:01", TimeAccuracy.Seconds, "0:01")]
-        [DataRow("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
-        [DataRow("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
-        [DataRow("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
-        [DataRow("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
-        [DataRow("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
-        [DataRow("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
-        [DataRow("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Seconds, "-")]
+        [InlineData(null, TimeAccuracy.Tenths, "-")]
+        [InlineData(null, TimeAccuracy.Hundredths, "-")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0:00.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0:00.00")]
+        [InlineData("00:00:01", TimeAccuracy.Seconds, "0:01")]
+        [InlineData("00:00:00.5", TimeAccuracy.Tenths, "0:00.5")]
+        [InlineData("00:00:01.001", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:00:01.009", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:05:01.999", TimeAccuracy.Tenths, "5:01.9")]
+        [InlineData("00:25:01.999", TimeAccuracy.Tenths, "25:01.9")]
+        [InlineData("01:05:01.999", TimeAccuracy.Tenths, "1:05:01.9")]
+        [InlineData("00:00:00.05", TimeAccuracy.Hundredths, "0:00.05")]
+        [InlineData("00:10:00.006", TimeAccuracy.Hundredths, "10:00.00")]
         public void TestRegularSumOfBestTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
         {
             var formatter = new RegularSumOfBestTimeFormatter();
@@ -129,27 +127,27 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, "0")]
-        [DataRow("00:00:00", "0:00")]
-        [DataRow("00:00:01", "0:01")]
-        [DataRow("00:00:02.0", "0:02")]
-        [DataRow("00:00:03.00", "0:03")]
-        [DataRow("00:00:01.2", "0:01.2")]
-        [DataRow("00:00:01.20", "0:01.2")]
-        [DataRow("00:00:01.200", "0:01.2")]
-        [DataRow("00:00:01.23", "0:01.23")]
-        [DataRow("00:00:01.234", "0:01.23")]
-        [DataRow("00:00:01.2345", "0:01.23")]
-        [DataRow("00:00:01.2000", "0:01.2")]
-        [DataRow("00:00:01.204", "0:01.20")]
-        [DataRow("00:00:01.2005", "0:01.20")]
-        [DataRow("00:05:01.999", "5:01.99")]
-        [DataRow("00:25:01.999", "25:01.99")]
-        [DataRow("00:10:00.006", "10:00.00")]
+        [Theory]
+        [InlineData(null, "0")]
+        [InlineData("00:00:00", "0:00")]
+        [InlineData("00:00:01", "0:01")]
+        [InlineData("00:00:02.0", "0:02")]
+        [InlineData("00:00:03.00", "0:03")]
+        [InlineData("00:00:01.2", "0:01.2")]
+        [InlineData("00:00:01.20", "0:01.2")]
+        [InlineData("00:00:01.200", "0:01.2")]
+        [InlineData("00:00:01.23", "0:01.23")]
+        [InlineData("00:00:01.234", "0:01.23")]
+        [InlineData("00:00:01.2345", "0:01.23")]
+        [InlineData("00:00:01.2000", "0:01.2")]
+        [InlineData("00:00:01.204", "0:01.20")]
+        [InlineData("00:00:01.2005", "0:01.20")]
+        [InlineData("00:05:01.999", "5:01.99")]
+        [InlineData("00:25:01.999", "25:01.99")]
+        [InlineData("00:10:00.006", "10:00.00")]
         public void TestAutomaticPrecisionTimeFormatter(string timespanText, string expected)
         {
             var formatter = new AutomaticPrecisionTimeFormatter();
@@ -159,16 +157,16 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
         
-        [TestMethod]
-        [DataRow("-00:00:00.05", TimeAccuracy.Hundredths, "−0:00.05")] // Actual:<0:00.05> [Fail]
-        [DataRow("-00:00:01.009", TimeAccuracy.Tenths, "−0:01.0")] // Actual:<0:01.0> [Fail]
-        [DataRow("-00:05:01.999", TimeAccuracy.Tenths, "−5:01.9")] // Actual:<5:01.9> [Fail]
-        [DataRow("-9.12:09:01.999", TimeAccuracy.Hundredths, "−228:09:01.99")] // Actual:<9:01.99> [Fail]
-        [DataRow("-1.00:02:01.999", TimeAccuracy.Hundredths, "−24:02:01.99")] // Actual:<0:01.99> [Fail]
+        [Theory]
+        [InlineData("-00:00:00.05", TimeAccuracy.Hundredths, "−0:00.05")] // Actual:<0:00.05> [Fail]
+        [InlineData("-00:00:01.009", TimeAccuracy.Tenths, "−0:01.0")] // Actual:<0:01.0> [Fail]
+        [InlineData("-00:05:01.999", TimeAccuracy.Tenths, "−5:01.9")] // Actual:<5:01.9> [Fail]
+        [InlineData("-9.12:09:01.999", TimeAccuracy.Hundredths, "−228:09:01.99")] // Actual:<9:01.99> [Fail]
+        [InlineData("-1.00:02:01.999", TimeAccuracy.Hundredths, "−24:02:01.99")] // Actual:<0:01.99> [Fail]
         public void NegativesTestRegularTimeFormatter(string timespanText, TimeAccuracy timeAccuracy, string expected)
         {
             var formatter = new RegularTimeFormatter(timeAccuracy);
@@ -178,7 +176,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatterTests
 {
 
-    [TestClass]
     public class ShortTimeFormatterTests
     {
         // These tests cover the following, which are/were all based on ShortTimeFormatter 
@@ -13,14 +12,14 @@ namespace LiveSplit.Tests.TimeFormatterTests
         // new PossibleTimeSaveFormatter(); // ShortTimeFormatter with Accuracy
         // new SegmentTimesFormatter(timeAccuracy); // similar/same as PossibleTimeSaveFormatter
 
-        [TestMethod]
-        [DataRow(null, "0.00")]
-        [DataRow("00:00:00", "0.00")]
-        [DataRow("00:00:01.03", "1.03")]
-        [DataRow("00:05:01.03", "5:01.03")]
-        [DataRow("-00:05:01.03", "−5:01.03")]
-        [DataRow("07:05:01.03", "7:05:01.03")]
-        [DataRow("1.07:05:01.03", "31:05:01.03")]
+        [Theory]
+        [InlineData(null, "0.00")]
+        [InlineData("00:00:00", "0.00")]
+        [InlineData("00:00:01.03", "1.03")]
+        [InlineData("00:05:01.03", "5:01.03")]
+        [InlineData("-00:05:01.03", "−5:01.03")]
+        [InlineData("07:05:01.03", "7:05:01.03")]
+        [InlineData("1.07:05:01.03", "31:05:01.03")]
 
         public void TestShortTimeFormatter(string timespanText, string expected)
         {
@@ -31,48 +30,48 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
 
             // test if it's the same as using TimeFormat.Seconds too
             string formatted2 = formatter.Format(time, TimeFormat.Seconds);
-            Assert.AreEqual(formatted2, formatted);
+            Assert.Equal(formatted2, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeFormat.Seconds,  "0.00")] 
-        [DataRow(null, TimeFormat.Minutes,  "0.00")]
-        [DataRow(null, TimeFormat.Hours,    "0.00")]
-        [DataRow(null, TimeFormat.TenHours, "0.00")]
+        [Theory]
+        [InlineData(null, TimeFormat.Seconds,  "0.00")] 
+        [InlineData(null, TimeFormat.Minutes,  "0.00")]
+        [InlineData(null, TimeFormat.Hours,    "0.00")]
+        [InlineData(null, TimeFormat.TenHours, "0.00")]
 
-        [DataRow("00:00:00", TimeFormat.Seconds,         "0.00")]
-        [DataRow("00:00:00", TimeFormat.Minutes,     "00:00.00")]
-        [DataRow("00:00:00", TimeFormat.Hours,     "0:00:00.00")]
-        [DataRow("00:00:00", TimeFormat.TenHours, "00:00:00.00")]
+        [InlineData("00:00:00", TimeFormat.Seconds,         "0.00")]
+        [InlineData("00:00:00", TimeFormat.Minutes,     "00:00.00")]
+        [InlineData("00:00:00", TimeFormat.Hours,     "0:00:00.00")]
+        [InlineData("00:00:00", TimeFormat.TenHours, "00:00:00.00")]
 
-        [DataRow("00:00:01.03", TimeFormat.Seconds,         "1.03")]
-        [DataRow("00:00:01.03", TimeFormat.Minutes,     "00:01.03")]
-        [DataRow("00:00:01.03", TimeFormat.Hours,     "0:00:01.03")]
-        [DataRow("00:00:01.03", TimeFormat.TenHours, "00:00:01.03")]
+        [InlineData("00:00:01.03", TimeFormat.Seconds,         "1.03")]
+        [InlineData("00:00:01.03", TimeFormat.Minutes,     "00:01.03")]
+        [InlineData("00:00:01.03", TimeFormat.Hours,     "0:00:01.03")]
+        [InlineData("00:00:01.03", TimeFormat.TenHours, "00:00:01.03")]
 
-        [DataRow("00:05:01.03", TimeFormat.Seconds,      "5:01.03")]
-        [DataRow("00:05:01.03", TimeFormat.Minutes,     "05:01.03")]
-        [DataRow("00:05:01.03", TimeFormat.Hours,     "0:05:01.03")]
-        [DataRow("00:05:01.03", TimeFormat.TenHours, "00:05:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.Seconds,      "5:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.Minutes,     "05:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.Hours,     "0:05:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.TenHours, "00:05:01.03")]
 
-        [DataRow("-00:05:01.03", TimeFormat.Seconds,      "−5:01.03")]
-        [DataRow("-00:05:01.03", TimeFormat.Minutes,     "−05:01.03")]
-        [DataRow("-00:05:01.03", TimeFormat.Hours,     "−0:05:01.03")]
-        [DataRow("-00:05:01.03", TimeFormat.TenHours, "−00:05:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.Seconds,      "−5:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.Minutes,     "−05:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.Hours,     "−0:05:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.TenHours, "−00:05:01.03")]
 
-        [DataRow("07:05:01.03", TimeFormat.Seconds,   "7:05:01.03")]
-        [DataRow("07:05:01.03", TimeFormat.Minutes,   "7:05:01.03")]
-        [DataRow("07:05:01.03", TimeFormat.Hours,     "7:05:01.03")]
-        [DataRow("07:05:01.03", TimeFormat.TenHours, "07:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.Seconds,   "7:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.Minutes,   "7:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.Hours,     "7:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.TenHours, "07:05:01.03")]
 
-        [DataRow("1.07:05:01.03", TimeFormat.Seconds,  "31:05:01.03")]
-        [DataRow("1.07:05:01.03", TimeFormat.Minutes,  "31:05:01.03")]
-        [DataRow("1.07:05:01.03", TimeFormat.Hours,    "31:05:01.03")]
-        [DataRow("1.07:05:01.03", TimeFormat.TenHours, "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.Seconds,  "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.Minutes,  "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.Hours,    "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.TenHours, "31:05:01.03")]
         public void TestShortTimeFormatterWithTimeFormat(string timespanText, TimeFormat format, string expected)
         {
             var formatter = new ShortTimeFormatter();
@@ -82,44 +81,44 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time, format);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Seconds, "-")] 
-        [DataRow(null, TimeAccuracy.Tenths, "-")]
-        [DataRow(null, TimeAccuracy.Hundredths, "-")] 
+        [Theory]
+        [InlineData(null, TimeAccuracy.Seconds, "-")] 
+        [InlineData(null, TimeAccuracy.Tenths, "-")]
+        [InlineData(null, TimeAccuracy.Hundredths, "-")] 
 
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "0")]
-        [DataRow("00:00:00", TimeAccuracy.Tenths, "0.0")]
-        [DataRow("00:00:00", TimeAccuracy.Hundredths, "0.00")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0.00")]
         
-        [DataRow("00:05:01", TimeAccuracy.Seconds, "5:01")]
-        [DataRow("00:05:01.2", TimeAccuracy.Seconds, "5:01")]
-        [DataRow("00:05:01.02", TimeAccuracy.Seconds, "5:01")]
-        [DataRow("00:05:01.002", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.2", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.02", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.002", TimeAccuracy.Seconds, "5:01")]
 
-        [DataRow("00:05:01", TimeAccuracy.Tenths, "5:01.0")]
-        [DataRow("00:05:01.2", TimeAccuracy.Tenths, "5:01.2")]
-        [DataRow("00:05:01.02", TimeAccuracy.Tenths, "5:01.0")]
-        [DataRow("00:05:01.002", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01.2", TimeAccuracy.Tenths, "5:01.2")]
+        [InlineData("00:05:01.02", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01.002", TimeAccuracy.Tenths, "5:01.0")]
 
-        [DataRow("00:05:01", TimeAccuracy.Hundredths, "5:01.00")]
-        [DataRow("00:05:01.2", TimeAccuracy.Hundredths, "5:01.20")]
-        [DataRow("00:05:01.02", TimeAccuracy.Hundredths, "5:01.02")]
-        [DataRow("00:05:01.002", TimeAccuracy.Hundredths, "5:01.00")]
+        [InlineData("00:05:01", TimeAccuracy.Hundredths, "5:01.00")]
+        [InlineData("00:05:01.2", TimeAccuracy.Hundredths, "5:01.20")]
+        [InlineData("00:05:01.02", TimeAccuracy.Hundredths, "5:01.02")]
+        [InlineData("00:05:01.002", TimeAccuracy.Hundredths, "5:01.00")]
 
-        [DataRow("-00:05:01.03", TimeAccuracy.Seconds, "−5:01")]
-        [DataRow("-00:05:01.03", TimeAccuracy.Tenths, "−5:01.0")]
-        [DataRow("-00:05:01.03", TimeAccuracy.Hundredths, "−5:01.03")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Seconds, "−5:01")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Tenths, "−5:01.0")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Hundredths, "−5:01.03")]
 
-        [DataRow("07:05:01.29", TimeAccuracy.Seconds, "7:05:01")]
-        [DataRow("07:05:01.29", TimeAccuracy.Tenths, "7:05:01.2")]
-        [DataRow("07:05:01.29", TimeAccuracy.Hundredths, "7:05:01.29")]
+        [InlineData("07:05:01.29", TimeAccuracy.Seconds, "7:05:01")]
+        [InlineData("07:05:01.29", TimeAccuracy.Tenths, "7:05:01.2")]
+        [InlineData("07:05:01.29", TimeAccuracy.Hundredths, "7:05:01.29")]
 
-        [DataRow("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
-        [DataRow("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
-        [DataRow("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
         public void TestPossibleTimeSaveFormatter(string timespanText, TimeAccuracy accuracy, string expected)
         {
             var formatter = new PossibleTimeSaveFormatter();
@@ -130,44 +129,44 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
 
-        [TestMethod]
-        [DataRow(null, TimeAccuracy.Seconds, "-")]
-        [DataRow(null, TimeAccuracy.Tenths, "-")]
-        [DataRow(null, TimeAccuracy.Hundredths, "-")]
+        [Theory]
+        [InlineData(null, TimeAccuracy.Seconds, "-")]
+        [InlineData(null, TimeAccuracy.Tenths, "-")]
+        [InlineData(null, TimeAccuracy.Hundredths, "-")]
 
-        [DataRow("00:00:00", TimeAccuracy.Seconds, "0")]
-        [DataRow("00:00:00", TimeAccuracy.Tenths, "0.0")]
-        [DataRow("00:00:00", TimeAccuracy.Hundredths, "0.00")]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0.00")]
 
-        [DataRow("00:05:01", TimeAccuracy.Seconds, "5:01")]
-        [DataRow("00:05:01.2", TimeAccuracy.Seconds, "5:01")]
-        [DataRow("00:05:01.02", TimeAccuracy.Seconds, "5:01")]
-        [DataRow("00:05:01.002", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.2", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.02", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.002", TimeAccuracy.Seconds, "5:01")]
 
-        [DataRow("00:05:01", TimeAccuracy.Tenths, "5:01.0")]
-        [DataRow("00:05:01.2", TimeAccuracy.Tenths, "5:01.2")]
-        [DataRow("00:05:01.02", TimeAccuracy.Tenths, "5:01.0")]
-        [DataRow("00:05:01.002", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01.2", TimeAccuracy.Tenths, "5:01.2")]
+        [InlineData("00:05:01.02", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01.002", TimeAccuracy.Tenths, "5:01.0")]
 
-        [DataRow("00:05:01", TimeAccuracy.Hundredths, "5:01.00")]
-        [DataRow("00:05:01.2", TimeAccuracy.Hundredths, "5:01.20")]
-        [DataRow("00:05:01.02", TimeAccuracy.Hundredths, "5:01.02")]
-        [DataRow("00:05:01.002", TimeAccuracy.Hundredths, "5:01.00")]
+        [InlineData("00:05:01", TimeAccuracy.Hundredths, "5:01.00")]
+        [InlineData("00:05:01.2", TimeAccuracy.Hundredths, "5:01.20")]
+        [InlineData("00:05:01.02", TimeAccuracy.Hundredths, "5:01.02")]
+        [InlineData("00:05:01.002", TimeAccuracy.Hundredths, "5:01.00")]
 
-        [DataRow("-00:05:01.03", TimeAccuracy.Seconds, "−5:01")]
-        [DataRow("-00:05:01.03", TimeAccuracy.Tenths, "−5:01.0")]
-        [DataRow("-00:05:01.03", TimeAccuracy.Hundredths, "−5:01.03")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Seconds, "−5:01")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Tenths, "−5:01.0")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Hundredths, "−5:01.03")]
 
-        [DataRow("07:05:01.29", TimeAccuracy.Seconds, "7:05:01")]
-        [DataRow("07:05:01.29", TimeAccuracy.Tenths, "7:05:01.2")]
-        [DataRow("07:05:01.29", TimeAccuracy.Hundredths, "7:05:01.29")]
+        [InlineData("07:05:01.29", TimeAccuracy.Seconds, "7:05:01")]
+        [InlineData("07:05:01.29", TimeAccuracy.Tenths, "7:05:01.2")]
+        [InlineData("07:05:01.29", TimeAccuracy.Hundredths, "7:05:01.29")]
 
-        [DataRow("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
-        [DataRow("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
-        [DataRow("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
         public void TestSegmentTimesFormatter(string timespanText, TimeAccuracy accuracy, string expected)
         {
             var formatter = new SegmentTimesFormatter(accuracy);
@@ -177,7 +176,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
@@ -1,142 +1,132 @@
 ﻿using System;
-using LiveSplit.TimeFormatters;
 using Xunit;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.Tests.TimeFormatterTests
 {
-
     public class ShortTimeFormatterTests
     {
-        // These tests cover the following, which are/were all based on ShortTimeFormatter 
-        // new ShortTimeFormatter(); // Format() accepts a TimeFormat
-        // new PossibleTimeSaveFormatter(); // ShortTimeFormatter with Accuracy
-        // new SegmentTimesFormatter(timeAccuracy); // similar/same as PossibleTimeSaveFormatter
+        [Fact]
+        public void FormatsTimeCorrectly_WhenTimeIsNullAndNoFormatIsSupplied()
+        {
+            var sut = new ShortTimeFormatter();
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal("0.00", formattedTime);
+        }
+
+        [Fact]
+        public void FormatsTimeInSecondsByDefault_WhenTimeIsNullAndNoFormatIsSupplied()
+        {
+            var sut = new ShortTimeFormatter();
+            var defaultFormat = sut.Format(null);
+
+            var formattedValueInSeconds = sut.Format(null, TimeFormat.Seconds);
+            Assert.Equal(defaultFormat, formattedValueInSeconds);
+        }
 
         [Theory]
-        [InlineData(null, "0.00")]
         [InlineData("00:00:00", "0.00")]
         [InlineData("00:00:01.03", "1.03")]
         [InlineData("00:05:01.03", "5:01.03")]
         [InlineData("-00:05:01.03", "−5:01.03")]
         [InlineData("07:05:01.03", "7:05:01.03")]
         [InlineData("1.07:05:01.03", "31:05:01.03")]
-
-        public void TestShortTimeFormatter(string timespanText, string expected)
+        public void FormatsTimeCorrectly_WhenTimeIsValidAndNoFormatIsSupplied(string timespanText, string expectedTime)
         {
-            var formatter = new ShortTimeFormatter();
+            var sut = new ShortTimeFormatter();
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
-
-            // test if it's the same as using TimeFormat.Seconds too
-            string formatted2 = formatter.Format(time, TimeFormat.Seconds);
-            Assert.Equal(formatted2, formatted);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
 
         [Theory]
-        [InlineData(null, TimeFormat.Seconds,  "0.00")] 
-        [InlineData(null, TimeFormat.Minutes,  "0.00")]
-        [InlineData(null, TimeFormat.Hours,    "0.00")]
-        [InlineData(null, TimeFormat.TenHours, "0.00")]
+        [InlineData("00:00:00")]
+        [InlineData("00:00:01.03")]
+        [InlineData("00:05:01.03")]
+        [InlineData("-00:05:01.03")]
+        [InlineData("07:05:01.03")]
+        [InlineData("1.07:05:01.03")]
+        public void FormatsTimeInSecondsByDefault_WhenTimeIsValidAndNoFormatIsSupplied(string timespanText)
+        {
+            var sut = new ShortTimeFormatter();
+            var time = TimeSpan.Parse(timespanText);
 
-        [InlineData("00:00:00", TimeFormat.Seconds,         "0.00")]
-        [InlineData("00:00:00", TimeFormat.Minutes,     "00:00.00")]
-        [InlineData("00:00:00", TimeFormat.Hours,     "0:00:00.00")]
+            var defaultFormat = sut.Format(time);
+            var formattedTimeInSeconds = sut.Format(time, TimeFormat.Seconds);
+            Assert.Equal(defaultFormat, formattedTimeInSeconds);
+        }
+
+        [Theory]
+        [InlineData(TimeFormat.Seconds)]
+        [InlineData(TimeFormat.Minutes)]
+        [InlineData(TimeFormat.Hours)]
+        [InlineData(TimeFormat.TenHours)]
+        public void FormatsNullTimeInGivenFormatCorrectly(TimeFormat givenFormat)
+        {
+            var sut = new ShortTimeFormatter();
+
+            var formattedTime = sut.Format(null, givenFormat);
+            Assert.Equal("0.00", formattedTime);
+        }
+
+        [Theory]
+        [InlineData("00:00:00", TimeFormat.Seconds, "0.00")]
+        [InlineData("00:00:00", TimeFormat.Minutes, "00:00.00")]
+        [InlineData("00:00:00", TimeFormat.Hours, "0:00:00.00")]
         [InlineData("00:00:00", TimeFormat.TenHours, "00:00:00.00")]
 
-        [InlineData("00:00:01.03", TimeFormat.Seconds,         "1.03")]
-        [InlineData("00:00:01.03", TimeFormat.Minutes,     "00:01.03")]
-        [InlineData("00:00:01.03", TimeFormat.Hours,     "0:00:01.03")]
+        [InlineData("00:00:01.03", TimeFormat.Seconds, "1.03")]
+        [InlineData("00:00:01.03", TimeFormat.Minutes, "00:01.03")]
+        [InlineData("00:00:01.03", TimeFormat.Hours, "0:00:01.03")]
         [InlineData("00:00:01.03", TimeFormat.TenHours, "00:00:01.03")]
 
-        [InlineData("00:05:01.03", TimeFormat.Seconds,      "5:01.03")]
-        [InlineData("00:05:01.03", TimeFormat.Minutes,     "05:01.03")]
-        [InlineData("00:05:01.03", TimeFormat.Hours,     "0:05:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.Seconds, "5:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.Minutes, "05:01.03")]
+        [InlineData("00:05:01.03", TimeFormat.Hours, "0:05:01.03")]
         [InlineData("00:05:01.03", TimeFormat.TenHours, "00:05:01.03")]
 
-        [InlineData("-00:05:01.03", TimeFormat.Seconds,      "−5:01.03")]
-        [InlineData("-00:05:01.03", TimeFormat.Minutes,     "−05:01.03")]
-        [InlineData("-00:05:01.03", TimeFormat.Hours,     "−0:05:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.Seconds, "−5:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.Minutes, "−05:01.03")]
+        [InlineData("-00:05:01.03", TimeFormat.Hours, "−0:05:01.03")]
         [InlineData("-00:05:01.03", TimeFormat.TenHours, "−00:05:01.03")]
 
-        [InlineData("07:05:01.03", TimeFormat.Seconds,   "7:05:01.03")]
-        [InlineData("07:05:01.03", TimeFormat.Minutes,   "7:05:01.03")]
-        [InlineData("07:05:01.03", TimeFormat.Hours,     "7:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.Seconds, "7:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.Minutes, "7:05:01.03")]
+        [InlineData("07:05:01.03", TimeFormat.Hours, "7:05:01.03")]
         [InlineData("07:05:01.03", TimeFormat.TenHours, "07:05:01.03")]
 
-        [InlineData("1.07:05:01.03", TimeFormat.Seconds,  "31:05:01.03")]
-        [InlineData("1.07:05:01.03", TimeFormat.Minutes,  "31:05:01.03")]
-        [InlineData("1.07:05:01.03", TimeFormat.Hours,    "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.Seconds, "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.Minutes, "31:05:01.03")]
+        [InlineData("1.07:05:01.03", TimeFormat.Hours, "31:05:01.03")]
         [InlineData("1.07:05:01.03", TimeFormat.TenHours, "31:05:01.03")]
-        public void TestShortTimeFormatterWithTimeFormat(string timespanText, TimeFormat format, string expected)
+        public void FormatsTimeCorrectly_WhenTimeIsValidAndTimeFormatIsSupplied(string timespanText, TimeFormat format,
+            string expectedTime)
         {
-            var formatter = new ShortTimeFormatter();
+            var sut = new ShortTimeFormatter();
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
+            var formattedTime = sut.Format(time, format);
+            Assert.Equal(expectedTime, formattedTime);
+        }
+    }
 
-            string formatted = formatter.Format(time, format);
-            Assert.Equal(expected, formatted);
+    public class SegmentTimesFormatterShould
+    {
+        [Theory]
+        [InlineData(TimeAccuracy.Seconds)]
+        [InlineData(TimeAccuracy.Tenths)]
+        [InlineData(TimeAccuracy.Hundredths)]
+        public void FormatTimeAsDash_WhenTimeIsNullRegardlessOfAccuracy(TimeAccuracy accuracy)
+        {
+            var sut = new SegmentTimesFormatter(accuracy);
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
         }
 
         [Theory]
-        [InlineData(null, TimeAccuracy.Seconds, "-")] 
-        [InlineData(null, TimeAccuracy.Tenths, "-")]
-        [InlineData(null, TimeAccuracy.Hundredths, "-")] 
-
-        [InlineData("00:00:00", TimeAccuracy.Seconds, "0")]
-        [InlineData("00:00:00", TimeAccuracy.Tenths, "0.0")]
-        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0.00")]
-        
-        [InlineData("00:05:01", TimeAccuracy.Seconds, "5:01")]
-        [InlineData("00:05:01.2", TimeAccuracy.Seconds, "5:01")]
-        [InlineData("00:05:01.02", TimeAccuracy.Seconds, "5:01")]
-        [InlineData("00:05:01.002", TimeAccuracy.Seconds, "5:01")]
-
-        [InlineData("00:05:01", TimeAccuracy.Tenths, "5:01.0")]
-        [InlineData("00:05:01.2", TimeAccuracy.Tenths, "5:01.2")]
-        [InlineData("00:05:01.02", TimeAccuracy.Tenths, "5:01.0")]
-        [InlineData("00:05:01.002", TimeAccuracy.Tenths, "5:01.0")]
-
-        [InlineData("00:05:01", TimeAccuracy.Hundredths, "5:01.00")]
-        [InlineData("00:05:01.2", TimeAccuracy.Hundredths, "5:01.20")]
-        [InlineData("00:05:01.02", TimeAccuracy.Hundredths, "5:01.02")]
-        [InlineData("00:05:01.002", TimeAccuracy.Hundredths, "5:01.00")]
-
-        [InlineData("-00:05:01.03", TimeAccuracy.Seconds, "−5:01")]
-        [InlineData("-00:05:01.03", TimeAccuracy.Tenths, "−5:01.0")]
-        [InlineData("-00:05:01.03", TimeAccuracy.Hundredths, "−5:01.03")]
-
-        [InlineData("07:05:01.29", TimeAccuracy.Seconds, "7:05:01")]
-        [InlineData("07:05:01.29", TimeAccuracy.Tenths, "7:05:01.2")]
-        [InlineData("07:05:01.29", TimeAccuracy.Hundredths, "7:05:01.29")]
-
-        [InlineData("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
-        [InlineData("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
-        [InlineData("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
-        public void TestPossibleTimeSaveFormatter(string timespanText, TimeAccuracy accuracy, string expected)
-        {
-            var formatter = new PossibleTimeSaveFormatter();
-            formatter.Accuracy = accuracy;
-
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
-        }
-
-        [Theory]
-        [InlineData(null, TimeAccuracy.Seconds, "-")]
-        [InlineData(null, TimeAccuracy.Tenths, "-")]
-        [InlineData(null, TimeAccuracy.Hundredths, "-")]
-
         [InlineData("00:00:00", TimeAccuracy.Seconds, "0")]
         [InlineData("00:00:00", TimeAccuracy.Tenths, "0.0")]
         [InlineData("00:00:00", TimeAccuracy.Hundredths, "0.00")]
@@ -167,16 +157,76 @@ namespace LiveSplit.Tests.TimeFormatterTests
         [InlineData("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
         [InlineData("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
         [InlineData("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
-        public void TestSegmentTimesFormatter(string timespanText, TimeAccuracy accuracy, string expected)
+        public void FormatTimeCorrectly_WhenTimeIsValidAndAccuracyIsSupplied(string timespanText, TimeAccuracy accuracy, string expectedTime)
         {
-            var formatter = new SegmentTimesFormatter(accuracy);
+            var sut = new SegmentTimesFormatter(accuracy);
+            var time = TimeSpan.Parse(timespanText);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
+        }
+    }
 
-            string formatted = formatter.Format(time);
-            Assert.Equal(expected, formatted);
+    public class PossibleTimeSaveFormatterShould
+    {
+        [Theory]
+        [InlineData(TimeAccuracy.Seconds)]
+        [InlineData(TimeAccuracy.Tenths)]
+        [InlineData(TimeAccuracy.Hundredths)]
+        public void FormatTimeAsDash_WhenTimeIsNullRegardlessOfAccuracy(TimeAccuracy accuracy)
+        {
+            var sut = new PossibleTimeSaveFormatter
+            {
+                Accuracy = accuracy
+            };
+
+            var formattedTime = sut.Format(null);
+            Assert.Equal(TimeFormatConstants.DASH, formattedTime);
+        }
+
+        [Theory]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, "0.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, "0.00")]
+
+        [InlineData("00:05:01", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.2", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.02", TimeAccuracy.Seconds, "5:01")]
+        [InlineData("00:05:01.002", TimeAccuracy.Seconds, "5:01")]
+
+        [InlineData("00:05:01", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01.2", TimeAccuracy.Tenths, "5:01.2")]
+        [InlineData("00:05:01.02", TimeAccuracy.Tenths, "5:01.0")]
+        [InlineData("00:05:01.002", TimeAccuracy.Tenths, "5:01.0")]
+
+        [InlineData("00:05:01", TimeAccuracy.Hundredths, "5:01.00")]
+        [InlineData("00:05:01.2", TimeAccuracy.Hundredths, "5:01.20")]
+        [InlineData("00:05:01.02", TimeAccuracy.Hundredths, "5:01.02")]
+        [InlineData("00:05:01.002", TimeAccuracy.Hundredths, "5:01.00")]
+
+        [InlineData("-00:05:01.03", TimeAccuracy.Seconds, "−5:01")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Tenths, "−5:01.0")]
+        [InlineData("-00:05:01.03", TimeAccuracy.Hundredths, "−5:01.03")]
+
+        [InlineData("07:05:01.29", TimeAccuracy.Seconds, "7:05:01")]
+        [InlineData("07:05:01.29", TimeAccuracy.Tenths, "7:05:01.2")]
+        [InlineData("07:05:01.29", TimeAccuracy.Hundredths, "7:05:01.29")]
+
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Seconds, "31:05:01")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Tenths, "31:05:01.9")]
+        [InlineData("1.07:05:01.9999", TimeAccuracy.Hundredths, "31:05:01.99")]
+        public void FormatTimeCorrectly_WhenTimeIsValidAndAccuracyIsSupplied(string timespanText, TimeAccuracy accuracy,
+            string expectedTime)
+        {
+            var sut = new PossibleTimeSaveFormatter
+            {
+                Accuracy = accuracy
+            };
+
+            var time = TimeSpan.Parse(timespanText);
+
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using LiveSplit.TimeFormatters;
 using Xunit;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.Tests.TimeFormatTests
 {
@@ -29,9 +29,9 @@ namespace LiveSplit.Tests.TimeFormatTests
 
         [InlineData("-5:01:15:45", DigitsFormat.SingleDigitHours, "−5d 1:15:45")]
         [InlineData("-6:02:56:51", DigitsFormat.DoubleDigitHours, "−6d 02:56:51")]
-        public void FormatsTimespamCorrectly_WhenShowDaysIsTrue(string timespanText, DigitsFormat format, string expected)
+        public void FormatsTimCorrectly_WhenShowDaysIsTrue(string timespanText, DigitsFormat format, string expectedTime)
         {
-            var formatter = new GeneralTimeFormatter
+            var sut = new GeneralTimeFormatter
             {
                 DigitsFormat = format,
                 ShowDays = true,
@@ -39,9 +39,9 @@ namespace LiveSplit.Tests.TimeFormatTests
             };
 
             var time = TimeSpan.Parse(timespanText);
-            var formatted = formatter.Format(time);
+            var formattedTime = sut.Format(time);
 
-            Assert.Equal(expected, formatted);
+            Assert.Equal(expectedTime, formattedTime);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
@@ -1,35 +1,34 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatTests
 {
-    [TestClass]
     public class ShowDaysTests
     {
-        [TestMethod]
-        [DataRow("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
-        [DataRow("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
+        [Theory]
+        [InlineData("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
+        [InlineData("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("1:02:51:12", "1d 2:51:12", DigitsFormat.SingleDigitSeconds)]
-        [DataRow("1:03:42:34", "1d 3:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [DataRow("1:04:33:56", "1d 4:33:56", DigitsFormat.SingleDigitMinutes)]
-        [DataRow("1:05:24:23", "1d 5:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [DataRow("1:01:15:45", "1d 1:15:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("1:02:56:51", "1d 02:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("1:02:51:12", "1d 2:51:12", DigitsFormat.SingleDigitSeconds)]
+        [InlineData("1:03:42:34", "1d 3:42:34", DigitsFormat.DoubleDigitSeconds)]
+        [InlineData("1:04:33:56", "1d 4:33:56", DigitsFormat.SingleDigitMinutes)]
+        [InlineData("1:05:24:23", "1d 5:24:23", DigitsFormat.DoubleDigitMinutes)]
+        [InlineData("1:01:15:45", "1d 1:15:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("1:02:56:51", "1d 02:56:51", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("1:00:00:00", "1d 0:00:00", DigitsFormat.SingleDigitHours)]
-        [DataRow("3:00:00:00", "3d 00:00:00", DigitsFormat.DoubleDigitHours)]
+        [InlineData("1:00:00:00", "1d 0:00:00", DigitsFormat.SingleDigitHours)]
+        [InlineData("3:00:00:00", "3d 00:00:00", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("2:00:00:23", "2d 0:00:23", DigitsFormat.SingleDigitHours)]
-        [DataRow("4:00:00:23", "4d 00:00:23", DigitsFormat.DoubleDigitHours)]
+        [InlineData("2:00:00:23", "2d 0:00:23", DigitsFormat.SingleDigitHours)]
+        [InlineData("4:00:00:23", "4d 00:00:23", DigitsFormat.DoubleDigitHours)]
 
-        [DataRow("-5:01:15:45", "−5d 1:15:45", DigitsFormat.SingleDigitHours)]
-        [DataRow("-6:02:56:51", "−6d 02:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("-5:01:15:45", "−5d 1:15:45", DigitsFormat.SingleDigitHours)]
+        [InlineData("-6:02:56:51", "−6d 02:56:51", DigitsFormat.DoubleDigitHours)]
         public void TestShowDays(string timespanText, string expected, DigitsFormat format)
         {
             var formatter = new GeneralTimeFormatter();
@@ -42,7 +41,7 @@ namespace LiveSplit.Tests.TimeFormatTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShowDaysTests.cs
@@ -7,40 +7,40 @@ namespace LiveSplit.Tests.TimeFormatTests
     public class ShowDaysTests
     {
         [Theory]
-        [InlineData("00:00:01", "1", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("00:00:02", "02", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("00:00:03", "0:03", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("00:00:04", "00:04", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("00:00:05", "0:00:05", DigitsFormat.SingleDigitHours)]
-        [InlineData("00:00:06", "00:00:06", DigitsFormat.DoubleDigitHours)]
+        [InlineData("00:00:01", DigitsFormat.SingleDigitSeconds, "1")]
+        [InlineData("00:00:02", DigitsFormat.DoubleDigitSeconds, "02")]
+        [InlineData("00:00:03", DigitsFormat.SingleDigitMinutes, "0:03")]
+        [InlineData("00:00:04", DigitsFormat.DoubleDigitMinutes, "00:04")]
+        [InlineData("00:00:05", DigitsFormat.SingleDigitHours, "0:00:05")]
+        [InlineData("00:00:06", DigitsFormat.DoubleDigitHours, "00:00:06")]
 
-        [InlineData("1:02:51:12", "1d 2:51:12", DigitsFormat.SingleDigitSeconds)]
-        [InlineData("1:03:42:34", "1d 3:42:34", DigitsFormat.DoubleDigitSeconds)]
-        [InlineData("1:04:33:56", "1d 4:33:56", DigitsFormat.SingleDigitMinutes)]
-        [InlineData("1:05:24:23", "1d 5:24:23", DigitsFormat.DoubleDigitMinutes)]
-        [InlineData("1:01:15:45", "1d 1:15:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("1:02:56:51", "1d 02:56:51", DigitsFormat.DoubleDigitHours)]
+        [InlineData("1:02:51:12", DigitsFormat.SingleDigitSeconds, "1d 2:51:12")]
+        [InlineData("1:03:42:34", DigitsFormat.DoubleDigitSeconds, "1d 3:42:34")]
+        [InlineData("1:04:33:56", DigitsFormat.SingleDigitMinutes, "1d 4:33:56")]
+        [InlineData("1:05:24:23", DigitsFormat.DoubleDigitMinutes, "1d 5:24:23")]
+        [InlineData("1:01:15:45", DigitsFormat.SingleDigitHours, "1d 1:15:45")]
+        [InlineData("1:02:56:51", DigitsFormat.DoubleDigitHours, "1d 02:56:51")]
 
-        [InlineData("1:00:00:00", "1d 0:00:00", DigitsFormat.SingleDigitHours)]
-        [InlineData("3:00:00:00", "3d 00:00:00", DigitsFormat.DoubleDigitHours)]
+        [InlineData("1:00:00:00", DigitsFormat.SingleDigitHours, "1d 0:00:00")]
+        [InlineData("3:00:00:00", DigitsFormat.DoubleDigitHours, "3d 00:00:00")]
 
-        [InlineData("2:00:00:23", "2d 0:00:23", DigitsFormat.SingleDigitHours)]
-        [InlineData("4:00:00:23", "4d 00:00:23", DigitsFormat.DoubleDigitHours)]
+        [InlineData("2:00:00:23", DigitsFormat.SingleDigitHours, "2d 0:00:23")]
+        [InlineData("4:00:00:23", DigitsFormat.DoubleDigitHours, "4d 00:00:23")]
 
-        [InlineData("-5:01:15:45", "−5d 1:15:45", DigitsFormat.SingleDigitHours)]
-        [InlineData("-6:02:56:51", "−6d 02:56:51", DigitsFormat.DoubleDigitHours)]
-        public void TestShowDays(string timespanText, string expected, DigitsFormat format)
+        [InlineData("-5:01:15:45", DigitsFormat.SingleDigitHours, "−5d 1:15:45")]
+        [InlineData("-6:02:56:51", DigitsFormat.DoubleDigitHours, "−6d 02:56:51")]
+        public void FormatsTimespamCorrectly_WhenShowDaysIsTrue(string timespanText, DigitsFormat format, string expected)
         {
-            var formatter = new GeneralTimeFormatter();
-            formatter.DigitsFormat = format;
-            formatter.ShowDays = true;
-            formatter.Accuracy = TimeAccuracy.Seconds;
+            var formatter = new GeneralTimeFormatter
+            {
+                DigitsFormat = format,
+                ShowDays = true,
+                Accuracy = TimeAccuracy.Seconds
+            };
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
+            var time = TimeSpan.Parse(timespanText);
+            var formatted = formatter.Format(time);
 
-            string formatted = formatter.Format(time);
             Assert.Equal(expected, formatted);
         }
     }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
@@ -1,28 +1,26 @@
 ﻿using System;
 using LiveSplit.TimeFormatters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace LiveSplit.Tests.TimeFormatTests
 {
-    [TestClass]
     public class TimeAccuracyTests
     {
-        [TestMethod]
-        [DataRow("00:00:00", "0:00", TimeAccuracy.Seconds)]
-        [DataRow("00:00:01", "0:01.0", TimeAccuracy.Tenths)]
-        [DataRow("00:00:02", "0:02.00", TimeAccuracy.Hundredths)]
-        [DataRow("00:00:03", "0:03.000", TimeAccuracy.Milliseconds)]
+        [Theory]
+        [InlineData("00:00:00", "0:00", TimeAccuracy.Seconds)]
+        [InlineData("00:00:01", "0:01.0", TimeAccuracy.Tenths)]
+        [InlineData("00:00:02", "0:02.00", TimeAccuracy.Hundredths)]
+        [InlineData("00:00:03", "0:03.000", TimeAccuracy.Milliseconds)]
 
-        [DataRow("00:00:04", "0:04", TimeAccuracy.Seconds)]
-        [DataRow("00:00:05.2", "0:05.2", TimeAccuracy.Tenths)]
-        [DataRow("00:00:06.22", "0:06.22", TimeAccuracy.Hundredths)]
-        [DataRow("00:00:07.222", "0:07.222", TimeAccuracy.Milliseconds)]
+        [InlineData("00:00:04", "0:04", TimeAccuracy.Seconds)]
+        [InlineData("00:00:05.2", "0:05.2", TimeAccuracy.Tenths)]
+        [InlineData("00:00:06.22", "0:06.22", TimeAccuracy.Hundredths)]
+        [InlineData("00:00:07.222", "0:07.222", TimeAccuracy.Milliseconds)]
 
-        [DataRow("00:00:08.8888888", "0:08", TimeAccuracy.Seconds)]
-        [DataRow("00:00:09.8888888", "0:09.8", TimeAccuracy.Tenths)]
-        [DataRow("00:00:10.8888888", "0:10.88", TimeAccuracy.Hundredths)]
-        [DataRow("00:00:11.8888888", "0:11.888", TimeAccuracy.Milliseconds)]
-
+        [InlineData("00:00:08.8888888", "0:08", TimeAccuracy.Seconds)]
+        [InlineData("00:00:09.8888888", "0:09.8", TimeAccuracy.Tenths)]
+        [InlineData("00:00:10.8888888", "0:10.88", TimeAccuracy.Hundredths)]
+        [InlineData("00:00:11.8888888", "0:11.888", TimeAccuracy.Milliseconds)]
         public void TestTimeAccuracy(string timespanText, string expected, TimeAccuracy accuracy)
         {
             var formatter = new GeneralTimeFormatter();
@@ -34,7 +32,7 @@ namespace LiveSplit.Tests.TimeFormatTests
                 time = TimeSpan.Parse(timespanText);
 
             string formatted = formatter.Format(time);
-            Assert.AreEqual(expected, formatted);
+            Assert.Equal(expected, formatted);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using LiveSplit.TimeFormatters;
 using Xunit;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.Tests.TimeFormatTests
 {
@@ -21,17 +21,17 @@ namespace LiveSplit.Tests.TimeFormatTests
         [InlineData("00:00:09.8888888", TimeAccuracy.Tenths, "0:09.8")]
         [InlineData("00:00:10.8888888", TimeAccuracy.Hundredths, "0:10.88")]
         [InlineData("00:00:11.8888888", TimeAccuracy.Milliseconds, "0:11.888")]
-        public void FormatsTimespanCorrectly_WhenDeterminedAccuracyIsGiven(string timespanText, TimeAccuracy accuracy, string expected)
+        public void FormatsTimeCorrectly_WhenDeterminedAccuracyIsSupplied(string timespanText, TimeAccuracy accuracy, string expectedTime)
         {
-            var formatter = new GeneralTimeFormatter
+            var sut = new GeneralTimeFormatter
             {
                 DigitsFormat = DigitsFormat.SingleDigitMinutes,
                 Accuracy = accuracy
             };
             var time = TimeSpan.Parse(timespanText);
-            var formatted = formatter.Format(time);
+            var formattedTime = sut.Format(time);
 
-            Assert.Equal(expected, formatted);
+            Assert.Equal(expectedTime, formattedTime);
         }
     }
 }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/TimeAccuracyTests.cs
@@ -7,31 +7,30 @@ namespace LiveSplit.Tests.TimeFormatTests
     public class TimeAccuracyTests
     {
         [Theory]
-        [InlineData("00:00:00", "0:00", TimeAccuracy.Seconds)]
-        [InlineData("00:00:01", "0:01.0", TimeAccuracy.Tenths)]
-        [InlineData("00:00:02", "0:02.00", TimeAccuracy.Hundredths)]
-        [InlineData("00:00:03", "0:03.000", TimeAccuracy.Milliseconds)]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, "0:00")]
+        [InlineData("00:00:01", TimeAccuracy.Tenths, "0:01.0")]
+        [InlineData("00:00:02", TimeAccuracy.Hundredths, "0:02.00")]
+        [InlineData("00:00:03", TimeAccuracy.Milliseconds, "0:03.000")]
 
-        [InlineData("00:00:04", "0:04", TimeAccuracy.Seconds)]
-        [InlineData("00:00:05.2", "0:05.2", TimeAccuracy.Tenths)]
-        [InlineData("00:00:06.22", "0:06.22", TimeAccuracy.Hundredths)]
-        [InlineData("00:00:07.222", "0:07.222", TimeAccuracy.Milliseconds)]
+        [InlineData("00:00:04", TimeAccuracy.Seconds, "0:04")]
+        [InlineData("00:00:05.2", TimeAccuracy.Tenths, "0:05.2")]
+        [InlineData("00:00:06.22", TimeAccuracy.Hundredths, "0:06.22")]
+        [InlineData("00:00:07.222", TimeAccuracy.Milliseconds, "0:07.222")]
 
-        [InlineData("00:00:08.8888888", "0:08", TimeAccuracy.Seconds)]
-        [InlineData("00:00:09.8888888", "0:09.8", TimeAccuracy.Tenths)]
-        [InlineData("00:00:10.8888888", "0:10.88", TimeAccuracy.Hundredths)]
-        [InlineData("00:00:11.8888888", "0:11.888", TimeAccuracy.Milliseconds)]
-        public void TestTimeAccuracy(string timespanText, string expected, TimeAccuracy accuracy)
+        [InlineData("00:00:08.8888888", TimeAccuracy.Seconds, "0:08")]
+        [InlineData("00:00:09.8888888", TimeAccuracy.Tenths, "0:09.8")]
+        [InlineData("00:00:10.8888888", TimeAccuracy.Hundredths, "0:10.88")]
+        [InlineData("00:00:11.8888888", TimeAccuracy.Milliseconds, "0:11.888")]
+        public void FormatsTimespanCorrectly_WhenDeterminedAccuracyIsGiven(string timespanText, TimeAccuracy accuracy, string expected)
         {
-            var formatter = new GeneralTimeFormatter();
-            formatter.DigitsFormat = DigitsFormat.SingleDigitMinutes;
-            formatter.Accuracy = accuracy;
+            var formatter = new GeneralTimeFormatter
+            {
+                DigitsFormat = DigitsFormat.SingleDigitMinutes,
+                Accuracy = accuracy
+            };
+            var time = TimeSpan.Parse(timespanText);
+            var formatted = formatter.Format(time);
 
-            TimeSpan? time = null;
-            if (timespanText != null)
-                time = TimeSpan.Parse(timespanText);
-
-            string formatted = formatter.Format(time);
             Assert.Equal(expected, formatted);
         }
     }

--- a/LiveSplit/LiveSplit.Tests/packages.config
+++ b/LiveSplit/LiveSplit.Tests/packages.config
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net45" />
-  <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net45" />
+  <package id="xunit" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Unit testing overhaul

- migrated to Xunit framework (parallel test execution, NET Core compatibility, streamlined syntax, yaml still works as tests can be run with vstest)
- removed logic from tests by splitting null cases which forced branching to new tests (rationale: tests should have cyclomatic complexity of 1: no conditionals, no loops, every line of a test must be executed every time it runs)
- split multiple asserts in different tests (rationale: unit tests should test a single thing, once something is asserted no further actions other than assertions should be executed)
- moved parametrized expected value to the end of parameter list for consistence
- used DASH constant when required
- made test names more descriptive
- used object initialization and type inference when possible
- made subject under test clear by using SUT nomenclature (which will be more useful as tests become longer)

Also used class/method pair for naming tests in a couple of cases to see how people feel about it (ie: _SegmentTimesFormatterShould.FormatTimeAsDash_WhenTimeIsNullRegardlessOfAccuracy_). If people don't object I'll be renaming *Tests to *Should for humanized test names.

Unfortunately Live Unit Testing isn't working as _Codaxy.Xlio_ is a NET 3.5 project which calls _Sgen.exe_ (temporarily adjusting Framework version to 4.6.1 reveals the error), this happened even before the Xunit migration (I'm pretty much sure this could be compiled in 4.7.2 or even Core 3.1 if not for that assembly, ever tried that?).

Didn't modify _AutoSplitterXML.cs_ as it's not a unit test, it's an integration test which should be in a different test assembly (however since Live Unit Testing is not working it's not that much of a problem right now). I'll eventually refactor the test. I can also further refactor existing tests to minimize duplication of code, and start building more tests.

Any question / suggestion welcomed.