### PR TITLE
Faster loading of edit splits menu.

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -211,36 +211,6 @@ namespace LiveSplit.View
 
             cbxGameName.GetAllItemsForText = x => new string[0];
 
-            Task.Factory.StartNew(() =>
-                {
-                    try
-                    {
-                        gameNames = CompositeGameList.Instance.GetGameNames().ToArray();
-                        abbreviations = gameNames
-                        .Select(x => x.GetAbbreviations()
-                            .Select(y => new KeyValuePair<string, string>(x, y)))
-                        .SelectMany(x => x)
-                        .GroupBy(x => x.Value, x => x.Key);
-                        cbxGameName.GetAllItemsForText = x => SearchForGameName(x);
-                        this.InvokeIfRequired(() =>
-                        {
-                            try
-                            {
-                                cbxGameName.Items.AddRange(gameNames);
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex);
-                            }
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex);
-                    }
-                });
-
-
             cbxRunCategory.AutoCompleteSource = AutoCompleteSource.ListItems;
             cbxRunCategory.Items.AddRange(new[] { "Any%", "Low%", "100%" });
             cbxRunCategory.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
@@ -303,6 +273,39 @@ namespace LiveSplit.View
         {
             if (Run.IsAutoSplitterActive())
                 Run.AutoSplitter.Deactivate();
+        }
+
+        private void FillCbxGameName()
+        {
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    gameNames = CompositeGameList.Instance.GetGameNames().ToArray();
+                    abbreviations = gameNames
+                    .Select(x => x.GetAbbreviations()
+                        .Select(y => new KeyValuePair<string, string>(x, y)))
+                    .SelectMany(x => x)
+                    .GroupBy(x => x.Value, x => x.Key);
+                    cbxGameName.GetAllItemsForText = x => SearchForGameName(x);
+                    this.InvokeIfRequired(() =>
+                    {
+                        Application.DoEvents();
+                        try
+                        {
+                            cbxGameName.Items.AddRange(gameNames);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex);
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex);
+                }
+            });
         }
 
         void RefreshCategoryAutoCompleteList()
@@ -1049,6 +1052,7 @@ namespace LiveSplit.View
             RebuildComparisonColumns();
             IsInitialized = true;
             UpdateButtonsStatus();
+            FillCbxGameName();
             cbxGameName.UpdateUI();
         }
 


### PR DESCRIPTION
When I want to open the edit splits menu a second time during execution of the program, it takes nearly 4 seconds until the window is showing. With this fix, thats no longer the case. I moved the fillCbxGameName-Logic to until after the form is initialized and added a call to Application.DoEvents() to render the form before filling the combobox. 