### PR TITLE
Secondary (or more?) Global Hotkeys

### DIFF
--- a/LiveSplit/LiveSplit.Core/Options/HotkeyProfile.cs
+++ b/LiveSplit/LiveSplit.Core/Options/HotkeyProfile.cs
@@ -8,6 +8,7 @@ namespace LiveSplit.Options
     public class HotkeyProfile : ICloneable
     {
         public KeyOrButton SplitKey { get; set; }
+        public KeyOrButton SecondarySplitKey { get; set; }
         public KeyOrButton ResetKey { get; set; }
         public KeyOrButton SkipKey { get; set; }
         public KeyOrButton UndoKey { get; set; }
@@ -33,6 +34,12 @@ namespace LiveSplit.Options
                 hotkeyProfile.SplitKey = new KeyOrButton(keyStart.InnerText);
             else
                 hotkeyProfile.SplitKey = null;
+
+            var secondaryKeyStart = element["SecondarySplitKey"];
+            if (!string.IsNullOrEmpty(secondaryKeyStart.InnerText))
+                hotkeyProfile.SecondarySplitKey = new KeyOrButton(secondaryKeyStart.InnerText);
+            else
+                hotkeyProfile.SecondarySplitKey = null;
 
             var keyReset = element["ResetKey"];
             if (!string.IsNullOrEmpty(keyReset.InnerText))
@@ -100,6 +107,11 @@ namespace LiveSplit.Options
                 splitKey.InnerText = SplitKey.ToString();
             parent.AppendChild(splitKey);
 
+            var secondarySplitKey = document.CreateElement("SecondarySplitKey");
+            if (SecondarySplitKey != null)
+                secondarySplitKey.InnerText = SecondarySplitKey.ToString();
+            parent.AppendChild(secondarySplitKey);
+
             var resetKey = document.CreateElement("ResetKey");
             if (ResetKey != null)
                 resetKey.InnerText = ResetKey.ToString();
@@ -149,6 +161,7 @@ namespace LiveSplit.Options
             return new HotkeyProfile()
             {
                 SplitKey = SplitKey,
+                SecondarySplitKey = SecondarySplitKey,
                 ResetKey = ResetKey,
                 SkipKey = SkipKey,
                 UndoKey = UndoKey,

--- a/LiveSplit/LiveSplit.Core/Options/Settings.cs
+++ b/LiveSplit/LiveSplit.Core/Options/Settings.cs
@@ -125,6 +125,17 @@ namespace LiveSplit.Options
                         Log.Error(e);
                     }
                 }
