### PR TITLE
Adjust length of sleep instruction on TimerWorker for time spent refreshing

### DIFF
--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -33,7 +33,6 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
-using System.Timers;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
@@ -79,8 +78,6 @@ namespace LiveSplit.View
         protected float TotalPosition { get; set; }
 
         private bool DontRedraw = false;
-
-        private StringBuilder sb = new StringBuilder();
 
         protected Region UpdateRegion { get; set; }
 
@@ -1179,9 +1176,6 @@ namespace LiveSplit.View
 
         void TimerElapsed()
         {
-            //((System.Timers.Timer)source).Interval = 10;
-            //int logCount = 0;
-            decimal updateStartTime = DateTime.Now.Ticks;
             try
             {
                 this.InvokeIfRequired(() =>
@@ -1242,8 +1236,6 @@ namespace LiveSplit.View
                     Invalidate();
                 }
             }
-            decimal updateEndTime = DateTime.Now.Ticks;
-            sb.AppendLine(String.Format("Frametime: {0} \n", updateEndTime));
         }
 
         private void FixSize()

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -31,7 +31,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;


### PR DESCRIPTION
This will increase the consistency of the timer refresh rate when more resource intensive components are used (ie load removers using optical character recognition)

On a side note: Due to delay between a thread's sleep duration ending and the thread actually resuming execution the refresh rate entered in the settings will differ vastly from the refresh rate actually achieved (ie entering a refresh rate of 30 will result in an actual refresh rate of 23)