### PR TITLE
Add setting for drop decimal poss. time save in prev. seg component

### DIFF
--- a/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
@@ -33,6 +33,11 @@ namespace LiveSplit.TimeFormatters {
         public bool DropDecimals { get; set; }
 
         /// <summary>
+        /// If true, don't display decimals if absolute time is 1 minute or more
+        /// </summary>
+        public bool DropDecimalsPossibleTimeSave { get; set; }
+
+        /// <summary>
         /// If true, don't display trailing zero demical places
         /// </summary>
         public bool AutomaticPrecision { get; set; } = false;
@@ -86,7 +91,7 @@ namespace LiveSplit.TimeFormatters {
             }
             else
             {
-                if (DropDecimals && time.TotalMinutes >= 1)
+                if ((DropDecimalsPossibleTimeSave || DropDecimals) && time.TotalMinutes >= 1)
                     decimalFormat = "";
                 else if (Accuracy == TimeAccuracy.Seconds)
                     decimalFormat = "";

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/PossibleTimeSaveFormatter.cs
@@ -8,6 +8,7 @@ namespace LiveSplit.TimeFormatters
         {
             Accuracy = TimeAccuracy.Seconds;
             DropDecimals = false;
+            DropDecimalsPossibleTimeSave = false;
             NullFormat = NullFormat.Dash;
         }
     }


### PR DESCRIPTION
Adds support to save the drop decimal setting for possible time save in previous segment component in https://github.com/LiveSplit/LiveSplit.PreviousSegment/pull/5