### PR TITLE
Shorten median comparison name

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
@@ -10,6 +10,7 @@ namespace LiveSplit.Model.Comparisons
             AddShortComparisonName(BestSegmentsComparisonGenerator.ComparisonName, BestSegmentsComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(Run.PersonalBestComparisonName, "PB");
             AddShortComparisonName(AverageSegmentsComparisonGenerator.ComparisonName, AverageSegmentsComparisonGenerator.ShortComparisonName);
+            AddShortComparisonName(MedianSegmentsComparisonGenerator.ComparisonName, MedianSegmentsComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(WorstSegmentsComparisonGenerator.ComparisonName, WorstSegmentsComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(PercentileComparisonGenerator.ComparisonName, PercentileComparisonGenerator.ShortComparisonName);
             AddShortComparisonName(LatestRunComparisonGenerator.ComparisonName, LatestRunComparisonGenerator.ShortComparisonName);


### PR DESCRIPTION
Fixes #2206 

![median](https://user-images.githubusercontent.com/87248013/148158149-91fde26c-1725-4f9a-a297-8f7b099f9fed.png)

As an aside, if this goes in then the longest comparison name becomes the Best Split Times comparison which I think could be shortened to 'BST' as mentioned in #1369 

Beyond that, I think that the shortened comparison name for the Balanced PB can be shortened to something even shorter like 'Bal. PB' or 'BPB', but that's just my preference