+                if (hotkeyProfile.SecondarySplitKey != null)
+                {
+                    try
+                    {
+                        RegisterHotkey(hook, hotkeyProfile.SecondarySplitKey, deactivateForOtherPrograms);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e);
+                    }
+                }
                 if (hotkeyProfile.ResetKey != null)
                 {
                     try

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
@@ -35,35 +35,6 @@
             this.label5 = new System.Windows.Forms.Label();
             this.btnLogOut = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.chkDeactivateForOtherPrograms = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.chkGlobalHotkeys = new System.Windows.Forms.CheckBox();
-            this.chkDoubleTap = new System.Windows.Forms.CheckBox();
-            this.txtStartSplit = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
-            this.txtReset = new System.Windows.Forms.TextBox();
-            this.txtPause = new System.Windows.Forms.TextBox();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.txtSkip = new System.Windows.Forms.TextBox();
-            this.txtUndo = new System.Windows.Forms.TextBox();
-            this.label7 = new System.Windows.Forms.Label();
-            this.txtToggle = new System.Windows.Forms.TextBox();
-            this.label8 = new System.Windows.Forms.Label();
-            this.label9 = new System.Windows.Forms.Label();
-            this.txtSwitchPrevious = new System.Windows.Forms.TextBox();
-            this.txtSwitchNext = new System.Windows.Forms.TextBox();
-            this.label10 = new System.Windows.Forms.Label();
-            this.txtDelay = new System.Windows.Forms.TextBox();
-            this.grpHotkeyProfiles = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.lblProfile = new System.Windows.Forms.Label();
-            this.cmbHotkeyProfiles = new System.Windows.Forms.ComboBox();
-            this.btnRemoveProfile = new System.Windows.Forms.Button();
-            this.btnRenameProfile = new System.Windows.Forms.Button();
-            this.btnNewProfile = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.cbxRaceViewer = new System.Windows.Forms.ComboBox();
             this.label11 = new System.Windows.Forms.Label();
@@ -73,11 +44,50 @@
             this.chkSimpleSOB = new System.Windows.Forms.CheckBox();
             this.chkWarnOnReset = new System.Windows.Forms.CheckBox();
             this.chkAllowGamepads = new System.Windows.Forms.CheckBox();
+            this.grpHotkeyProfiles = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.btnNewProfile = new System.Windows.Forms.Button();
+            this.btnRenameProfile = new System.Windows.Forms.Button();
+            this.btnRemoveProfile = new System.Windows.Forms.Button();
+            this.cmbHotkeyProfiles = new System.Windows.Forms.ComboBox();
+            this.lblProfile = new System.Windows.Forms.Label();
+            this.txtDelay = new System.Windows.Forms.TextBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.txtSwitchNext = new System.Windows.Forms.TextBox();
+            this.txtSwitchPrevious = new System.Windows.Forms.TextBox();
+            this.label9 = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
+            this.txtToggle = new System.Windows.Forms.TextBox();
+            this.label7 = new System.Windows.Forms.Label();
+            this.txtUndo = new System.Windows.Forms.TextBox();
+            this.txtSkip = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.txtPause = new System.Windows.Forms.TextBox();
+            this.txtReset = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.txtStartSplit = new System.Windows.Forms.TextBox();
+            this.chkDoubleTap = new System.Windows.Forms.CheckBox();
+            this.chkGlobalHotkeys = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.chkDeactivateForOtherPrograms = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+            this.txtSecondarySplit = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
             this.grpHotkeyProfiles.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.tableLayoutPanel4.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -101,7 +111,7 @@
             this.tableLayoutPanel1.Controls.Add(this.chkSimpleSOB, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.chkWarnOnReset, 1, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 7;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -173,371 +183,6 @@
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Hotkeys";
-            // 
-            // tableLayoutPanel2
-            // 
-            this.tableLayoutPanel2.ColumnCount = 3;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 178F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 56F));
-            this.tableLayoutPanel2.Controls.Add(this.chkDeactivateForOtherPrograms, 1, 8);
-            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.chkGlobalHotkeys, 0, 8);
-            this.tableLayoutPanel2.Controls.Add(this.chkDoubleTap, 0, 9);
-            this.tableLayoutPanel2.Controls.Add(this.txtStartSplit, 1, 0);
-            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.label6, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.txtReset, 1, 1);
-            this.tableLayoutPanel2.Controls.Add(this.txtPause, 1, 4);
-            this.tableLayoutPanel2.Controls.Add(this.label3, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.txtSkip, 1, 3);
-            this.tableLayoutPanel2.Controls.Add(this.txtUndo, 1, 2);
-            this.tableLayoutPanel2.Controls.Add(this.label7, 0, 7);
-            this.tableLayoutPanel2.Controls.Add(this.txtToggle, 1, 7);
-            this.tableLayoutPanel2.Controls.Add(this.label8, 0, 5);
-            this.tableLayoutPanel2.Controls.Add(this.label9, 0, 6);
-            this.tableLayoutPanel2.Controls.Add(this.txtSwitchPrevious, 1, 5);
-            this.tableLayoutPanel2.Controls.Add(this.txtSwitchNext, 1, 6);
-            this.tableLayoutPanel2.Controls.Add(this.label10, 1, 9);
-            this.tableLayoutPanel2.Controls.Add(this.txtDelay, 2, 9);
-            this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 11);
-            this.tableLayoutPanel2.Controls.Add(this.chkAllowGamepads, 0, 10);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 12;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 402);
-            this.tableLayoutPanel2.TabIndex = 0;
-            // 
-            // chkDeactivateForOtherPrograms
-            // 
-            this.chkDeactivateForOtherPrograms.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
-            this.chkDeactivateForOtherPrograms.AutoSize = true;
-            this.tableLayoutPanel2.SetColumnSpan(this.chkDeactivateForOtherPrograms, 2);
-            this.chkDeactivateForOtherPrograms.Location = new System.Drawing.Point(185, 235);
-            this.chkDeactivateForOtherPrograms.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkDeactivateForOtherPrograms.Name = "chkDeactivateForOtherPrograms";
-            this.chkDeactivateForOtherPrograms.Size = new System.Drawing.Size(172, 23);
-            this.chkDeactivateForOtherPrograms.TabIndex = 10;
-            this.chkDeactivateForOtherPrograms.Text = "Deactivate For Other Programs";
-            this.chkDeactivateForOtherPrograms.UseVisualStyleBackColor = true;
-            // 
-            // label1
-            // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 8);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(172, 13);
-            this.label1.TabIndex = 4;
-            this.label1.Text = "Start / Split:";
-            // 
-            // chkGlobalHotkeys
-            // 
-            this.chkGlobalHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
-            this.chkGlobalHotkeys.AutoSize = true;
-            this.chkGlobalHotkeys.Location = new System.Drawing.Point(7, 235);
-            this.chkGlobalHotkeys.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkGlobalHotkeys.Name = "chkGlobalHotkeys";
-            this.chkGlobalHotkeys.Size = new System.Drawing.Size(98, 23);
-            this.chkGlobalHotkeys.TabIndex = 9;
-            this.chkGlobalHotkeys.Text = "Global Hotkeys";
-            this.chkGlobalHotkeys.UseVisualStyleBackColor = true;
-            this.chkGlobalHotkeys.CheckedChanged += new System.EventHandler(this.chkGlobalHotkeys_CheckedChanged);
-            // 
-            // chkDoubleTap
-            // 
-            this.chkDoubleTap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkDoubleTap.AutoSize = true;
-            this.chkDoubleTap.Location = new System.Drawing.Point(7, 267);
-            this.chkDoubleTap.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
-            this.chkDoubleTap.Name = "chkDoubleTap";
-            this.chkDoubleTap.Size = new System.Drawing.Size(168, 17);
-            this.chkDoubleTap.TabIndex = 11;
-            this.chkDoubleTap.Text = "Double Tap Prevention";
-            this.chkDoubleTap.UseVisualStyleBackColor = true;
-            // 
-            // txtStartSplit
-            // 
-            this.txtStartSplit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtStartSplit, 2);
-            this.txtStartSplit.Location = new System.Drawing.Point(181, 4);
-            this.txtStartSplit.Name = "txtStartSplit";
-            this.txtStartSplit.ReadOnly = true;
-            this.txtStartSplit.Size = new System.Drawing.Size(184, 20);
-            this.txtStartSplit.TabIndex = 1;
-            this.txtStartSplit.Enter += new System.EventHandler(this.Split_Set_Enter);
-            // 
-            // label2
-            // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 37);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(172, 13);
-            this.label2.TabIndex = 5;
-            this.label2.Text = "Reset:";
-            // 
-            // label6
-            // 
-            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(3, 124);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(172, 13);
-            this.label6.TabIndex = 8;
-            this.label6.Text = "Pause:";
-            // 
-            // txtReset
-            // 
-            this.txtReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtReset, 2);
-            this.txtReset.Location = new System.Drawing.Point(181, 33);
-            this.txtReset.Name = "txtReset";
-            this.txtReset.ReadOnly = true;
-            this.txtReset.Size = new System.Drawing.Size(184, 20);
-            this.txtReset.TabIndex = 2;
-            this.txtReset.Enter += new System.EventHandler(this.Reset_Set_Enter);
-            // 
-            // txtPause
-            // 
-            this.txtPause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtPause, 2);
-            this.txtPause.Location = new System.Drawing.Point(181, 120);
-            this.txtPause.Name = "txtPause";
-            this.txtPause.ReadOnly = true;
-            this.txtPause.Size = new System.Drawing.Size(184, 20);
-            this.txtPause.TabIndex = 5;
-            this.txtPause.Enter += new System.EventHandler(this.Pause_Set_Enter);
-            // 
-            // label3
-            // 
-            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 95);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(172, 13);
-            this.label3.TabIndex = 6;
-            this.label3.Text = "Skip Split:";
-            // 
-            // label4
-            // 
-            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 66);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(172, 13);
-            this.label4.TabIndex = 7;
-            this.label4.Text = "Undo Split:";
-            // 
-            // txtSkip
-            // 
-            this.txtSkip.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtSkip, 2);
-            this.txtSkip.Location = new System.Drawing.Point(181, 91);
-            this.txtSkip.Name = "txtSkip";
-            this.txtSkip.ReadOnly = true;
-            this.txtSkip.Size = new System.Drawing.Size(184, 20);
-            this.txtSkip.TabIndex = 4;
-            this.txtSkip.Enter += new System.EventHandler(this.Skip_Set_Enter);
-            // 
-            // txtUndo
-            // 
-            this.txtUndo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtUndo, 2);
-            this.txtUndo.Location = new System.Drawing.Point(181, 62);
-            this.txtUndo.Name = "txtUndo";
-            this.txtUndo.ReadOnly = true;
-            this.txtUndo.Size = new System.Drawing.Size(184, 20);
-            this.txtUndo.TabIndex = 3;
-            this.txtUndo.Enter += new System.EventHandler(this.Undo_Set_Enter);
-            // 
-            // label7
-            // 
-            this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 211);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(172, 13);
-            this.label7.TabIndex = 9;
-            this.label7.Text = "Toggle Global Hotkeys:";
-            // 
-            // txtToggle
-            // 
-            this.txtToggle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtToggle, 2);
-            this.txtToggle.Location = new System.Drawing.Point(181, 207);
-            this.txtToggle.Name = "txtToggle";
-            this.txtToggle.ReadOnly = true;
-            this.txtToggle.Size = new System.Drawing.Size(184, 20);
-            this.txtToggle.TabIndex = 8;
-            this.txtToggle.Enter += new System.EventHandler(this.Toggle_Set_Enter);
-            // 
-            // label8
-            // 
-            this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(3, 153);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(172, 13);
-            this.label8.TabIndex = 10;
-            this.label8.Text = "Switch Comparison (Previous):";
-            // 
-            // label9
-            // 
-            this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(3, 182);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(172, 13);
-            this.label9.TabIndex = 12;
-            this.label9.Text = "Switch Comparison (Next):";
-            // 
-            // txtSwitchPrevious
-            // 
-            this.txtSwitchPrevious.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchPrevious, 2);
-            this.txtSwitchPrevious.Location = new System.Drawing.Point(181, 149);
-            this.txtSwitchPrevious.Name = "txtSwitchPrevious";
-            this.txtSwitchPrevious.ReadOnly = true;
-            this.txtSwitchPrevious.Size = new System.Drawing.Size(184, 20);
-            this.txtSwitchPrevious.TabIndex = 6;
-            this.txtSwitchPrevious.Enter += new System.EventHandler(this.Switch_Previous_Set_Enter);
-            // 
-            // txtSwitchNext
-            // 
-            this.txtSwitchNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchNext, 2);
-            this.txtSwitchNext.Location = new System.Drawing.Point(181, 178);
-            this.txtSwitchNext.Name = "txtSwitchNext";
-            this.txtSwitchNext.ReadOnly = true;
-            this.txtSwitchNext.Size = new System.Drawing.Size(184, 20);
-            this.txtSwitchNext.TabIndex = 7;
-            this.txtSwitchNext.Enter += new System.EventHandler(this.Switch_Next_Set_Enter);
-            // 
-            // label10
-            // 
-            this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(181, 269);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(128, 13);
-            this.label10.TabIndex = 14;
-            this.label10.Text = "Hotkey Delay (Seconds):";
-            // 
-            // txtDelay
-            // 
-            this.txtDelay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtDelay.Location = new System.Drawing.Point(315, 265);
-            this.txtDelay.Name = "txtDelay";
-            this.txtDelay.Size = new System.Drawing.Size(50, 20);
-            this.txtDelay.TabIndex = 12;
-            this.txtDelay.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            // 
-            // grpHotkeyProfiles
-            // 
-            this.tableLayoutPanel2.SetColumnSpan(this.grpHotkeyProfiles, 3);
-            this.grpHotkeyProfiles.Controls.Add(this.tableLayoutPanel3);
-            this.grpHotkeyProfiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 322);
-            this.grpHotkeyProfiles.Name = "grpHotkeyProfiles";
-            this.grpHotkeyProfiles.Size = new System.Drawing.Size(362, 77);
-            this.grpHotkeyProfiles.TabIndex = 13;
-            this.grpHotkeyProfiles.TabStop = false;
-            this.grpHotkeyProfiles.Text = "Hotkey Profiles";
-            // 
-            // tableLayoutPanel3
-            // 
-            this.tableLayoutPanel3.ColumnCount = 4;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 89.11917F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 10.88083F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 81F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 82F));
-            this.tableLayoutPanel3.Controls.Add(this.lblProfile, 0, 0);
-            this.tableLayoutPanel3.Controls.Add(this.cmbHotkeyProfiles, 1, 0);
-            this.tableLayoutPanel3.Controls.Add(this.btnRemoveProfile, 3, 1);
-            this.tableLayoutPanel3.Controls.Add(this.btnRenameProfile, 2, 1);
-            this.tableLayoutPanel3.Controls.Add(this.btnNewProfile, 0, 1);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 2;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(356, 58);
-            this.tableLayoutPanel3.TabIndex = 0;
-            // 
-            // lblProfile
-            // 
-            this.lblProfile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.lblProfile.AutoSize = true;
-            this.lblProfile.Location = new System.Drawing.Point(3, 8);
-            this.lblProfile.Name = "lblProfile";
-            this.lblProfile.Size = new System.Drawing.Size(166, 13);
-            this.lblProfile.TabIndex = 0;
-            this.lblProfile.Text = "Active Hotkey Profile:";
-            // 
-            // cmbHotkeyProfiles
-            // 
-            this.cmbHotkeyProfiles.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanel3.SetColumnSpan(this.cmbHotkeyProfiles, 3);
-            this.cmbHotkeyProfiles.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbHotkeyProfiles.FormattingEnabled = true;
-            this.cmbHotkeyProfiles.Location = new System.Drawing.Point(175, 4);
-            this.cmbHotkeyProfiles.Name = "cmbHotkeyProfiles";
-            this.cmbHotkeyProfiles.Size = new System.Drawing.Size(178, 21);
-            this.cmbHotkeyProfiles.TabIndex = 0;
-            this.cmbHotkeyProfiles.SelectedIndexChanged += new System.EventHandler(this.cmbHotkeyProfiles_SelectedIndexChanged);
-            // 
-            // btnRemoveProfile
-            // 
-            this.btnRemoveProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnRemoveProfile.Location = new System.Drawing.Point(278, 32);
-            this.btnRemoveProfile.Name = "btnRemoveProfile";
-            this.btnRemoveProfile.Size = new System.Drawing.Size(75, 23);
-            this.btnRemoveProfile.TabIndex = 3;
-            this.btnRemoveProfile.Text = "Remove";
-            this.btnRemoveProfile.UseVisualStyleBackColor = true;
-            this.btnRemoveProfile.Click += new System.EventHandler(this.btnRemoveProfile_Click);
-            // 
-            // btnRenameProfile
-            // 
-            this.btnRenameProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnRenameProfile.Location = new System.Drawing.Point(196, 32);
-            this.btnRenameProfile.Name = "btnRenameProfile";
-            this.btnRenameProfile.Size = new System.Drawing.Size(75, 23);
-            this.btnRenameProfile.TabIndex = 2;
-            this.btnRenameProfile.Text = "Rename";
-            this.btnRenameProfile.UseVisualStyleBackColor = true;
-            this.btnRenameProfile.Click += new System.EventHandler(this.btnRenameProfile_Click);
-            // 
-            // btnNewProfile
-            // 
-            this.btnNewProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.tableLayoutPanel3.SetColumnSpan(this.btnNewProfile, 2);
-            this.btnNewProfile.Location = new System.Drawing.Point(115, 32);
-            this.btnNewProfile.Name = "btnNewProfile";
-            this.btnNewProfile.Size = new System.Drawing.Size(75, 23);
-            this.btnNewProfile.TabIndex = 1;
-            this.btnNewProfile.Text = "New";
-            this.btnNewProfile.UseVisualStyleBackColor = true;
-            this.btnNewProfile.Click += new System.EventHandler(this.btnNewProfile_Click);
             // 
             // btnCancel
             // 
