### PR TITLE
Drop Decimals in PossibleTimeSaveFormatter

### DIFF
--- a/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
@@ -7,6 +7,7 @@ namespace LiveSplit.TimeFormatters
         public PossibleTimeSaveFormatter()
         {
             Accuracy = TimeAccuracy.Seconds;
+            DropDecimals = false;
             NullFormat = NullFormat.Dash;
         }
     }

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
@@ -228,5 +228,44 @@ namespace LiveSplit.Tests.TimeFormatterTests
             var formattedTime = sut.Format(time);
             Assert.Equal(expectedTime, formattedTime);
         }
+
+        [Theory]
+        [InlineData("00:00:00", TimeAccuracy.Seconds, false, "0")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, false, "0.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, false, "0.00")]
+
+        [InlineData("00:00:00", TimeAccuracy.Seconds, true, "0")]
+        [InlineData("00:00:00", TimeAccuracy.Tenths, true, "0.0")]
+        [InlineData("00:00:00", TimeAccuracy.Hundredths, true, "0.00")]
+
+        [InlineData("00:01:30.00", TimeAccuracy.Seconds, false, "1:30")]
+        [InlineData("00:01:30.00", TimeAccuracy.Tenths, false, "1:30.0")]
+        [InlineData("00:01:30.00", TimeAccuracy.Hundredths, false, "1:30.00")]
+
+        [InlineData("00:01:30.00", TimeAccuracy.Seconds, true, "1:30")]
+        [InlineData("00:01:30.00", TimeAccuracy.Tenths, true, "1:30")]
+        [InlineData("00:01:30.00", TimeAccuracy.Hundredths, true, "1:30")]
+
+        [InlineData("07:05:01.29", TimeAccuracy.Seconds, false, "7:05:01")]
+        [InlineData("07:05:01.29", TimeAccuracy.Tenths, false, "7:05:01.2")]
+        [InlineData("07:05:01.29", TimeAccuracy.Hundredths, false, "7:05:01.29")]
+
+        [InlineData("07:05:01.29", TimeAccuracy.Seconds, true, "7:05:01")]
+        [InlineData("07:05:01.29", TimeAccuracy.Tenths, true, "7:05:01")]
+        [InlineData("07:05:01.29", TimeAccuracy.Hundredths, true, "7:05:01")]
+        public void FormatTimeCorrectly_WhenDecimalsDropped(string timespanText, TimeAccuracy accuracy,
+            bool dropDecimals, string expectedTime)
+        {
+            var sut = new PossibleTimeSaveFormatter
+            {
+                DropDecimals = dropDecimals,
+                Accuracy = accuracy
+            };
+
+            var time = TimeSpan.Parse(timespanText);
+
+            var formattedTime = sut.Format(time);
+            Assert.Equal(expectedTime, formattedTime);
+        }
     }
 }


### PR DESCRIPTION
Added a line to PossibleTimeSaveFormatter.cs to support the dropping of decimals in the component if greater than one minute
resolves #2182 

https://github.com/LiveSplit/LiveSplit/pull/2194

![Screenshot (194)](https://user-images.githubusercontent.com/59705816/145639217-47ae8d06-686a-4612-9cf1-31c001a41e6a.png)
![Screenshot (195)](https://user-images.githubusercontent.com/59705816/145639221-c5e3fd33-e73c-4e33-ab40-1db6b0686d61.png)
