### PR TITLE
Dialogue Disposal Fix

### DIFF
--- a/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
@@ -261,12 +261,14 @@ namespace LiveSplit.View
 
         private void btnSetSize_Click(object sender, EventArgs e)
         {
-            var setSizeDialog = new SetSizeForm(CurrentState.Form);
-            var oldSize = CurrentState.Form.Size;
-            var result = setSizeDialog.ShowDialog();
+            using (var setSizeDialog = new SetSizeForm(CurrentState.Form))
+            {
+                var oldSize = CurrentState.Form.Size;
+                var result = setSizeDialog.ShowDialog();
 
-            if (result == DialogResult.Cancel)
-                CurrentState.Form.Size = oldSize;
+                if (result == DialogResult.Cancel)
+                    CurrentState.Form.Size = oldSize;
+            }   
         }
 
         private void lbxComponents_DoubleClick(object sender, EventArgs e)

--- a/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
@@ -228,26 +228,29 @@ namespace LiveSplit.View
             }
         }
 
-        private void ShowLayoutSettings(LiveSplit.UI.Components.IComponent tabControl = null)
+        private void ShowLayoutSettings(UI.Components.IComponent tabControl = null)
         {
             var oldSettings = (Options.LayoutSettings)Layout.Settings.Clone();
-            var settingsDialog = new LayoutSettingsDialog(Layout.Settings, Layout, tabControl);
-            var result = settingsDialog.ShowDialog(this);
-            if (result == DialogResult.OK)
+            using (var settingsDialog = new LayoutSettingsDialog(Layout.Settings, Layout, tabControl))
             {
-                if (oldSettings.BackgroundImage != null && oldSettings.BackgroundImage != Layout.Settings.BackgroundImage)
-                    ImagesToDispose.Add(oldSettings.BackgroundImage);
+                var result = settingsDialog.ShowDialog(this);
+                if (result == DialogResult.OK)
+                {
+                    if (oldSettings.BackgroundImage != null && oldSettings.BackgroundImage != Layout.Settings.BackgroundImage)
+                        ImagesToDispose.Add(oldSettings.BackgroundImage);
 
-                Layout.HasChanged = true;
-            }
-            else if (result == DialogResult.Cancel)
-            {
-                if (Layout.Settings.BackgroundImage != null && oldSettings.BackgroundImage != Layout.Settings.BackgroundImage)
-                    Layout.Settings.BackgroundImage.Dispose();
+                    Layout.HasChanged = true;
+                }
+                else if (result == DialogResult.Cancel)
+                {
+                    if (Layout.Settings.BackgroundImage != null && oldSettings.BackgroundImage != Layout.Settings.BackgroundImage)
+                        Layout.Settings.BackgroundImage.Dispose();
 
-                Layout.Settings.Assign(oldSettings);
-                LayoutSettingsAssigned(null, null);
+                    Layout.Settings.Assign(oldSettings);
+                    LayoutSettingsAssigned(null, null);
+                }
             }
+            
             BindingList.ResetBindings();
         }
 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -2487,33 +2487,36 @@ namespace LiveSplit.View
 
         private void settingsMenuItem_Click(object sender, EventArgs e)
         {
-            var editor = new SettingsDialog(Hook, Settings, CurrentState.CurrentHotkeyProfile);
-            editor.SumOfBestModeChanged += editor_SumOfBestModeChanged;
-            try
+            using (var editor = new SettingsDialog(Hook, Settings, CurrentState.CurrentHotkeyProfile))
             {
-                TopMost = false;
-                var oldSettings = (ISettings)Settings.Clone();
-                Settings.UnregisterAllHotkeys(Hook);
-                var result = editor.ShowDialog(this);
-                if (result == DialogResult.Cancel)
+                editor.SumOfBestModeChanged += editor_SumOfBestModeChanged;
+                try
                 {
-                    var regenerate = Settings.SimpleSumOfBest != oldSettings.SimpleSumOfBest;
-                    CurrentState.Settings = Settings = oldSettings;
-                    if (regenerate)
-                        RegenerateComparisons();
+                    TopMost = false;
+                    var oldSettings = (ISettings)Settings.Clone();
+                    Settings.UnregisterAllHotkeys(Hook);
+                    var result = editor.ShowDialog(this);
+                    if (result == DialogResult.Cancel)
+                    {
+                        var regenerate = Settings.SimpleSumOfBest != oldSettings.SimpleSumOfBest;
+                        CurrentState.Settings = Settings = oldSettings;
+                        if (regenerate)
+                            RegenerateComparisons();
+                    }
+                    else
+                    {
+                        SwitchComparisonGenerators();
+                        CurrentState.CurrentHotkeyProfile = editor.SelectedHotkeyProfile;
+                    }
+                    Settings.RegisterHotkeys(Hook, CurrentState.CurrentHotkeyProfile);
+                    UpdateRaceProviderIntegration();
                 }
-                else
+                finally
                 {
-                    SwitchComparisonGenerators();
-                    CurrentState.CurrentHotkeyProfile = editor.SelectedHotkeyProfile;
+                    editor.SumOfBestModeChanged -= editor_SumOfBestModeChanged;
+                    SetProgressBar();
+                    TopMost = Layout.Settings.AlwaysOnTop;
                 }
-                Settings.RegisterHotkeys(Hook, CurrentState.CurrentHotkeyProfile);
-                UpdateRaceProviderIntegration();
-            }
-            finally
-            {
-                SetProgressBar();
-                TopMost = Layout.Settings.AlwaysOnTop;
             }
         }
 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1970,34 +1970,40 @@ namespace LiveSplit.View
         {
             var runCopy = CurrentState.Run.Clone() as IRun;
             var activeAutoSplitters = new List<string>(CurrentState.Settings.ActiveAutoSplitters);
-            var editor = new RunEditorDialog(CurrentState);
-            editor.RunEdited += editor_RunEdited;
-            editor.ComparisonRenamed += editor_ComparisonRenamed;
-            editor.SegmentRemovedOrAdded += editor_SegmentRemovedOrAdded;
-            try
+            using (RunEditorDialog editor = new RunEditorDialog(CurrentState))
             {
-                TopMost = false;
-                IsInDialogMode = true;
-                if (CurrentState.CurrentPhase == TimerPhase.NotRunning)
-                    editor.AllowChangingSegments = true;
-                var result = editor.ShowDialog(this);
-                if (result == DialogResult.Cancel)
+                editor.RunEdited += editor_RunEdited;
+                editor.ComparisonRenamed += editor_ComparisonRenamed;
+                editor.SegmentRemovedOrAdded += editor_SegmentRemovedOrAdded;
+                try
                 {
-                    foreach (var image in runCopy.Select(x => x.Icon))
-                        editor.ImagesToDispose.Remove(image);
-                    editor.ImagesToDispose.Remove(runCopy.GameIcon);
+                    TopMost = false;
+                    IsInDialogMode = true;
+                    if (CurrentState.CurrentPhase == TimerPhase.NotRunning)
+                        editor.AllowChangingSegments = true;
+                    var result = editor.ShowDialog(this);
+                    if (result == DialogResult.Cancel)
+                    {
+                        foreach (var image in runCopy.Select(x => x.Icon))
+                            editor.ImagesToDispose.Remove(image);
+                        editor.ImagesToDispose.Remove(runCopy.GameIcon);
 
-                    CurrentState.Settings.ActiveAutoSplitters = activeAutoSplitters;
-                    SetRun(runCopy);
-                    CurrentState.CallRunManuallyModified();
+                        CurrentState.Settings.ActiveAutoSplitters = activeAutoSplitters;
+                        SetRun(runCopy);
+                        CurrentState.CallRunManuallyModified();
+                    }
+                    foreach (var image in editor.ImagesToDispose)
+                        image.Dispose();
                 }
-                foreach (var image in editor.ImagesToDispose)
-                    image.Dispose();
-            }
-            finally
-            {
-                TopMost = Layout.Settings.AlwaysOnTop;
-                IsInDialogMode = false;
+                finally
+                {
+                    TopMost = Layout.Settings.AlwaysOnTop;
+                    IsInDialogMode = false;
+
+                    editor.RunEdited -= editor_RunEdited;
+                    editor.ComparisonRenamed -= editor_ComparisonRenamed;
+                    editor.SegmentRemovedOrAdded -= editor_SegmentRemovedOrAdded;
+                }
             }
         }
 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -921,9 +921,12 @@ namespace LiveSplit.View
 
         void editSplitHistoryMenuItem_Click(object sender, EventArgs e)
         {
-            var editHistoryDialog = new EditHistoryDialog(Settings.RecentSplits.Select(x => x.Path));
-            if (editHistoryDialog.ShowDialog(this) != System.Windows.Forms.DialogResult.Cancel)
-                Settings.RecentSplits = new List<RecentSplitsFile>(Settings.RecentSplits.Where(x => editHistoryDialog.History.Contains(x.Path)));
+            using (var editHistoryDialog = new EditHistoryDialog(Settings.RecentSplits.Select(x => x.Path)))
+            {
+                if (editHistoryDialog.ShowDialog(this) != DialogResult.Cancel)
+                    Settings.RecentSplits = new List<RecentSplitsFile>(Settings.RecentSplits.Where(x => editHistoryDialog.History.Contains(x.Path)));
+            }
+
             UpdateRecentSplits();
         }
 