@@ -649,12 +294,431 @@
             this.chkAllowGamepads.Text = "Allow Gamepads as Hotkeys";
             this.chkAllowGamepads.UseVisualStyleBackColor = true;
             // 
+            // grpHotkeyProfiles
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.grpHotkeyProfiles, 3);
+            this.grpHotkeyProfiles.Controls.Add(this.tableLayoutPanel3);
+            this.grpHotkeyProfiles.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 322);
+            this.grpHotkeyProfiles.Name = "grpHotkeyProfiles";
+            this.grpHotkeyProfiles.Size = new System.Drawing.Size(362, 77);
+            this.grpHotkeyProfiles.TabIndex = 13;
+            this.grpHotkeyProfiles.TabStop = false;
+            this.grpHotkeyProfiles.Text = "Hotkey Profiles";
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.ColumnCount = 4;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 89.11917F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 10.88083F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 81F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 85F));
+            this.tableLayoutPanel3.Controls.Add(this.lblProfile, 0, 0);
+            this.tableLayoutPanel3.Controls.Add(this.cmbHotkeyProfiles, 1, 0);
+            this.tableLayoutPanel3.Controls.Add(this.btnRemoveProfile, 3, 1);
+            this.tableLayoutPanel3.Controls.Add(this.btnRenameProfile, 2, 1);
+            this.tableLayoutPanel3.Controls.Add(this.btnNewProfile, 0, 1);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 2;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(356, 58);
+            this.tableLayoutPanel3.TabIndex = 0;
+            // 
+            // btnNewProfile
+            // 
+            this.btnNewProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.tableLayoutPanel3.SetColumnSpan(this.btnNewProfile, 2);
+            this.btnNewProfile.Location = new System.Drawing.Point(111, 32);
+            this.btnNewProfile.Name = "btnNewProfile";
+            this.btnNewProfile.Size = new System.Drawing.Size(75, 23);
+            this.btnNewProfile.TabIndex = 1;
+            this.btnNewProfile.Text = "New";
+            this.btnNewProfile.UseVisualStyleBackColor = true;
+            this.btnNewProfile.Click += new System.EventHandler(this.btnNewProfile_Click);
+            // 
+            // btnRenameProfile
+            // 
+            this.btnRenameProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.btnRenameProfile.Location = new System.Drawing.Point(192, 32);
+            this.btnRenameProfile.Name = "btnRenameProfile";
+            this.btnRenameProfile.Size = new System.Drawing.Size(75, 23);
+            this.btnRenameProfile.TabIndex = 2;
+            this.btnRenameProfile.Text = "Rename";
+            this.btnRenameProfile.UseVisualStyleBackColor = true;
+            this.btnRenameProfile.Click += new System.EventHandler(this.btnRenameProfile_Click);
+            // 
+            // btnRemoveProfile
+            // 
+            this.btnRemoveProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.btnRemoveProfile.Location = new System.Drawing.Point(278, 32);
+            this.btnRemoveProfile.Name = "btnRemoveProfile";
+            this.btnRemoveProfile.Size = new System.Drawing.Size(75, 23);
+            this.btnRemoveProfile.TabIndex = 3;
+            this.btnRemoveProfile.Text = "Remove";
+            this.btnRemoveProfile.UseVisualStyleBackColor = true;
+            this.btnRemoveProfile.Click += new System.EventHandler(this.btnRemoveProfile_Click);
+            // 
+            // cmbHotkeyProfiles
+            // 
+            this.cmbHotkeyProfiles.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel3.SetColumnSpan(this.cmbHotkeyProfiles, 3);
+            this.cmbHotkeyProfiles.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbHotkeyProfiles.FormattingEnabled = true;
+            this.cmbHotkeyProfiles.Location = new System.Drawing.Point(172, 4);
+            this.cmbHotkeyProfiles.Name = "cmbHotkeyProfiles";
+            this.cmbHotkeyProfiles.Size = new System.Drawing.Size(181, 21);
+            this.cmbHotkeyProfiles.TabIndex = 0;
+            this.cmbHotkeyProfiles.SelectedIndexChanged += new System.EventHandler(this.cmbHotkeyProfiles_SelectedIndexChanged);
+            // 
+            // lblProfile
+            // 
+            this.lblProfile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblProfile.AutoSize = true;
+            this.lblProfile.Location = new System.Drawing.Point(3, 8);
+            this.lblProfile.Name = "lblProfile";
+            this.lblProfile.Size = new System.Drawing.Size(163, 13);
+            this.lblProfile.TabIndex = 0;
+            this.lblProfile.Text = "Active Hotkey Profile:";
+            // 
+            // txtDelay
+            // 
+            this.txtDelay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtDelay.Location = new System.Drawing.Point(315, 265);
+            this.txtDelay.Name = "txtDelay";
+            this.txtDelay.Size = new System.Drawing.Size(50, 20);
+            this.txtDelay.TabIndex = 12;
+            this.txtDelay.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // label10
+            // 
+            this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(181, 269);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(128, 13);
+            this.label10.TabIndex = 14;
+            this.label10.Text = "Hotkey Delay (Seconds):";
+            // 
+            // txtSwitchNext
+            // 
+            this.txtSwitchNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchNext, 2);
+            this.txtSwitchNext.Location = new System.Drawing.Point(181, 178);
+            this.txtSwitchNext.Name = "txtSwitchNext";
+            this.txtSwitchNext.ReadOnly = true;
+            this.txtSwitchNext.Size = new System.Drawing.Size(184, 20);
+            this.txtSwitchNext.TabIndex = 7;
+            this.txtSwitchNext.Enter += new System.EventHandler(this.Switch_Next_Set_Enter);
+            // 
+            // txtSwitchPrevious
+            // 
+            this.txtSwitchPrevious.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchPrevious, 2);
+            this.txtSwitchPrevious.Location = new System.Drawing.Point(181, 149);
+            this.txtSwitchPrevious.Name = "txtSwitchPrevious";
+            this.txtSwitchPrevious.ReadOnly = true;
+            this.txtSwitchPrevious.Size = new System.Drawing.Size(184, 20);
+            this.txtSwitchPrevious.TabIndex = 6;
+            this.txtSwitchPrevious.Enter += new System.EventHandler(this.Switch_Previous_Set_Enter);
+            // 
+            // label9
+            // 
+            this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(3, 182);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(172, 13);
+            this.label9.TabIndex = 12;
+            this.label9.Text = "Switch Comparison (Next):";
+            // 
+            // label8
+            // 
+            this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(3, 153);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(172, 13);
+            this.label8.TabIndex = 10;
+            this.label8.Text = "Switch Comparison (Previous):";
+            // 
+            // txtToggle
+            // 
+            this.txtToggle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtToggle, 2);
+            this.txtToggle.Location = new System.Drawing.Point(181, 207);
+            this.txtToggle.Name = "txtToggle";
+            this.txtToggle.ReadOnly = true;
+            this.txtToggle.Size = new System.Drawing.Size(184, 20);
+            this.txtToggle.TabIndex = 8;
+            this.txtToggle.Enter += new System.EventHandler(this.Toggle_Set_Enter);
+            // 
+            // label7
+            // 
+            this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(3, 211);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(172, 13);
+            this.label7.TabIndex = 9;
+            this.label7.Text = "Toggle Global Hotkeys:";
+            // 
+            // txtUndo
+            // 
+            this.txtUndo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtUndo, 2);
+            this.txtUndo.Location = new System.Drawing.Point(181, 62);
+            this.txtUndo.Name = "txtUndo";
+            this.txtUndo.ReadOnly = true;
+            this.txtUndo.Size = new System.Drawing.Size(184, 20);
+            this.txtUndo.TabIndex = 3;
+            this.txtUndo.Enter += new System.EventHandler(this.Undo_Set_Enter);
+            // 
+            // txtSkip
+            // 
+            this.txtSkip.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtSkip, 2);
+            this.txtSkip.Location = new System.Drawing.Point(181, 91);
+            this.txtSkip.Name = "txtSkip";
+            this.txtSkip.ReadOnly = true;
+            this.txtSkip.Size = new System.Drawing.Size(184, 20);
+            this.txtSkip.TabIndex = 4;
+            this.txtSkip.Enter += new System.EventHandler(this.Skip_Set_Enter);
+            // 
+            // label4
+            // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(3, 66);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(172, 13);
+            this.label4.TabIndex = 7;
+            this.label4.Text = "Undo Split:";
+            // 
+            // label3
+            // 
+            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(3, 95);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(172, 13);
+            this.label3.TabIndex = 6;
+            this.label3.Text = "Skip Split:";
+            // 
+            // txtPause
+            // 
+            this.txtPause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtPause, 2);
+            this.txtPause.Location = new System.Drawing.Point(181, 120);
+            this.txtPause.Name = "txtPause";
+            this.txtPause.ReadOnly = true;
+            this.txtPause.Size = new System.Drawing.Size(184, 20);
+            this.txtPause.TabIndex = 5;
+            this.txtPause.Enter += new System.EventHandler(this.Pause_Set_Enter);
+            // 
+            // txtReset
+            // 
+            this.txtReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtReset, 2);
+            this.txtReset.Location = new System.Drawing.Point(181, 33);
+            this.txtReset.Name = "txtReset";
+            this.txtReset.ReadOnly = true;
+            this.txtReset.Size = new System.Drawing.Size(184, 20);
+            this.txtReset.TabIndex = 2;
+            this.txtReset.Enter += new System.EventHandler(this.Reset_Set_Enter);
+            // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(3, 124);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(172, 13);
+            this.label6.TabIndex = 8;
+            this.label6.Text = "Pause:";
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 37);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(172, 13);
+            this.label2.TabIndex = 5;
+            this.label2.Text = "Reset:";
+            // 
+            // txtStartSplit
+            // 
+            this.txtStartSplit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel2.SetColumnSpan(this.txtStartSplit, 2);
+            this.txtStartSplit.Location = new System.Drawing.Point(181, 4);
+            this.txtStartSplit.Name = "txtStartSplit";
+            this.txtStartSplit.ReadOnly = true;
+            this.txtStartSplit.Size = new System.Drawing.Size(184, 20);
+            this.txtStartSplit.TabIndex = 1;
+            this.txtStartSplit.Enter += new System.EventHandler(this.Split_Set_Enter);
+            // 
+            // chkDoubleTap
+            // 
+            this.chkDoubleTap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkDoubleTap.AutoSize = true;
+            this.chkDoubleTap.Location = new System.Drawing.Point(7, 267);
+            this.chkDoubleTap.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkDoubleTap.Name = "chkDoubleTap";
+            this.chkDoubleTap.Size = new System.Drawing.Size(168, 17);
+            this.chkDoubleTap.TabIndex = 11;
+            this.chkDoubleTap.Text = "Double Tap Prevention";
+            this.chkDoubleTap.UseVisualStyleBackColor = true;
+            // 
+            // chkGlobalHotkeys
+            // 
+            this.chkGlobalHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.chkGlobalHotkeys.AutoSize = true;
+            this.chkGlobalHotkeys.Location = new System.Drawing.Point(7, 235);
+            this.chkGlobalHotkeys.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkGlobalHotkeys.Name = "chkGlobalHotkeys";
+            this.chkGlobalHotkeys.Size = new System.Drawing.Size(98, 23);
+            this.chkGlobalHotkeys.TabIndex = 9;
+            this.chkGlobalHotkeys.Text = "Global Hotkeys";
+            this.chkGlobalHotkeys.UseVisualStyleBackColor = true;
+            this.chkGlobalHotkeys.CheckedChanged += new System.EventHandler(this.chkGlobalHotkeys_CheckedChanged);
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 8);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(172, 13);
+            this.label1.TabIndex = 4;
+            this.label1.Text = "Start / Split:";
+            // 
+            // chkDeactivateForOtherPrograms
+            // 
+            this.chkDeactivateForOtherPrograms.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.chkDeactivateForOtherPrograms.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.chkDeactivateForOtherPrograms, 2);
+            this.chkDeactivateForOtherPrograms.Location = new System.Drawing.Point(185, 235);
+            this.chkDeactivateForOtherPrograms.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkDeactivateForOtherPrograms.Name = "chkDeactivateForOtherPrograms";
+            this.chkDeactivateForOtherPrograms.Size = new System.Drawing.Size(172, 23);
+            this.chkDeactivateForOtherPrograms.TabIndex = 10;
+            this.chkDeactivateForOtherPrograms.Text = "Deactivate For Other Programs";
+            this.chkDeactivateForOtherPrograms.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.ColumnCount = 3;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 178F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel2.Controls.Add(this.chkDeactivateForOtherPrograms, 1, 8);
+            this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.chkGlobalHotkeys, 0, 8);
+            this.tableLayoutPanel2.Controls.Add(this.chkDoubleTap, 0, 9);
+            this.tableLayoutPanel2.Controls.Add(this.txtStartSplit, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.label6, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.txtReset, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.txtPause, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.label3, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.txtSkip, 1, 3);
+            this.tableLayoutPanel2.Controls.Add(this.txtUndo, 1, 2);
+            this.tableLayoutPanel2.Controls.Add(this.label7, 0, 7);
+            this.tableLayoutPanel2.Controls.Add(this.txtToggle, 1, 7);
+            this.tableLayoutPanel2.Controls.Add(this.label8, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this.label9, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.txtSwitchPrevious, 1, 5);
+            this.tableLayoutPanel2.Controls.Add(this.txtSwitchNext, 1, 6);
+            this.tableLayoutPanel2.Controls.Add(this.label10, 1, 9);
+            this.tableLayoutPanel2.Controls.Add(this.txtDelay, 2, 9);
+            this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 11);
+            this.tableLayoutPanel2.Controls.Add(this.chkAllowGamepads, 0, 10);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 12;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 402);
+            this.tableLayoutPanel2.TabIndex = 0;
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(7, 7);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.tableLayoutPanel1);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.groupBox2);
+            this.splitContainer1.Size = new System.Drawing.Size(621, 601);
+            this.splitContainer1.SplitterDistance = 380;
+            this.splitContainer1.TabIndex = 1;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.tableLayoutPanel4);
+            this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox2.Location = new System.Drawing.Point(0, 0);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(237, 601);
+            this.groupBox2.TabIndex = 3;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Secondary Hotkeys";
+            // 
+            // tableLayoutPanel4
+            // 
+            this.tableLayoutPanel4.AutoSize = true;
+            this.tableLayoutPanel4.ColumnCount = 1;
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel4.Controls.Add(this.txtSecondarySplit, 0, 0);
+            this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+            this.tableLayoutPanel4.RowCount = 1;
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(231, 29);
+            this.tableLayoutPanel4.TabIndex = 0;
+            // 
+            // txtSecondarySplit
+            // 
+            this.txtSecondarySplit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSecondarySplit.Location = new System.Drawing.Point(3, 4);
+            this.txtSecondarySplit.Name = "txtSecondarySplit";
+            this.txtSecondarySplit.ReadOnly = true;
+            this.txtSecondarySplit.Size = new System.Drawing.Size(225, 20);
+            this.txtSecondarySplit.TabIndex = 16;
+            this.txtSecondarySplit.Enter += new System.EventHandler(this.Secondary_Split_Set_Enter);
+            // 
             // SettingsDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(394, 615);
