### PR TITLE
Prompt to Save Splits When Closing LiveSplit After Changing Autosplitter Settings

### DIFF
--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -1388,6 +1388,7 @@ namespace LiveSplit.View
                 autoSplitterSettings.InnerXml = Run.AutoSplitter.Component.GetSettings(document).InnerXml;
                 autoSplitterSettings.Attributes.Append(SettingsHelper.ToAttribute(document, "gameName", Run.GameName));
                 Run.AutoSplitterSettings = autoSplitterSettings;
+                Run.HasChanged = true;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/LiveSplit/LiveSplit/issues/2176
Just sets Run.HasChanged to true when you hit 'OK' in the autosplitter settings window.