@@ -956,9 +959,12 @@ namespace LiveSplit.View
 
         void editLayoutHistoryMenuItem_Click(object sender, EventArgs e)
         {
-            var editHistoryDialog = new EditHistoryDialog(Settings.RecentLayouts);
-            if (editHistoryDialog.ShowDialog(this) != System.Windows.Forms.DialogResult.Cancel)
-                Settings.RecentLayouts = editHistoryDialog.History;
+            using (var editHistoryDialog = new EditHistoryDialog(Settings.RecentLayouts))
+            {
+
+                if (editHistoryDialog.ShowDialog(this) != System.Windows.Forms.DialogResult.Cancel)
+                    Settings.RecentLayouts = editHistoryDialog.History;
+            }
             UpdateRecentLayouts();
         }
 

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -2586,21 +2586,24 @@ namespace LiveSplit.View
 
         private void shareMenuItem_Click(object sender, EventArgs e)
         {
-            try
-            {
-                TopMost = false;
-                IsInDialogMode = true;
-                Settings.UnregisterAllHotkeys(Hook);
-                new ShareRunDialog(
-                    (LiveSplitState)(CurrentState.Clone()),
+            using (var dialog = new ShareRunDialog(
+                    (LiveSplitState)CurrentState.Clone(),
                     Settings,
-                    () => MakeScreenShot(false)).ShowDialog(this);
-                Settings.RegisterHotkeys(Hook, CurrentState.CurrentHotkeyProfile);
-            }
-            finally
+                    () => MakeScreenShot(false)))
             {
-                TopMost = Layout.Settings.AlwaysOnTop;
-                IsInDialogMode = false;
+                try
+                {
+                    TopMost = false;
+                    IsInDialogMode = true;
+                    Settings.UnregisterAllHotkeys(Hook);
+                    dialog.ShowDialog(this);
+                    Settings.RegisterHotkeys(Hook, CurrentState.CurrentHotkeyProfile);
+                }
+                finally
+                {
+                    TopMost = Layout.Settings.AlwaysOnTop;
+                    IsInDialogMode = false;
+                }
             }
         }
 


### PR DESCRIPTION
I noticed while digging around in the code that the program often neglects to actually dispose of certain forms after displaying them. I went through and added `using` statements to all such instances. Doing so seems to have improved memory usage. I also made it so all events on these dialogs are unsubscribed from before their disposal.