### PR TITLE
Change GetBestSegmentColor to public

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/LiveSplitStateHelper.cs
+++ b/LiveSplit/LiveSplit.Core/Model/LiveSplitStateHelper.cs
@@ -195,7 +195,11 @@ namespace LiveSplit.Model
             return bestSegment == null || curSegment < bestSegment || delta < TimeSpan.Zero;
         }
 
-        private static Color GetBestSegmentColor(LiveSplitState state)
+        /// <summary>
+        /// Returns the current Best Segment color, including if the Rainbow Color is being used.
+        /// </summary>
+        /// <param name="state">The current state.</param>
+        public static Color GetBestSegmentColor(LiveSplitState state)
         {
             if (state.LayoutSettings.UseRainbowColor)
             {


### PR DESCRIPTION
Currently the only way to get the Rainbow Color is to have a gold split and pass it to GetSplitColor, which is convoluted. I don't see a downside to making this method public.