-            this.Controls.Add(this.tableLayoutPanel1);
+            this.ClientSize = new System.Drawing.Size(635, 615);
+            this.Controls.Add(this.splitContainer1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "SettingsDialog";
@@ -664,47 +728,60 @@
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.groupBox1.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
             this.grpHotkeyProfiles.ResumeLayout(false);
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.tableLayoutPanel4.ResumeLayout(false);
+            this.tableLayoutPanel4.PerformLayout();
             this.ResumeLayout(false);
 
         }
 
         #endregion
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.TextBox txtStartSplit;
-        private System.Windows.Forms.TextBox txtReset;
-        private System.Windows.Forms.TextBox txtSkip;
-        private System.Windows.Forms.TextBox txtUndo;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
-        private System.Windows.Forms.CheckBox chkGlobalHotkeys;
-        private System.Windows.Forms.Label label6;
-        private System.Windows.Forms.TextBox txtPause;
         private System.Windows.Forms.CheckBox chkWarnOnReset;
-        private System.Windows.Forms.TextBox txtToggle;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.CheckBox chkDoubleTap;
         private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.ComboBox cbxRaceViewer;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.CheckBox chkSimpleSOB;
+        private System.Windows.Forms.Button btnChooseComparisons;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Button btnLogOut;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.Button btnChooseRaceProvider;
+        private System.Windows.Forms.Label label13;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.CheckBox chkDeactivateForOtherPrograms;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.CheckBox chkGlobalHotkeys;
+        private System.Windows.Forms.CheckBox chkDoubleTap;
+        private System.Windows.Forms.TextBox txtStartSplit;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.TextBox txtReset;
+        private System.Windows.Forms.TextBox txtPause;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.TextBox txtSkip;
+        private System.Windows.Forms.TextBox txtUndo;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.TextBox txtToggle;
         private System.Windows.Forms.Label label8;
