### PR TITLE
add `ScriptExtended` auto splitter type

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
+++ b/LiveSplit/LiveSplit.Core/Model/AutoSplitter.cs
@@ -11,7 +11,7 @@ namespace LiveSplit.Model
 {
     public enum AutoSplitterType
     {
-        Component, Script
+        Component, Script, ScriptExtended
     }
     public class AutoSplitter : ICloneable
     {
@@ -34,7 +34,7 @@ namespace LiveSplit.Model
             {
                 try
                 {
-                    if (!IsDownloaded || Type == AutoSplitterType.Script)
+                    if (!IsDownloaded || Type == AutoSplitterType.Script || Type == AutoSplitterType.ScriptExtended)
                         DownloadFiles();
                     if (Type == AutoSplitterType.Component)
                     {
@@ -72,7 +72,7 @@ namespace LiveSplit.Model
                     client.DownloadFile(new Uri(url), tempLocalPath);
                     File.Copy(tempLocalPath, localPath, true);
 
-                    if (url != URLs.First())
+                    if (Type != AutoSplitterType.ScriptExtended && url != URLs.First())
                     {
                         var factory = ComponentManager.LoadFactory<IComponentFactory>(localPath);
                         if (factory != null)

--- a/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
+++ b/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
@@ -45,10 +45,10 @@ namespace LiveSplit.Tests.AutoSplitterTests
             Assert.True(!autoSplitters.Values.Any(x => !x.URLs.Any()), "Auto Splitters need to have at least one URL");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".asl")) && x.Type == AutoSplitterType.Component),
                 "ASL Script is downloaded even though Type \"Component\" is specified");
-            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".dll")) && x.Type == AutoSplitterType.Script),
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.First().EndsWith(".dll") && x.Type == AutoSplitterType.Script),
                 "Component is downloaded even though Type \"Script\" is specified");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.First().EndsWith(".dll") && x.Type == AutoSplitterType.ScriptExtended),
-                "Component was first file even though Type \"ScriptExtended\" is specified");
+                "Component is first file even though Type \"ScriptExtended\" is specified");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => !Uri.IsWellFormedUriString(y, UriKind.Absolute))),
                 "Auto Splitters need to have valid URLs");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => Regex.IsMatch(y, "https://github.com/[^/]*/[^/]*/blob/"))),

--- a/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
+++ b/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
@@ -45,8 +45,10 @@ namespace LiveSplit.Tests.AutoSplitterTests
             Assert.True(!autoSplitters.Values.Any(x => !x.URLs.Any()), "Auto Splitters need to have at least one URL");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".asl")) && x.Type == AutoSplitterType.Component),
                 "ASL Script is downloaded even though Type \"Component\" is specified");
-            Assert.True(!autoSplitters.Values.Any(x => x.URLs.First().EndsWith(".dll") && x.Type == AutoSplitterType.Script),
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".dll")) && x.Type == AutoSplitterType.Script),
                 "Component is downloaded even though Type \"Script\" is specified");
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.First().EndsWith(".dll") && x.Type == AutoSplitterType.ScriptExtended),
+                "Component was first file even though Type \"ScriptExtended\" is specified");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => !Uri.IsWellFormedUriString(y, UriKind.Absolute))),
                 "Auto Splitters need to have valid URLs");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => Regex.IsMatch(y, "https://github.com/[^/]*/[^/]*/blob/"))),


### PR DESCRIPTION
Adds a new type of `AutoSplitter`, allowing for deployment of additional files with an ASL script that do not get parsed as `IComponent`s.