### PR TITLE
Add Eye of the Temple to AutoSplitters

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14122,4 +14122,14 @@
         <Description>Autosplitter with options for different categories.  (by SioN)</Description>
         <Website>https://speed.siontea.com/game/mefb/</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Eye of the Temple</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/runevision/EyeOfTheTempleAutoSplitter/main/EyeOfTheTemple.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Loadless timer based on in-game time. (By runevision)</Description>
+    </AutoSplitter>
 </AutoSplitters>


### PR DESCRIPTION
I'm the developer of Eye of the Temple and I made this simple autosplitter based on the in-game timer.

I don't know if or how speedrunners might want to split their runs so it only splits when the timer stops for now. However, there's info in the ASL file that others could use to extend its functionality if they want.