-        private System.Windows.Forms.TextBox txtSwitchPrevious;
         private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.TextBox txtSwitchPrevious;
         private System.Windows.Forms.TextBox txtSwitchNext;
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.TextBox txtDelay;
-        private System.Windows.Forms.ComboBox cbxRaceViewer;
-        private System.Windows.Forms.Label label11;
-        private System.Windows.Forms.CheckBox chkDeactivateForOtherPrograms;
-        private System.Windows.Forms.CheckBox chkSimpleSOB;
-        private System.Windows.Forms.Button btnChooseComparisons;
         private System.Windows.Forms.GroupBox grpHotkeyProfiles;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.Label lblProfile;
@@ -712,11 +789,10 @@
         private System.Windows.Forms.Button btnRemoveProfile;
         private System.Windows.Forms.Button btnRenameProfile;
         private System.Windows.Forms.Button btnNewProfile;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.Button btnLogOut;
-        private System.Windows.Forms.Label label12;
-        private System.Windows.Forms.Button btnChooseRaceProvider;
-        private System.Windows.Forms.Label label13;
         private System.Windows.Forms.CheckBox chkAllowGamepads;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
+        private System.Windows.Forms.TextBox txtSecondarySplit;
     }
 }

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
@@ -20,6 +20,7 @@ namespace LiveSplit.View
         public string SelectedHotkeyProfile { get; set; }
 
         public string SplitKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].SplitKey);
