### PR TITLE
prevent additional files for `AutoSplitterType.Script` to create an `…

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
+++ b/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
@@ -72,7 +72,7 @@ namespace LiveSplit.Model
                     client.DownloadFile(new Uri(url), tempLocalPath);
                     File.Copy(tempLocalPath, localPath, true);
 
-                    if (url != URLs.First())
+                    if (Type == AutoSplitterType.Component && url != URLs.First())
                     {
                         var factory = ComponentManager.LoadFactory<IComponentFactory>(localPath);
                         if (factory != null)


### PR DESCRIPTION
Some (my) auto splitters may want to provide additional `.dll` libraries to make some functions in ASL easier. These additional files are attempted to be parsed as `IComponent`s, putting a handle on the file and locking them from use.

This change brings an inherent issue; `AutoSplitterType.Script` auto splitters can no longer provide actual additional components. So far, no auto splitter that is of type `Script` in `LiveSplit.AutoSplitters.xml` does this, and I find it unlikely it will ever happen, but this possibility should be kept open.

What other potential ways to fix this could we use? Perhaps we could check the file extension? This is arguably worse, since users are then forced to change their `.dll` libraries' extension to something random.