### PR TITLE
Add Feature: ability to create a custom comparison from Save Splits

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -1868,11 +1868,40 @@ namespace LiveSplit.View
                 || CurrentState.CurrentPhase == TimerPhase.Paused))
             {
                 DontRedraw = true;
-                result = MessageBox.Show(this, "This run did not beat your current splits. Would you like to save this run as a Personal Best?", "Save as Personal Best?", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+                string name = "";
+                result = InputBox.Show("New Comparison", "Comparison Name: (leave blank to replace Personal Best)", ref name);
                 DontRedraw = false;
-                if (result == DialogResult.Yes)
+                if (result == DialogResult.OK)
                 {
-                    Model.ResetAndSetAttemptAsPB();
+                    if (name.Length <= 0)
+                        Model.ResetAndSetAttemptAsPB();
+                    else
+                    {
+                        if (CurrentState.Run.CustomComparisons.Contains(name))
+                        {
+                            result = MessageBox.Show("This Comparison already exists. Would you like to overwrite it?", "Overwrite " + name + "?", MessageBoxButtons.YesNoCancel);
+                            if (result == DialogResult.Yes)
+                            {
+                                foreach (var current in CurrentState.Run)
+                                    current.Comparisons[name] = current.SplitTime;
+                            }
+                            else if (result == DialogResult.Cancel)
+                                return false;
+                        }
+                        else if (CurrentState.Run.Comparisons.Contains(name))
+                        {
+                            result = MessageBox.Show("This Comparison already exists and is not a custom comparison.", "The change will be ignored.", MessageBoxButtons.OKCancel);
+                            if (result == DialogResult.Cancel)
+                                return false;
+                        }
+                        else
+                        {
+                            CurrentState.Run.CustomComparisons.Add(name);
+                            foreach (var current in CurrentState.Run)
+                                current.Comparisons[name] = current.SplitTime;
+                        }
+                        Model.Reset();
+                    }
                 }
                 else if (result == DialogResult.Cancel)
                     return false;


### PR DESCRIPTION
Unsure if this is something desired for the main branch, but I figured it was worth opening just in case.

Currently, the option exists to overwrite your Personal Best if you select the "Save Splits" option in a finished state with a time worse than your Personal Best.

These changes replace that option with the ability to take the current run and add it as a custom comparison, without overriding the Personal Best.

The option to overwrite the Personal Best still exists if the text field is left blank by the user.

It's very rudimentary in its current state (partly due to my lack of experience with Windows Forms), and it should probably be tidied up on the user's end before being fully committed. Currently though it serves its part as a demonstration.