+        public string SecondarySplitKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].SecondarySplitKey);
         public string ResetKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].ResetKey);
         public string SkipKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].SkipKey);
         public string UndoKey => FormatKey(Settings.HotkeyProfiles[SelectedHotkeyProfile].UndoKey);
@@ -87,6 +88,7 @@ namespace LiveSplit.View
         private void UpdateDisplayedHotkeyValues()
         {
             txtStartSplit.Text = SplitKey;
+            txtSecondarySplit.Text = SecondarySplitKey;
             txtReset.Text = ResetKey;
             txtSkip.Text = SkipKey;
             txtUndo.Text = UndoKey;
@@ -227,6 +229,13 @@ namespace LiveSplit.View
             SetHotkeyHandlers((TextBox)sender, x =>
             {
                 Settings.HotkeyProfiles[SelectedHotkeyProfile].SplitKey = x;
+            });
+        }
+        private void Secondary_Split_Set_Enter(object sender, EventArgs e)
+        {
+            SetHotkeyHandlers((TextBox)sender, x =>
+            {
+                Settings.HotkeyProfiles[SelectedHotkeyProfile].SecondarySplitKey = x;
             });
         }
         private void Reset_Set_Enter(object sender, EventArgs e)

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1073,7 +1073,7 @@ namespace LiveSplit.View
 
                 if ((ActiveForm == this || hotkeyProfile.GlobalHotkeysEnabled) && !ResetMessageShown && !IsInDialogMode)
                 {
-                    if (hotkeyProfile.SplitKey == e)
+                    if (hotkeyProfile.SplitKey == e || hotkeyProfile.SecondarySplitKey == e)
                     {
                         if (hotkeyProfile.HotkeyDelay > 0)
                         {


### PR DESCRIPTION
Following on from #2104, this patchset (sloppily!) adds a second 'Split' hotkey, that can be changed independently of the primary one. This small modification has been created specifically to solve *one* user need, but I think that with some large-scale improvement it would be welcomed by the whole user base. For a real solution, we probably want to have a keybind system where each action has a `List<KeyOrButton>`.

The intent of this PR is not to get *these* patches [as they exist now] to be merged, but to facilitate a discussion and experiment with how such an extensible keybind system would work (both technically and in UI).