### PR TITLE
Fixed Cancel button not cancelling.

### DIFF
--- a/LiveSplit/LiveSplit.View/View/ComponentSettingsDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/ComponentSettingsDialog.Designer.cs
@@ -52,7 +52,7 @@
             // btnOK
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOK.Location = new System.Drawing.Point(331, 522);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);

--- a/LiveSplit/LiveSplit.View/View/ComponentSettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ComponentSettingsDialog.cs
@@ -27,7 +27,6 @@ namespace LiveSplit.View
 
         private void btnCancel_Click(object sender, EventArgs e)
         {
-            Component.SetSettings(ComponentSettings);
             DialogResult = DialogResult.Cancel;
             Close();
         }


### PR DESCRIPTION
If the user selects "Cancel", `SetSettings` should not be called, as it is expressly against the user's (and component developers') wishes.

As-is, if a user accesses the Component Settings dialog mid-run and only clicks Cancel, it causes buggy behavior when `SetSettings` is called.

This is counter-intuitive for the user: "Nothing should happen if I hit Cancel." And it can be tricky for component developers to debug issues caused by this, especially since the issues are not persistent. For instance, when LiveSplit is restarted, the buggy behaviors due to the erroneous `SetSettings` will not happen.