### PR TITLE
Add multi-language feature

### DIFF
--- a/LiveSplit/Languages/README.md
+++ b/LiveSplit/Languages/README.md
@@ -2,6 +2,8 @@
 
 Copy the entire **`Languages` folder** to the directory where **LiveSplit.exe** is located.
 
+Run LiveSplit.exe, right click on the window and set the language in `Settings` -> `Languages`.
+
 ## Add Other Languages
 
 If LiveSplit does not support your language, you can add your language to it.

--- a/LiveSplit/Languages/README.md
+++ b/LiveSplit/Languages/README.md
@@ -1,0 +1,14 @@
+# Multiple Language Support
+
+Copy the entire **`Languages` folder** to the directory where **LiveSplit.exe** is located.
+
+## Add Other Languages
+
+If LiveSplit does not support your language, you can add your language to it.
+
+1. Create a new file ending in .cfg in the Languages folder with a name that is an abbreviation for your language. For example, `zh-CN.cfg`.
+2. Copy all the contents of the `en.cfg` file into the newly created file.
+3. Change the contents of the DisplayName tag to the name of your language, which will be displayed in the "Settings" -> "Language" option. For example, `<DisplayName>English</DisplayName>`.
+4. Translate all content in xml tags to your language based on English text.
+
+After completing the above, you can switch to your language in the "Settings" -> "Language" of the software.

--- a/LiveSplit/Languages/en.cfg
+++ b/LiveSplit/Languages/en.cfg
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Language>
+    <DisplayName>English</DisplayName>
+    <!-- common -->
+    <btnCancel>Cancel</btnCancel>
+    <btnOK>OK</btnOK>
+    <btnSearch>Search</btnSearch>
+    <btnClose>Close</btnClose>
+    <Text>Text: </Text>
+    <Icon>Icon: </Icon>
+    <Name>Name:</Name>
+    <SegmentName>Segment Name</SegmentName>
+    <SegmentTime>Segment Time</SegmentTime>
+    <BestSegment>Best Segment</BestSegment>
+    <Error>Error</Error>
+
+    <!-- TimerForm -->
+    <editSplitsMenuItem>Edit Splits...</editSplitsMenuItem>
+    <openSplitsMenuItem>Open Splits</openSplitsMenuItem>
+    <saveSplitsMenuItem>Save Splits</saveSplitsMenuItem>
+    <saveSplitsAsMenuItem>Save Splits As...</saveSplitsAsMenuItem>
+    <closeSplitsMenuItem>Close Splits</closeSplitsMenuItem>
+    <controlMenuItem>Control</controlMenuItem>
+    <comparisonMenuItem>Comparison</comparisonMenuItem>
+    <shareMenuItem>Share...</shareMenuItem>
+    <editLayoutMenuItem>Edit Layout...</editLayoutMenuItem>
+    <openLayoutMenuItem>Open Layout</openLayoutMenuItem>
+    <saveLayoutMenuItem>Save Layout</saveLayoutMenuItem>
+    <saveLayoutAsMenuItem>Save Layout As...</saveLayoutAsMenuItem>
+    <settingsMenuItem>Settings</settingsMenuItem>
+    <aboutMenuItem>About</aboutMenuItem>
+    <exitMenuItem>Exit</exitMenuItem>
+    <splitMenuItem_Start>Start</splitMenuItem_Start>
+    <splitMenuItem_Split>Split</splitMenuItem_Split>
+    <splitMenuItem_Resume>Resume</splitMenuItem_Resume>
+    <resetMenuItem>Reset</resetMenuItem>
+    <undoSplitMenuItem>Undo Split</undoSplitMenuItem>
+    <skipSplitMenuItem>Skip Split</skipSplitMenuItem>
+    <pauseMenuItem>Pause</pauseMenuItem>
+    <undoPausesMenuItem>Undo All Pause</undoPausesMenuItem>
+    <hotkeysMenuItem>Global Hotkeys</hotkeysMenuItem>
+    <PersonalBest>Personal Best</PersonalBest>
+    <BestSegments>Best Segments</BestSegments>
+    <AverageSegments>Average Segments</AverageSegments>
+    <NewRace>New Race...</NewRace>
+    <OpenLayoutFromURL>Open Layout from URL</OpenLayoutFromURL>
+    <OpenLayoutText>The selected file was not recognized as a layout file. (</OpenLayoutText>
+    <OpenLayoutText_1>The layout file couldn't be downloaded.</OpenLayoutText_1>
+    <SpeedRunsLiveRulesText>Please read through the rules of SpeedRunsLive carefully.\r\nDo you agree to these rules?</SpeedRunsLiveRulesText>
+    <SpeedRunsLiveRules>SpeedRunsLive Rules</SpeedRunsLiveRules>
+    <OpenRunText>The selected file was not recognized as a splits file.</OpenRunText>
+    <SaveAsPersonalBestText>This run did not beat your current splits. Would you like to save this run as a Personal Best?</SaveAsPersonalBestText>
+    <SaveAsPersonalBest>Save as Personal Best?</SaveAsPersonalBest>
+    <SaveFailed>Save Failed</SaveFailed>
+    <SaveFailedText>Splits could not be saved!</SaveFailedText>
+    <SaveFailedText_1>Layout could not be saved!</SaveFailedText_1>
+    <SaveSplitsText>Your splits have been updated but not yet saved.\nDo you want to save your splits now?</SaveSplitsText>
+    <SaveSplits>Save Splits?</SaveSplits>
+    <SaveLayoutText>Your layout has been updated but not yet saved.\nDo you want to save your layout now?</SaveLayoutText>
+    <SaveLayout>Save Layout?</SaveLayout>
+    <FormClosingText>Settings could not be saved!</FormClosingText>
+    <UpdateTimesText>You have beaten some of your best times.\r\nDo you want to update them?</UpdateTimesText>
+    <UpdateTimes>Update Times?</UpdateTimes>
+    <Races>Races</Races>
+
+    <!-- SettingsDialog -->
+    <btnChooseRaceProvider>Manage Racing Services...</btnChooseRaceProvider>
+    <SavedAccounts>Saved Accounts:</SavedAccounts>
+    <btnLogOut>Log Out of All Accounts</btnLogOut>
+    <Hotkeys>HotKeys</Hotkeys>
+    <chkDeactivateForOtherPrograms>Deactivate For Other Programs</chkDeactivateForOtherPrograms>
+    <StartOrSplit>Start / Split:</StartOrSplit>
+    <chkGlobalHotkeys>Global Hotkeys</chkGlobalHotkeys>
+    <chkDoubleTap>Double Tap Prevention</chkDoubleTap>
+    <Reset>Reset:</Reset>
+    <Pause>Pause:</Pause>
+    <SkipSplit>Skip Split:</SkipSplit>
+    <UndoSplit>Undo Split:</UndoSplit>
+    <ToggleGlobalHotkeys>Toggle Global Hotkeys:</ToggleGlobalHotkeys>
+    <SwitchComparisonPrevious>Switch Comparison (Previous):</SwitchComparisonPrevious>
+    <SwitchComparisonNext>Switch Comparison (Next):</SwitchComparisonNext>
+    <HotkeyDelaySeconds>Hotkey Delay (Seconds):</HotkeyDelaySeconds>
+    <grpHotkeyProfiles>Hotkey Profiles</grpHotkeyProfiles>
+    <lblProfile>Active Hotkey Profile:</lblProfile>
+    <btnRemoveProfile>Remove</btnRemoveProfile>
+    <btnRenameProfile>Rename</btnRenameProfile>
+    <btnNewProfile>New</btnNewProfile>
+    <chkAllowGamepads>Allow Gamepads as Hotkeys</chkAllowGamepads>
+    <RaceViewer>Race Viewer:</RaceViewer>
+    <ActiveComparisons>Active Comparisons:</ActiveComparisons>
+    <RacingServices>Racing Services:</RacingServices>
+    <btnChooseComparisons>Choose Active Comparisons...</btnChooseComparisons>
+    <chkSimpleSOB>Simple Sum of Best Calculation</chkSimpleSOB>
+    <chkWarnOnReset>Warn On Reset If Better Times</chkWarnOnReset>
+    <labelRefreshRate>Refresh Rate (Hz):</labelRefreshRate>
+    <labelLanguage>Language</labelLanguage>
+    <SetHotkey>Set Hotkey...</SetHotkey>
+    <RenameProfileTitle>Rename Hotkey Profile</RenameProfileTitle>
+    <HotkeyProfileName>Hotkey Profile Name:</HotkeyProfileName>
+    <ProfileText>A Hotkey Profile with this name already exists.</ProfileText>
+    <ProfileCaption>Hotkey Profile Already Exists</ProfileCaption>
+    <NewProfileTitle>New Hotkey Profile</NewProfileTitle>
+
+    <!-- RunEditorDialog -->
+    <GameName>Game Name:</GameName>
+    <RunCategory>Run Category:</RunCategory>
+    <StartTimerAt>Start Timer at:</StartTimerAt>
+    <RealTime>Real Time</RealTime>
+    <GameTime>Game Time</GameTime>
+    <Metadata>Additional Info</Metadata>
+    <Attempts>Attempts:</Attempts>
+    <btnOther>Other...</btnOther>
+    <btnImportComparison>Import Comparison...</btnImportComparison>
+    <btnAddComparison>Add Comparison</btnAddComparison>
+    <btnMoveDown>Move Down</btnMoveDown>
+    <btnMoveUp>Move Up</btnMoveUp>
+    <btnRemove>Remove Segment</btnRemove>
+    <btnAdd>Insert Below</btnAdd>
+    <btnInsert>Insert Above</btnInsert>
+    <btnBrowseLayout>Browse</btnBrowseLayout>
+    <chkbxUseLayout>Use Layout</chkbxUseLayout>
+    <btnWebsite>Website</btnWebsite>
+    <btnSettings>Settings</btnSettings>
+    <btnActivate>Activate</btnActivate>
+    <btnDeactivate>Deactivate</btnDeactivate>
+    <lblDescription>Description</lblDescription>
+    <setIconToolStripMenuItem>Set Icon...</setIconToolStripMenuItem>
+    <downloadBoxartToolStripMenuItem>Download Box Art</downloadBoxartToolStripMenuItem>
+    <downloadIconToolStripMenuItem>Download Icon</downloadIconToolStripMenuItem>
+    <openFromURLMenuItem>Open from URL...</openFromURLMenuItem>
+    <removeIconToolStripMenuItem>Remove Icon</removeIconToolStripMenuItem>
+    <fromFileToolStripMenuItem>From File...</fromFileToolStripMenuItem>
+    <fromSpeedruncomToolStripMenuItem>From Speedrun.com...</fromSpeedruncomToolStripMenuItem>
+    <clearHistoryToolStripMenuItem>Clear History</clearHistoryToolStripMenuItem>
+    <clearTimesToolStripMenuItem>Clear Times</clearTimesToolStripMenuItem>
+    <cleanSumOfBestToolStripMenuItem>Clean Sum of Best</cleanSumOfBestToolStripMenuItem>
+    <RunEditorDialog>Splits Editor</RunEditorDialog>
+    <openFromURLMenuItem_1>From URL...</openFromURLMenuItem_1>
+    <editSplitHistoryMenuItem>Edit History</editSplitHistoryMenuItem>
+    <defaultLayoutMenuItem>Default</defaultLayoutMenuItem>
+    <AutoSplitterTip>There is no Auto Splitter available for this game.</AutoSplitterTip>
+    <RenameComparison>Rename Comparison</RenameComparison>
+    <NewComparison>New Comparison</NewComparison>
+    <ComparisonName>Comparison Name</ComparisonName>
+    <ComparisonText>A Comparison name cannot start with [Race].</ComparisonText>
+    <InvalidComparisonName>Invalid Comparison Name</InvalidComparisonName>
+    <ComparisonText_1>A Comparison with this name already exists.</ComparisonText_1>
+    <ComparisonAlreadyExists>Comparison Already Exists</ComparisonAlreadyExists>
+    <DownloadIconText>Could not download the icon of the game!</DownloadIconText>
+    <DownloadBoxArtText>Could not download the box art of the game!</DownloadBoxArtText>
+    <OpenGameIconFromURL>Open Game Icon from URL</OpenGameIconFromURL>
+    <OpenIconText>The URL was not recognized as an image.</OpenIconText>
+    <OpenIconText_1>The Game Icon couldn't be downloaded.</OpenIconText_1>
+
+    <!-- AboutBox -->
+    <textBoxTip>We've put a lot of work into LiveSplit. If you like the program, please consider donating.</textBoxTip>
+    <AboutBox>About LiveSplit</AboutBox>
+
+    <!-- AuthenticationDialog -->
+    <AuthenticationDialog>Authentication</AuthenticationDialog>
+    <Password>Password:</Password>
+    <Username>Username:</Username>
+    <chkRememberPassword>Remember Password</chkRememberPassword>
+
+    <!-- BrowseSpeedrunComDialog -->
+    <BrowseSpeedrunComDialog>Browse Speedrun.com</BrowseSpeedrunComDialog>
+    <btnDownload>Download</btnDownload>
+    <chkDownloadEmpty>Download Empty</chkDownloadEmpty>
+    <chkIncludeTimes>Include Times as Comparison</chkIncludeTimes>
+    <btnShowOnSpeedrunCom>Show on Speedrun.com</btnShowOnSpeedrunCom>
+    <SearchFailedText>Search Failed!</SearchFailedText>
+    <SearchFailedCaption>Search Failed</SearchFailedCaption>
+    <DownloadFailedText>Download Failed!</DownloadFailedText>
+    <DownloadFailedCaption>Download Failed</DownloadFailedCaption>
+    <EnterComparisonName>Enter Comparison Name</EnterComparisonName>
+
+    <!-- ChooseComparisonsDialog -->
+    <ChooseComparisonsDialog>Choose Comparisons</ChooseComparisonsDialog>
+
+    <!-- ComponentSettingsDialog -->
+    <ComponentSettingsDialog>Component Settings</ComponentSettingsDialog>
+    <labelScriptPath>Script Path:</labelScriptPath>
+    <btnSelectFile>Browse...</btnSelectFile>
+    <labelOptions>Options:</labelOptions>
+    <labelCustomSettings>Advanced:</labelCustomSettings>
+    <btnCheckAll>Check All</btnCheckAll>
+    <btnUncheckAll>Uncheck All</btnUncheckAll>
+    <btnResetToDefault>Reset to Default</btnResetToDefault>
+    <checkboxStart>Start</checkboxStart>
+    <checkboxSplit>Split</checkboxSplit>
+    <checkboxReset>Reset</checkboxReset>
+
+    <!-- EditHistoryDialog -->
+    <EditHistoryDialog>Edit History</EditHistoryDialog>
+    <btnRemoveSelected>Remove Selected</btnRemoveSelected>
+
+    <!-- LayoutEditorDialog -->
+    <LayoutEditorDialog>Layout Editor</LayoutEditorDialog>
+    <btnLayoutSettings>Layout Settings</btnLayoutSettings>
+    <rdoHorizontal>Horizontal</rdoHorizontal>
+    <rdoVertical>Vertical</rdoVertical>
+    <btnSetSize>Set Size</btnSetSize>
+    <AddComponentText>The Component could not be loaded.</AddComponentText>
+
+    <!-- LayoutSettingsControls -->
+    <chkMousePassThroughWhileRunning>Ignore Mouse While Running and Not In Focus</chkMousePassThroughWhileRunning>
+    <Colors>Colors</Colors>
+    <lblOutlines>Text Outlines:</lblOutlines>
+    <BestSegment_1>Best Segment:</BestSegment_1>
+    <AheadGainingTime>Ahead (Gaining Time):</AheadGainingTime>
+    <AheadLosingTime>Ahead (Losing Time):</AheadLosingTime>
+    <BehindGainingTime>Behind (Gaining Time):</BehindGainingTime>
+    <BehindLosingTime>Behind (Losing Time):</BehindLosingTime>
+    <chkRainbow>Use Rainbow Best Segment Color</chkRainbow>
+    <NotRunning>Not Running:</NotRunning>
+    <ThinSeparators>Thin Separators:</ThinSeparators>
+    <PersonalBest_1>Personal Best:</PersonalBest_1>
+    <Separators>Separators:</Separators>
+    <Paused>Paused:</Paused>
+    <Shadows>Shadows:</Shadows>
+    <chkAlwaysOnTop>Always on Top</chkAlwaysOnTop>
+    <Fonts>Fonts</Fonts>
+    <chkAntiAliasing>Anti-Aliasing</chkAntiAliasing>
+    <Timer>Timer:</Timer>
+    <Times>Times:</Times>
+    <btnTimer>Choose...</btnTimer>
+    <btnTimes>Choose...</btnTimes>
+    <btnTextFont>Choose...</btnTextFont>
+    <chkDropShadows>Drop Shadows</chkDropShadows>
+    <lblTimer>something</lblTimer>
+    <lblTimes>something</lblTimes>
+    <lblText>something</lblText>
+    <chkBestSegments>Show Best Segments</chkBestSegments>
+    <Opacity>Opacity:</Opacity>
+    <Background>Background</Background>
+    <lblBackgroundColor>Color:</lblBackgroundColor>
+    <lblBackgroundImage>Image:</lblBackgroundImage>
+    <lblImageOpacity>Image Opacity:</lblImageOpacity>
+    <lblBlur>Image Blur:</lblBlur>
+    <BackgroundImageText>Could not load image!</BackgroundImageText>
+    <SetBackgroundImage>Set Background Image...</SetBackgroundImage>
+
+    <!-- LayoutSettingsDialog -->
+    <LayoutSettingsDialog>Layout Settings</LayoutSettingsDialog>
+    <TabPageLayout>Layout</TabPageLayout>
+    <TabPageTimer>Timer</TabPageTimer>
+
+    <!-- MetadataControl -->
+    <lblRegion>Region:</lblRegion>
+    <lblPlatform>Platform:</lblPlatform>
+    <lblRules>Rules:</lblRules>
+    <btnAssociate>Associate with Speedrun.com...</btnAssociate>
+    <btnAssociate_1>Show on Speedrun.com...</btnAssociate_1>
+    <tbxRules></tbxRules>
+    <btnSubmitRun>Submit Run...</btnSubmitRun>
+    <UsesEmulator>Uses Emulator</UsesEmulator>
+    <associateRunTitle_1>Enter Speedrun.com URL</associateRunTitle_1>
+    <associateRunPromptText_1>Speedrun.com Run URL:</associateRunPromptText_1>
+    <associateRunText_1>The URL provided is not a valid speedrun.com Run URL.</associateRunText_1>
+    <InvalidURL>Invalid URL</InvalidURL>
+    <associateRunText_2>The run could not be associated.</associateRunText_2>
+    <SubmittingFailed>Submitting Failed</SubmittingFailed>
+
+    <!-- RaceProviderManagingDialog -->
+    <RaceProviderManagingDialog>Manage Racing Services</RaceProviderManagingDialog>
+    <websiteTextLabel>Website:</websiteTextLabel>
+    <rulesTextLabel>Rules:</rulesTextLabel>
+
+    <!-- SetSizeForm -->
+    <SetSizeForm>Set Layout Size</SetSizeForm>
+    <Width>Width:</Width>
+    <Height>Height:</Height>
+    <chkKeepAspectRatio>Keep Aspect Ratio</chkKeepAspectRatio>
+
+    <!-- ShareRunDialog -->
+    <ShareRunDialog>Run Sharer</ShareRunDialog>
+    <Game>Game:</Game>
+    <Category>Category:</Category>
+    <Version>Version:</Version>
+    <VideoURL>Video URL:</VideoURL>
+    <Insert>Insert:</Insert>
+    <btnInsertGame>Game</btnInsertGame>
+    <btnInsertCategory>Category</btnInsertCategory>
+    <btnInsertTitle>Title</btnInsertTitle>
+    <btnInsertPB>PB</btnInsertPB>
+    <btnPreview>Preview...</btnPreview>
+    <btnInsertSplitName>Split Name</btnInsertSplitName>
+    <btnInsertDeltaTime>Delta Time</btnInsertDeltaTime>
+    <btnInsertSplitTime>Split Time</btnInsertSplitTime>
+    <btnInsertStreamLink>Stream Link</btnInsertStreamLink>
+    <chkAttachSplits>Attach Splits</chkAttachSplits>
+    <btnShare>Share</btnShare>
+    <SubmitText>Your login information seems to be incorrect.</SubmitText>
+    <SubmitText_1>The run could not be shared.</SubmitText_1>
+
+    <!-- SpeedrunComSubmitDialog -->
+    <SpeedrunComSubmitDialog>Submitting to Speedrun.com</SpeedrunComSubmitDialog>
+    <Video>Video:</Video>
+    <Comment>Comment:</Comment>
+    <btnSubmit>Submit</btnSubmit>
+    <SubmitVideoText>You didn't provide a valid Video URL.</SubmitVideoText>
+    <SubmitVideoText_1>You didn't enter a valid Game Time.</SubmitVideoText_1>
+    <SubmitVideoText_2>You didn't enter a valid Real Time without Loads.</SubmitVideoText_2>
+    
+    <!-- SpeedRunsLiveForm -->
+    <SpeedRunsLiveForm>Joining Channel...</SpeedRunsLiveForm>
+    <chatBox></chatBox>
+    <chkReady>Ready</chkReady>
+    <btnJoinQuit>Enter Race</btnJoinQuit>
+    <KickedText>You have been kicked from the IRC Channel.</KickedText>
+    <KickedFromChannel>Kicked From Channel</KickedFromChannel>
+    <DisconnectedText>You have been disconnected from the IRC server.</DisconnectedText>
+    <Disconnected>Disconnected</Disconnected>
+    <NicknameInUseText>Your nickname is already in use.</NicknameInUseText>
+    <NicknameInUse>Nickname In Use</NicknameInUse>
+    <PasswordIncorrectText>The password is incorrect.</PasswordIncorrectText>
+    <PasswordIncorrect>Password Incorrect</PasswordIncorrect>
+    <QuitRace>Quit Race</QuitRace>
+    <EnterRace>Enter Race</EnterRace>
+    <RejoinRace>Rejoin Race</RejoinRace>
+    <ForfeitRace>Forfeit Race</ForfeitRace>
+    <RaceBotDidNotRespondText>RaceBot did not respond to your message. If you created a race within the last 5 minutes, you are not allowed to create another race.</RaceBotDidNotRespondText>
+    <RaceBotDidNotRespond>RaceBot Did Not Respond</RaceBotDidNotRespond>
+    <ConfirmationRequiredText>Due to SpeedRunsLive rules, you need to confirm that you have completed the race before leaving an unfinished race. Do you confirm that you legitimately finished the race?</ConfirmationRequiredText>
+    <ConfirmationRequired>Confirmation Required</ConfirmationRequired>
+
+    <!-- TimerSettings -->
+    <lblSize>Height:</lblSize>
+    <chkGradient>Show Gradient</chkGradient>
+    <TimerColor>Timer Color</TimerColor>
+    <chkOverrideTimerColors>Override Layout Settings</chkOverrideTimerColors>
+    <BackgroundColor>Background Color:</BackgroundColor>
+    <chkCenterTimer>Align to Center</chkCenterTimer>
+    <TimingMethod>Timing Method:</TimingMethod>
+    <TimerFormat>Timer Format:</TimerFormat>
+    <DecimalsFontSize>Decimals Font Size:</DecimalsFontSize>
+</Language>

--- a/LiveSplit/Languages/zh-CN.cfg
+++ b/LiveSplit/Languages/zh-CN.cfg
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Language>
+    <DisplayName>简体中文</DisplayName>
+    <!-- common -->
+    <btnCancel>取消</btnCancel>
+    <btnOK>确定</btnOK>
+    <btnSearch>搜索</btnSearch>
+    <btnClose>关闭</btnClose>
+    <Text>文本: </Text>
+    <Icon>图标: </Icon>
+    <Name>名称:</Name>
+    <SegmentName>片段名称</SegmentName>
+    <SegmentTime>片段时间</SegmentTime>
+    <BestSegment>最佳片段</BestSegment>
+    <Error>错误</Error>
+
+    <!-- TimerForm -->
+    <editSplitsMenuItem>编辑分段...</editSplitsMenuItem>
+    <openSplitsMenuItem>打开分段</openSplitsMenuItem>
+    <saveSplitsMenuItem>保存分段</saveSplitsMenuItem>
+    <saveSplitsAsMenuItem>保存分段到...</saveSplitsAsMenuItem>
+    <closeSplitsMenuItem>关闭分段</closeSplitsMenuItem>
+    <controlMenuItem>控制</controlMenuItem>
+    <comparisonMenuItem>比较</comparisonMenuItem>
+    <shareMenuItem>分享...</shareMenuItem>
+    <editLayoutMenuItem>编辑布局...</editLayoutMenuItem>
+    <openLayoutMenuItem>打开布局</openLayoutMenuItem>
+    <saveLayoutMenuItem>保存布局</saveLayoutMenuItem>
+    <saveLayoutAsMenuItem>保存布局到...</saveLayoutAsMenuItem>
+    <settingsMenuItem>设置</settingsMenuItem>
+    <aboutMenuItem>关于</aboutMenuItem>
+    <exitMenuItem>退出</exitMenuItem>
+    <splitMenuItem_Start>开始</splitMenuItem_Start>
+    <splitMenuItem_Split>分段</splitMenuItem_Split>
+    <splitMenuItem_Resume>恢复</splitMenuItem_Resume>
+    <resetMenuItem>重置</resetMenuItem>
+    <undoSplitMenuItem>重做分段</undoSplitMenuItem>
+    <skipSplitMenuItem>跳过分段</skipSplitMenuItem>
+    <pauseMenuItem>暂停</pauseMenuItem>
+    <undoPausesMenuItem>重做所有暂停</undoPausesMenuItem>
+    <hotkeysMenuItem>全局热键</hotkeysMenuItem>
+    <PersonalBest>个人最佳记录</PersonalBest>
+    <BestSegments>最佳片段</BestSegments>
+    <AverageSegments>平均片段</AverageSegments>
+    <NewRace>新的竞赛...</NewRace>
+    <OpenLayoutFromURL>从 URL 打开布局</OpenLayoutFromURL>
+    <OpenLayoutText>所选文件未被识别为布局文件。 (</OpenLayoutText>
+    <OpenLayoutText_1>无法下载布局文件。</OpenLayoutText_1>
+    <SpeedRunsLiveRulesText>请仔细阅读 SpeedRunsLive 的规则。\r\n您是否同意这些规则？</SpeedRunsLiveRulesText>
+    <SpeedRunsLiveRules>SpeedRunsLive 规则</SpeedRunsLiveRules>
+    <OpenRunText>所选文件未被识别为 Split 文件。</OpenRunText>
+    <SaveAsPersonalBestText>本次速通没有超过你当前的 splits. 你想把这次速通保存为个人最佳记录吗？</SaveAsPersonalBestText>
+    <SaveAsPersonalBest>保存为个人最佳记录？</SaveAsPersonalBest>
+    <SaveFailed>保存失败</SaveFailed>
+    <SaveFailedText>Splits 无法保存！</SaveFailedText>
+    <SaveFailedText_1>布局无法保存！</SaveFailedText_1>
+    <SaveSplitsText>你的分段内容已经更新，但尚未保存。\n你现在想保存你的 splits 吗？</SaveSplitsText>
+    <SaveSplits>保存分段？</SaveSplits>
+    <SaveLayoutText>你的布局已经更新，但尚未保存。\n你现在想保存你的布局吗</SaveLayoutText>
+    <SaveLayout>保存布局？</SaveLayout>
+    <FormClosingText>设置无法保存！</FormClosingText>
+    <UpdateTimesText>你已经超过了你的一些最佳时间。\r\n你想更新它们吗？</UpdateTimesText>
+    <UpdateTimes>更新记录?</UpdateTimes>
+    <Races>竞赛</Races>
+
+    <!-- SettingsDialog -->
+    <btnChooseRaceProvider>管理速通服务...</btnChooseRaceProvider>
+    <SavedAccounts>已保存的账户:</SavedAccounts>
+    <btnLogOut>登出所有账户</btnLogOut>
+    <Hotkeys>热键</Hotkeys>
+    <chkDeactivateForOtherPrograms>停用其他程序</chkDeactivateForOtherPrograms>
+    <StartOrSplit>开始 / 分段:</StartOrSplit>
+    <chkGlobalHotkeys>全局热键</chkGlobalHotkeys>
+    <chkDoubleTap>防止双击</chkDoubleTap>
+    <Reset>重置:</Reset>
+    <Pause>暂停:</Pause>
+    <SkipSplit>跳过分段:</SkipSplit>
+    <UndoSplit>重做分段:</UndoSplit>
+    <ToggleGlobalHotkeys>切换全局热键:</ToggleGlobalHotkeys>
+    <SwitchComparisonPrevious>切换比较 (上一个):</SwitchComparisonPrevious>
+    <SwitchComparisonNext>切换比较 (下一个):</SwitchComparisonNext>
+    <HotkeyDelaySeconds>热键延迟 (秒):</HotkeyDelaySeconds>
+    <grpHotkeyProfiles>热键配置文件</grpHotkeyProfiles>
+    <lblProfile>启用热键配置文件:</lblProfile>
+    <btnRemoveProfile>移除</btnRemoveProfile>
+    <btnRenameProfile>重命名</btnRenameProfile>
+    <btnNewProfile>新建</btnNewProfile>
+    <chkAllowGamepads>允许 Gamepads 作为热键</chkAllowGamepads>
+    <RaceViewer>竞赛视图:</RaceViewer>
+    <ActiveComparisons>启用比较:</ActiveComparisons>
+    <RacingServices>竞赛服务器:</RacingServices>
+    <btnChooseComparisons>选择启用比较...</btnChooseComparisons>
+    <chkSimpleSOB>缩略最佳成绩计算结果</chkSimpleSOB>
+    <chkWarnOnReset>重置记录时进行提示</chkWarnOnReset>
+    <labelRefreshRate>刷新率 (Hz):</labelRefreshRate>
+    <labelLanguage>语言</labelLanguage>
+    <SetHotkey>设置热键...</SetHotkey>
+    <RenameProfileTitle>重命名热键配置文件</RenameProfileTitle>
+    <HotkeyProfileName>热键配置文件名称:</HotkeyProfileName>
+    <ProfileText>此名称的热键配置文件已存在</ProfileText>
+    <ProfileCaption>热键配置文件已存在</ProfileCaption>
+    <NewProfileTitle>新建热键配置文件</NewProfileTitle>
+
+    <!-- RunEditorDialog -->
+    <GameName>游戏名称:</GameName>
+    <RunCategory>速通类型:</RunCategory>
+    <StartTimerAt>开始时间:</StartTimerAt>
+    <RealTime>真实时间</RealTime>
+    <GameTime>游戏时间</GameTime>
+    <Metadata>附加信息</Metadata>
+    <Attempts>尝试次数:</Attempts>
+    <btnOther>其他...</btnOther>
+    <btnImportComparison>导入对比...</btnImportComparison>
+    <btnAddComparison>添加对比</btnAddComparison>
+    <btnMoveDown>下移</btnMoveDown>
+    <btnMoveUp>上移</btnMoveUp>
+    <btnRemove>移除片段</btnRemove>
+    <btnAdd>在下方插入</btnAdd>
+    <btnInsert>在上方插入</btnInsert>
+    <btnBrowseLayout>浏览</btnBrowseLayout>
+    <chkbxUseLayout>使用布局</chkbxUseLayout>
+    <btnWebsite>网站</btnWebsite>
+    <btnSettings>设置</btnSettings>
+    <btnActivate>启用</btnActivate>
+    <btnDeactivate>禁用</btnDeactivate>
+    <lblDescription>描述</lblDescription>
+    <setIconToolStripMenuItem>设置图标...</setIconToolStripMenuItem>
+    <downloadBoxartToolStripMenuItem>下载艺术框</downloadBoxartToolStripMenuItem>
+    <downloadIconToolStripMenuItem>下载图标</downloadIconToolStripMenuItem>
+    <openFromURLMenuItem>从 URL 打开...</openFromURLMenuItem>
+    <removeIconToolStripMenuItem>移除图标</removeIconToolStripMenuItem>
+    <fromFileToolStripMenuItem>从文件...</fromFileToolStripMenuItem>
+    <fromSpeedruncomToolStripMenuItem>从 Speedrun.com...</fromSpeedruncomToolStripMenuItem>
+    <clearHistoryToolStripMenuItem>清除历史记录</clearHistoryToolStripMenuItem>
+    <clearTimesToolStripMenuItem>清除计时</clearTimesToolStripMenuItem>
+    <cleanSumOfBestToolStripMenuItem>清除历史最佳记录</cleanSumOfBestToolStripMenuItem>
+    <RunEditorDialog>分段编辑器</RunEditorDialog>
+    <openFromURLMenuItem_1>从 URL...</openFromURLMenuItem_1>
+    <editSplitHistoryMenuItem>编辑历史记录</editSplitHistoryMenuItem>
+    <defaultLayoutMenuItem>默认</defaultLayoutMenuItem>
+    <AutoSplitterTip>该游戏没有可用的自动计时器</AutoSplitterTip>
+    <RenameComparison>重命名比较</RenameComparison>
+    <NewComparison>新的比较</NewComparison>
+    <ComparisonName>比较名称</ComparisonName>
+    <ComparisonText>比较名称不能以[RACE]开头。</ComparisonText>
+    <InvalidComparisonName>无效的比较名称</InvalidComparisonName>
+    <ComparisonText_1>此比较名称已经存在</ComparisonText_1>
+    <ComparisonAlreadyExists>比较已经存在</ComparisonAlreadyExists>
+    <DownloadIconText>不能下载这个游戏的图标!</DownloadIconText>
+    <DownloadBoxArtText>不能下载这个游戏的艺术框!</DownloadBoxArtText>
+    <OpenGameIconFromURL>从 URL 打开游戏图标</OpenGameIconFromURL>
+    <OpenIconText>无法识别该URL为图像。</OpenIconText>
+    <OpenIconText_1>游戏图标无法下载。</OpenIconText_1>
+
+    <!-- AboutBox -->
+    <textBoxTip>我们在 LiveSplit 上做了很多工作。如果你喜欢这个项目，请打赏我们。</textBoxTip>
+    <AboutBox>关于 LiveSplit</AboutBox>
+
+    <!-- AuthenticationDialog -->
+    <AuthenticationDialog>认证</AuthenticationDialog>
+    <Password>密码:</Password>
+    <Username>用户名:</Username>
+    <chkRememberPassword>记住密码</chkRememberPassword>
+
+    <!-- BrowseSpeedrunComDialog -->
+    <BrowseSpeedrunComDialog>浏览 Speedrun.com</BrowseSpeedrunComDialog>
+    <btnDownload>下载</btnDownload>
+    <chkDownloadEmpty>下载为空</chkDownloadEmpty>
+    <chkIncludeTimes>包含时间作为比较</chkIncludeTimes>
+    <btnShowOnSpeedrunCom>在 Speedrun.com 上展示</btnShowOnSpeedrunCom>
+    <SearchFailedText>搜索失败!</SearchFailedText>
+    <SearchFailedCaption>搜索失败</SearchFailedCaption>
+    <DownloadFailedText>下载失败!</DownloadFailedText>
+    <DownloadFailedCaption>下载失败</DownloadFailedCaption>
+    <EnterComparisonName>输入比较名称</EnterComparisonName>
+
+    <!-- ChooseComparisonsDialog -->
+    <ChooseComparisonsDialog>选择比较</ChooseComparisonsDialog>
+
+    <!-- ComponentSettingsDialog -->
+    <ComponentSettingsDialog>组件设置</ComponentSettingsDialog>
+    <labelScriptPath>脚本路径:</labelScriptPath>
+    <btnSelectFile>浏览...</btnSelectFile>
+    <labelOptions>选项:</labelOptions>
+    <labelCustomSettings>高级:</labelCustomSettings>
+    <btnCheckAll>全选</btnCheckAll>
+    <btnUncheckAll>取消全选</btnUncheckAll>
+    <btnResetToDefault>重置选择</btnResetToDefault>
+    <checkboxStart>开始</checkboxStart>
+    <checkboxSplit>分段</checkboxSplit>
+    <checkboxReset>重置</checkboxReset>
+
+    <!-- EditHistoryDialog -->
+    <EditHistoryDialog>编辑历史记录</EditHistoryDialog>
+    <btnRemoveSelected>移除所选</btnRemoveSelected>
+
+    <!-- LayoutEditorDialog -->
+    <LayoutEditorDialog>布局编辑器</LayoutEditorDialog>
+    <btnLayoutSettings>布局设置</btnLayoutSettings>
+    <rdoHorizontal>横向</rdoHorizontal>
+    <rdoVertical>纵向</rdoVertical>
+    <btnSetSize>设置尺寸</btnSetSize>
+    <AddComponentText>组件不能被加载</AddComponentText>
+
+    <!-- LayoutSettingsControls -->
+    <chkMousePassThroughWhileRunning>在没有聚焦的情况下忽略鼠标</chkMousePassThroughWhileRunning>
+    <Colors>颜色</Colors>
+    <lblOutlines>文本下划线:</lblOutlines>
+    <BestSegment_1>最佳片段:</BestSegment_1>
+    <AheadGainingTime>领先 (获得时间):</AheadGainingTime>
+    <AheadLosingTime>领先 (失去时间):</AheadLosingTime>
+    <BehindGainingTime>落后 (获得时间):</BehindGainingTime>
+    <BehindLosingTime>落后 (失去时间):</BehindLosingTime>
+    <chkRainbow>使用彩色展示最佳片段</chkRainbow>
+    <NotRunning>未运行:</NotRunning>
+    <ThinSeparators>弱分离器:</ThinSeparators>
+    <PersonalBest_1>个人最佳:</PersonalBest_1>
+    <Separators>分离器:</Separators>
+    <Paused>已暂停:</Paused>
+    <Shadows>阴影:</Shadows>
+    <chkAlwaysOnTop>总是在上面</chkAlwaysOnTop>
+    <Fonts>字体</Fonts>
+    <chkAntiAliasing>抗锯齿</chkAntiAliasing>
+    <Timer>计时器:</Timer>
+    <Times>时间:</Times>
+    <btnTimer>选择...</btnTimer>
+    <btnTimes>选择...</btnTimes>
+    <btnTextFont>选择...</btnTextFont>
+    <chkDropShadows>投影阴影</chkDropShadows>
+    <lblTimer>something</lblTimer>
+    <lblTimes>something</lblTimes>
+    <lblText>something</lblText>
+    <chkBestSegments>展示最佳片段</chkBestSegments>
+    <Opacity>透明度:</Opacity>
+    <Background>背景</Background>
+    <lblBackgroundColor>颜色:</lblBackgroundColor>
+    <lblBackgroundImage>图片:</lblBackgroundImage>
+    <lblImageOpacity>图片透明度:</lblImageOpacity>
+    <lblBlur>图片模糊度:</lblBlur>
+    <BackgroundImageText>不能加载图片!</BackgroundImageText>
+    <SetBackgroundImage>设置背景图片...</SetBackgroundImage>
+
+    <!-- LayoutSettingsDialog -->
+    <LayoutSettingsDialog>布局设置</LayoutSettingsDialog>
+    <TabPageLayout>布局</TabPageLayout>
+    <TabPageTimer>计时器</TabPageTimer>
+
+    <!-- MetadataControl -->
+    <lblRegion>地区:</lblRegion>
+    <lblPlatform>平台:</lblPlatform>
+    <lblRules>规则:</lblRules>
+    <btnAssociate>关联 Speedrun.com...</btnAssociate>
+    <btnAssociate_1>展示 Speedrun.com...</btnAssociate_1>
+    <tbxRules></tbxRules>
+    <btnSubmitRun>提交速通...</btnSubmitRun>
+    <UsesEmulator>使用模拟器</UsesEmulator>
+    <associateRunTitle_1>输入 Speedrun.com URL</associateRunTitle_1>
+    <associateRunPromptText_1>Speedrun.com 速通 URL:</associateRunPromptText_1>
+    <associateRunText_1>这个 URL 不是有效的 speedrun.com 速通 URL.</associateRunText_1>
+    <InvalidURL>无效的 URL</InvalidURL>
+    <associateRunText_2>这个速通不能被关联</associateRunText_2>
+    <SubmittingFailed>提交失败</SubmittingFailed>
+
+    <!-- RaceProviderManagingDialog -->
+    <RaceProviderManagingDialog>管理竞速服务</RaceProviderManagingDialog>
+    <websiteTextLabel>网站:</websiteTextLabel>
+    <rulesTextLabel>规则:</rulesTextLabel>
+
+    <!-- SetSizeForm -->
+    <SetSizeForm>设置布局尺寸</SetSizeForm>
+    <Width>宽度:</Width>
+    <Height>高度:</Height>
+    <chkKeepAspectRatio>锁定横纵比</chkKeepAspectRatio>
+
+    <!-- ShareRunDialog -->
+    <ShareRunDialog>速通分享器</ShareRunDialog>
+    <Game>游戏:</Game>
+    <Category>分类:</Category>
+    <Version>版本:</Version>
+    <VideoURL>视频 URL:</VideoURL>
+    <Insert>插入:</Insert>
+    <btnInsertGame>游戏</btnInsertGame>
+    <btnInsertCategory>分类</btnInsertCategory>
+    <btnInsertTitle>标题</btnInsertTitle>
+    <btnInsertPB>PB</btnInsertPB>
+    <btnPreview>预览...</btnPreview>
+    <btnInsertSplitName>Split 名称</btnInsertSplitName>
+    <btnInsertDeltaTime>时间差</btnInsertDeltaTime>
+    <btnInsertSplitTime>Split 时间</btnInsertSplitTime>
+    <btnInsertStreamLink>流式传输连接</btnInsertStreamLink>
+    <chkAttachSplits>附加 Splits</chkAttachSplits>
+    <btnShare>分享</btnShare>
+    <SubmitText>您的登录信息似乎不正确。</SubmitText>
+    <SubmitText_1>该速通不能被分享。</SubmitText_1>
+
+    <!-- SpeedrunComSubmitDialog -->
+    <SpeedrunComSubmitDialog>提交到 Speedrun.com</SpeedrunComSubmitDialog>
+    <Video>视频:</Video>
+    <Comment>评论:</Comment>
+    <btnSubmit>提交</btnSubmit>
+    <SubmitVideoText>你没有提供有效的视频 URL。</SubmitVideoText>
+    <SubmitVideoText_1>你没有输入有效的游戏时间。</SubmitVideoText_1>
+    <SubmitVideoText_2>你没有输入有效的无负载实时时间。</SubmitVideoText_2>
+    
+    <!-- SpeedRunsLiveForm -->
+    <SpeedRunsLiveForm>加入频道...</SpeedRunsLiveForm>
+    <chatBox></chatBox>
+    <chkReady>准备</chkReady>
+    <btnJoinQuit>进入竞赛</btnJoinQuit>
+    <KickedText>你已经被踢出 IRC 频道。</KickedText>
+    <KickedFromChannel>被踢出频道</KickedFromChannel>
+    <DisconnectedText>你已与 IRC 服务器断开连接。</DisconnectedText>
+    <Disconnected>断开连接</Disconnected>
+    <NicknameInUseText>你的昵称已被使用。</NicknameInUseText>
+    <NicknameInUse>昵称已存在</NicknameInUse>
+    <PasswordIncorrectText>密码不正确。</PasswordIncorrectText>
+    <PasswordIncorrect>密码不正确</PasswordIncorrect>
+    <QuitRace>退出竞赛</QuitRace>
+    <EnterRace>进入竞赛</EnterRace>
+    <RejoinRace>重新加入竞赛</RejoinRace>
+    <ForfeitRace>放弃竞赛</ForfeitRace>
+    <RaceBotDidNotRespondText>竞赛机器人没有响应你的信息。如果你在过去5分钟内创建了一场比赛，你就不允许再创建另一场比赛。</RaceBotDidNotRespondText>
+    <RaceBotDidNotRespond>竞赛机器人未响应</RaceBotDidNotRespond>
+    <ConfirmationRequiredText>由于 SpeedRunsLive 的规则，在离开未完成的比赛之前，您需要确认您已经完成了比赛。您是否确认您合法地完成了比赛？</ConfirmationRequiredText>
+    <ConfirmationRequired>需要确认</ConfirmationRequired>
+
+    <!-- TimerSettings -->
+    <lblSizeHeight>高度:</lblSizeHeight>
+    <lblSizeWidth>宽度</lblSizeWidth>
+    <chkGradient>显示渐变</chkGradient>
+    <TimerColor>计时器颜色</TimerColor>
+    <chkOverrideTimerColors>覆盖布局设置</chkOverrideTimerColors>
+    <BackgroundColor>背景颜色:</BackgroundColor>
+    <chkCenterTimer>居中对齐</chkCenterTimer>
+    <TimingMethod>计时方式:</TimingMethod>
+    <TimerFormat>计时器格式:</TimerFormat>
+    <DecimalsFontSize>小数字体大小:</DecimalsFontSize>
+</Language>

--- a/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/LiveSplit/LiveSplit.Core/LiveSplit.Core.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Model\TimingMethod.cs" />
     <Compile Include="Model\TimeStamp.cs" />
     <Compile Include="Options\HotkeyProfile.cs" />
+    <Compile Include="Options\Languages.cs" />
     <Compile Include="Options\Log.cs" />
     <Compile Include="Options\RaceProviderSettings.cs" />
     <Compile Include="Options\RecentSplitsFile.cs" />

--- a/LiveSplit/LiveSplit.Core/Options/ISettings.cs
+++ b/LiveSplit/LiveSplit.Core/Options/ISettings.cs
@@ -43,5 +43,6 @@ namespace LiveSplit.Options
         bool GlobalHotkeysEnabled { get; set; }
         bool DeactivateHotkeysForOtherPrograms { get; set; }
         bool DoubleTapPrevention { get; set; }
+        string Language { get; set; }
     }
 }

--- a/LiveSplit/LiveSplit.Core/Options/Languages.cs
+++ b/LiveSplit/LiveSplit.Core/Options/Languages.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using System.Xml;
+
+namespace LiveSplit.Options
+{
+    public class Languages : ICloneable
+    {
+        private static Languages instance = null;
+        public static Languages Instance { get
+            {
+                if (instance == null)
+                {
+                    instance = new Languages();
+                }
+                return instance;
+            }
+        }
+
+        Languages () {
+            GetLanguagesFromSettings();
+        }
+
+        public Dictionary<string, string> langString = new Dictionary<string, string>()
+        {
+            {"en", "English" },
+            {"zh-CN", "简体中文" },
+        };
+
+        public string replaceStr (string langStr)
+        {
+            return langString[langStr];
+        }
+        public string[] GetLanguagesList ()
+        {
+            var allFileNames = GetAllFileNames("Languages");
+            if (allFileNames != null)
+            {
+                var languagesList = allFileNames.ToArray();
+                for (var i = 0; i < languagesList.Length; i++)
+                {
+                    string filename = languagesList[i];
+                    XmlDocument xml = new XmlDocument();
+                    xml.Load(AppDomain.CurrentDomain.BaseDirectory + "Languages/" + languagesList[i]);
+                    XmlNode languageNode = xml.SelectSingleNode("Language");
+                    if (languageNode != null)
+                    {
+                        string displayName = languageNode.SelectSingleNode("DisplayName").InnerText;
+                        string value = "";
+                        string langKey = languagesList[i].Replace(".cfg", "");
+                        if (!langString.TryGetValue(langKey, out value))
+                        {
+                            langString.Add(langKey, displayName);
+                        }
+                        languagesList[i] = displayName;
+                    }
+                    else
+                    {
+                        languagesList[i] = languagesList[i].Replace(".cfg", "");
+                    }
+                }
+                return languagesList;
+            }
+            else
+            {
+                string[] languagesList = {"English"};
+                return languagesList;
+            }
+        }
+        // 获取当前系统的语言
+        public string localLanguage = System.Threading.Thread.CurrentThread.CurrentCulture.Name;
+        public string nowLanguage;
+
+        public string GetLanguage()
+        {
+            // Console.WriteLine("获取文件夹下所有文件名" + GetAllFileNames("languages"));
+            return nowLanguage;
+        }
+
+        public string GetText(string key, string oldString)
+        {
+            if (!Directory.Exists(AppDomain.CurrentDomain.BaseDirectory + @"Languages"))
+            {
+                localLanguage = "en";
+                nowLanguage = "en";
+                return oldString;
+            }
+            else
+            {
+                XmlDocument xmlDocument = new XmlDocument();
+                xmlDocument.Load(AppDomain.CurrentDomain.BaseDirectory + "Languages/" + nowLanguage + ".cfg");
+                XmlNode languageNode = xmlDocument.SelectSingleNode("Language");
+                if (languageNode != null)
+                {
+                    XmlNode textNode = languageNode.SelectSingleNode(key);
+                    if (textNode != null)
+                    {
+                        return textNode.InnerText;
+                    }
+                    else
+                    {
+                        Console.WriteLine("This key does not exist：" + key);
+                        return oldString;
+                    }
+                }
+                else
+                {
+                    return oldString;
+                }
+            }
+        }
+
+        public object Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<string> GetAllFileNames(string path, string pattern="*.cfg") 
+        {
+            if (Directory.Exists(AppDomain.CurrentDomain.BaseDirectory + @"Languages"))
+            {
+                List<FileInfo> folder = new DirectoryInfo(path).GetFiles(pattern).ToList();
+                if (folder.Count > 0)
+                {
+                    return folder.Select(x => x.Name).ToList();
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private string GetLanguagesFromSettings ()
+        {
+            string settingLanguage = null;
+            if (!File.Exists(AppDomain.CurrentDomain.BaseDirectory + @"settings.cfg"))
+            {
+                // Settings configuration file does not exist
+                nowLanguage = localLanguage;
+                settingLanguage = nowLanguage;
+            }
+            else
+            {
+                XmlDocument xml = new XmlDocument();
+                xml.Load(AppDomain.CurrentDomain.BaseDirectory + "settings.cfg");
+                XmlNode settings = xml.SelectSingleNode("Settings");
+                if (settings != null)
+                {
+                    XmlNode lang = settings.SelectSingleNode("Language");
+                    if (lang != null)
+                    {
+                        nowLanguage = lang.InnerText;
+                        settingLanguage = nowLanguage;
+                    }
+                    else
+                    {
+                        nowLanguage = localLanguage;
+                        settingLanguage = nowLanguage;
+                    }
+                }
+                else
+                {
+                    nowLanguage = localLanguage;
+                    settingLanguage = nowLanguage;
+                }
+            }
+            if (settingLanguage != null)
+            {
+                return settingLanguage;
+            }
+            else
+            {
+                nowLanguage = "en";
+                return nowLanguage;
+            }
+        }
+    }
+}

--- a/LiveSplit/LiveSplit.Core/Options/Settings.cs
+++ b/LiveSplit/LiveSplit.Core/Options/Settings.cs
@@ -73,6 +73,7 @@ namespace LiveSplit.Options
             get { return HotkeyProfiles.First().Value.DoubleTapPrevention; }
             set { HotkeyProfiles.First().Value.DoubleTapPrevention = value; }
         }
+        public string Language { get; set; }
 
         public Settings()
         {
@@ -97,7 +98,8 @@ namespace LiveSplit.Options
                 SimpleSumOfBest = SimpleSumOfBest,
                 RefreshRate = RefreshRate,
                 ActiveAutoSplitters = new List<string>(ActiveAutoSplitters),
-                ComparisonGeneratorStates = new Dictionary<string, bool>(ComparisonGeneratorStates)
+                ComparisonGeneratorStates = new Dictionary<string, bool>(ComparisonGeneratorStates),
+                Language = Languages.Instance.nowLanguage
             };
         }
 

--- a/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
@@ -17,22 +17,22 @@ namespace LiveSplit.Options.SettingsFactories
             {
                 HotkeyProfiles = new Dictionary<string, HotkeyProfile>()
                 {
-                    {HotkeyProfile.DefaultHotkeyProfileName, new HotkeyProfile()
-                        {
-                            SplitKey = new KeyOrButton(Keys.NumPad1),
-                            ResetKey = new KeyOrButton(Keys.NumPad3),
-                            UndoKey = new KeyOrButton(Keys.NumPad8),
-                            SkipKey = new KeyOrButton(Keys.NumPad2),
-                            SwitchComparisonPrevious = new KeyOrButton(Keys.NumPad4),
-                            SwitchComparisonNext = new KeyOrButton(Keys.NumPad6),
-                            PauseKey = null,
-                            ToggleGlobalHotkeys = null,
-                            GlobalHotkeysEnabled = false,
-                            DeactivateHotkeysForOtherPrograms = false,
-                            DoubleTapPrevention = true,
-                            AllowGamepadsAsHotkeys = false,
-                            HotkeyDelay = 0f
-                        }
+                    { HotkeyProfile.DefaultHotkeyProfileName, new HotkeyProfile()
+                    {
+                        SplitKey = new KeyOrButton(Keys.NumPad1),
+                        ResetKey = new KeyOrButton(Keys.NumPad3),
+                        UndoKey = new KeyOrButton(Keys.NumPad8),
+                        SkipKey = new KeyOrButton(Keys.NumPad2),
+                        SwitchComparisonPrevious = new KeyOrButton(Keys.NumPad4),
+                        SwitchComparisonNext = new KeyOrButton(Keys.NumPad6),
+                        PauseKey = null,
+                        ToggleGlobalHotkeys = null,
+                        GlobalHotkeysEnabled = false,
+                        DeactivateHotkeysForOtherPrograms = false,
+                        DoubleTapPrevention = true,
+                        AllowGamepadsAsHotkeys = false,
+                        HotkeyDelay = 0f
+                    }
                     }
                 },
                 WarnOnReset = true,
@@ -48,11 +48,12 @@ namespace LiveSplit.Options.SettingsFactories
                     { BestSplitTimesComparisonGenerator.ComparisonName, false },
                     { AverageSegmentsComparisonGenerator.ComparisonName, true },
                     { MedianSegmentsComparisonGenerator.ComparisonName, false },
-                    { WorstSegmentsComparisonGenerator.ComparisonName, false},
+                    { WorstSegmentsComparisonGenerator.ComparisonName, false },
                     { PercentileComparisonGenerator.ComparisonName, false },
                     { LatestRunComparisonGenerator.ComparisonName, false },
                     { NoneComparisonGenerator.ComparisonName, false }
-                }
+                },
+                Language = "en",
             };
         }
     }

--- a/LiveSplit/LiveSplit.Core/Options/SettingsFactories/XMLSettingsFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Options/SettingsFactories/XMLSettingsFactory.cs
@@ -35,6 +35,7 @@ namespace LiveSplit.Options.SettingsFactories
             settings.RefreshRate = ParseInt(parent["RefreshRate"], settings.RefreshRate);
             settings.LastComparison = ParseString(parent["LastComparison"], settings.LastComparison);
             settings.AgreedToSRLRules = ParseBool(parent["AgreedToSRLRules"], settings.AgreedToSRLRules);
+            settings.Language = ParseString(parent["language"], settings.Language);
 
             var recentLayouts = parent["RecentLayouts"];
             foreach (var layoutNode in recentLayouts.GetElementsByTagName("LayoutPath"))

--- a/LiveSplit/LiveSplit.Core/Options/SettingsSavers/XMLSettingsSaver.cs
+++ b/LiveSplit/LiveSplit.Core/Options/SettingsSavers/XMLSettingsSaver.cs
@@ -85,6 +85,7 @@ namespace LiveSplit.Options.SettingsSavers
             parent.AppendChild(autoSplittersActive);
 
             AddDriftToSettings(document, parent);
+            CreateSetting(document, parent, "Language", Languages.Instance.nowLanguage);
 
             document.Save(stream);
         }

--- a/LiveSplit/LiveSplit.View/View/AboutBox.cs
+++ b/LiveSplit/LiveSplit.View/View/AboutBox.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Windows.Forms;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -14,6 +15,7 @@ namespace LiveSplit.View
             lblVersion.Text = Git.Version;
             if (Git.Branch != "master" && Git.Branch != "HEAD")
                 labelProductName.Text = string.Format("{0} ({1})", labelProductName.Text, Git.Branch);
+            RefreshText();
         }
 
 #region Assembly Attribute Accessors
@@ -124,6 +126,12 @@ namespace LiveSplit.View
         private void lblVersion_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start(Git.RevisionUri.AbsoluteUri);
+        }
+
+        private void RefreshText ()
+        {
+            label1.Text = Languages.Instance.GetText("textBoxTip", "We\'ve put a lot of work into LiveSplit. If you like the program, please consider donating.");
+            Text = Languages.Instance.GetText("AboutBox", "About LiveSplit");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/AuthenticationDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/AuthenticationDialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -12,6 +13,7 @@ namespace LiveSplit.View
         public AuthenticationDialog()
         {
             InitializeComponent();
+            RefreshText();
             Load += AuthenticationDialog_Load;
         }
 
@@ -30,6 +32,16 @@ namespace LiveSplit.View
 
             DialogResult = DialogResult.OK;
             Close();
+        }
+
+        private void RefreshText ()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            label2.Text = Languages.Instance.GetText("Password", "Password:");
+            label1.Text = Languages.Instance.GetText("Username", "Username:");
+            chkRememberPassword.Text = Languages.Instance.GetText("chkRememberPassword", "Remember Password");
+            Text = Languages.Instance.GetText("AuthenticationDialog", "Authentication");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/BrowseSpeedrunComDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/BrowseSpeedrunComDialog.cs
@@ -51,6 +51,7 @@ namespace LiveSplit.View
                     }
                 }
             }
+            RefreshText();
         }
 
         private static int getDigits(int n)
@@ -254,7 +255,12 @@ namespace LiveSplit.View
             catch (Exception ex)
             {
                 Log.Error(ex);
-                MessageBox.Show(this, "Search Failed!", "Search Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this, 
+                    Languages.Instance.GetText("SearchFailedText", "Search Failed!"), 
+                    Languages.Instance.GetText("SearchFailedCaption", "Search Failed"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -283,7 +289,12 @@ namespace LiveSplit.View
             catch (Exception ex)
             {
                 Log.Error(ex);
-                MessageBox.Show(this, "Download Failed!", "Download Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this, 
+                    Languages.Instance.GetText("DownloadFailedText", "Download Failed!"), 
+                    Languages.Instance.GetText("DownloadFailedCaption", "Download Failed"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -297,19 +308,33 @@ namespace LiveSplit.View
                     var succeededName = false;
                     do
                     {
-                        var result = InputBox.Show(this, "Enter Comparison Name", "Name:", ref name);
+                        var result = InputBox.Show(
+                            this, 
+                            Languages.Instance.GetText("EnterComparisonName", "Enter Comparison Name"), 
+                            Languages.Instance.GetText("Name", "Name:"), 
+                            ref name);
                         if (result == DialogResult.Cancel)
                             return result;
 
                         if (name.StartsWith("[Race]"))
                         {
-                            result = MessageBox.Show(this, "A Comparison name cannot start with [Race].", "Invalid Comparison Name", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                            result = MessageBox.Show(
+                                this, 
+                                Languages.Instance.GetText("ComparisonText", "A Comparison name cannot start with [Race]."), 
+                                Languages.Instance.GetText("InvalidComparisonName", "Invalid Comparison Name"), 
+                                MessageBoxButtons.RetryCancel, 
+                                MessageBoxIcon.Error);
                             if (result == DialogResult.Cancel)
                                 return result;
                         }
                         else if (name == Model.Run.PersonalBestComparisonName)
                         {
-                            result = MessageBox.Show(this, "A Comparison with this name already exists.", "Comparison Already Exists", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                            result = MessageBox.Show(
+                                this, 
+                                Languages.Instance.GetText("ComparisonText_1", "A Comparison with this name already exists."), 
+                                Languages.Instance.GetText("ComparisonAlreadyExists", "Comparison Already Exists"), 
+                                MessageBoxButtons.RetryCancel, 
+                                MessageBoxIcon.Error);
                             if (result == DialogResult.Cancel)
                                 return result;
                         }
@@ -360,6 +385,16 @@ namespace LiveSplit.View
                     Process.Start(uri.AbsoluteUri);
                 }
             }
+        }
+
+        private void RefreshText ()
+        {
+            btnSearch.Text = Languages.Instance.GetText("btnSearch", "Search");
+            btnDownload.Text = Languages.Instance.GetText("btnDownload", "Download");
+            chkDownloadEmpty.Text = Languages.Instance.GetText("chkDownloadEmpty", "Download Empty");
+            chkIncludeTimes.Text = Languages.Instance.GetText("chkIncludeTimes", "Include Times as Comparison");
+            btnShowOnSpeedrunCom.Text = Languages.Instance.GetText("btnShowOnSpeedrunCom", "Show on Speedrun.com");
+            Text = Languages.Instance.GetText("BrowseSpeedrunComDialog", "Browse Speedrun.com");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/ChooseComparisonsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ChooseComparisonsDialog.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -25,6 +26,7 @@ namespace LiveSplit.View
                 LatestRunComparisonGenerator.ComparisonName,
                 NoneComparisonGenerator.ComparisonName
             });
+            RefreshText();
         }
 
         private void btnOK_Click(object sender, EventArgs e)
@@ -55,6 +57,13 @@ namespace LiveSplit.View
                 comparisonsListBox.SetItemChecked(comparisonsListBox.Items.IndexOf(generator.Key), generator.Value);
             }
             DialogInitialized = true;
+        }
+
+        private void RefreshText ()
+        {
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            Text = Languages.Instance.GetText("ChooseComparisonsDialog", "Choose Comparisons");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/ComponentSettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ComponentSettingsDialog.cs
@@ -4,6 +4,7 @@ using System;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Xml;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -17,6 +18,7 @@ namespace LiveSplit.View
             InitializeComponent();
             Component = component;
             AddComponent(component);
+            RefreshText();
         }
 
         private void btnOK_Click(object sender, EventArgs e)
@@ -44,6 +46,71 @@ namespace LiveSplit.View
             control.Location = new Point(0, 0);
             panel.Controls.Add(control);
             Name = name + " Settings";
+        }
+
+        private void RefreshText ()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            Text = Languages.Instance.GetText("ComponentSettingsDialog", "Component Settings");
+            foreach (Control item in panel.Controls)
+            {
+                foreach (Control item_1 in item.Controls)
+                {
+                    foreach (Control item_2 in item_1.Controls)
+                    {
+                        if (item_2.Controls.Count > 1)
+                        {
+                            foreach (Control item_3 in item_2.Controls)
+                            {
+                                if (item_3.Name == "btnCheckAll")
+                                {
+                                    item_3.Text = Languages.Instance.GetText("btnCheckAll", "Check All");
+                                }
+                                if (item_3.Name == "btnUncheckAll")
+                                {
+                                    item_3.Text = Languages.Instance.GetText("btnUncheckAll", "Uncheck All");
+                                }
+                                if (item_3.Name == "btnResetToDefault")
+                                {
+                                    item_3.Text = Languages.Instance.GetText("btnResetToDefault", "Reset to Default");
+                                }
+                                if (item_3.Name == "checkboxStart")
+                                {
+                                    item_3.Text = Languages.Instance.GetText("checkboxStart", "Start");
+                                    item_3.Size = new Size(item_3.Width + 20, item_3.Height);
+                                }
+                                if (item_3.Name == "checkboxSplit")
+                                {
+                                    item_3.Text = Languages.Instance.GetText("checkboxSplit", "Split");
+                                    item_3.Size = new Size(item_3.Width + 20, item_3.Height);
+                                }
+                                if (item_3.Name == "checkboxReset")
+                                {
+                                    item_3.Text = Languages.Instance.GetText("checkboxReset", "Reset");
+                                    item_3.Size = new Size(item_3.Width + 20, item_3.Height);
+                                }
+                            }
+                        }
+                        if (item_2.Name == "labelScriptPath")
+                        {
+                            item_2.Text = Languages.Instance.GetText("labelScriptPath", "Script Path:");
+                        }
+                        if (item_2.Name == "btnSelectFile")
+                        {
+                            item_2.Text = Languages.Instance.GetText("btnSelectFile", "Browse...");
+                        }
+                        if (item_2.Name == "labelOptions")
+                        {
+                            item_2.Text = Languages.Instance.GetText("labelOptions", "Options:");
+                        }
+                        if (item_2.Name == "labelCustomSettings")
+                        {
+                            item_2.Text = Languages.Instance.GetText("labelCustomSettings", "Advanced:");
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/EditHistoryDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/EditHistoryDialog.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -14,6 +15,7 @@ namespace LiveSplit.View
             InitializeComponent();
             History = history.Reverse().ToList();
             historyListBox.Items.AddRange(History.Where(x => !string.IsNullOrEmpty(x)).ToArray());
+            RefreshText();
         }
 
         private void btnOK_Click(object sender, EventArgs e)
@@ -36,6 +38,14 @@ namespace LiveSplit.View
 
             historyListBox.Items.Clear();
             historyListBox.Items.AddRange(History.Where(x => !string.IsNullOrEmpty(x)).ToArray());
+        }
+
+        private void RefreshText()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            btnRemove.Text = Languages.Instance.GetText("btnRemoveSelected", "Remove Selected");
+            Text = Languages.Instance.GetText("EditHistoryDialog", "Edit History");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/LayoutEditorDialog.cs
@@ -60,6 +60,7 @@ namespace LiveSplit.View
             CurrentState = state;
             var itemDragger = new ListBoxItemDragger(lbxComponents, form);
             itemDragger.DragCursor = Cursors.SizeAll;
+            RefreshText();
         }
 
         void rdoVertical_CheckedChanged(object sender, EventArgs e)
@@ -98,7 +99,12 @@ namespace LiveSplit.View
             catch (Exception e)
             {
                 Log.Error(e);
-                MessageBox.Show(this, "The Component could not be loaded.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this, 
+                    Languages.Instance.GetText("AddComponentText", "The Component could not be loaded."), 
+                    Languages.Instance.GetText("Error", "Error"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -299,6 +305,17 @@ namespace LiveSplit.View
         {
             DialogResult = DialogResult.Cancel;
             Close();
+        }
+
+        private void RefreshText()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            btnLayoutSettings.Text = Languages.Instance.GetText("btnLayoutSettings", "Layout Settings");
+            rdoHorizontal.Text = Languages.Instance.GetText("rdoHorizontal", "Horizontal");
+            rdoVertical.Text = Languages.Instance.GetText("rdoVertical", "Vertical");
+            btnSetSize.Text = Languages.Instance.GetText("btnSetSize", "Set Size");
+            Text = Languages.Instance.GetText("LayoutEditorDialog", "Layout Editor");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/LayoutSettingsControl.cs
+++ b/LiveSplit/LiveSplit.View/View/LayoutSettingsControl.cs
@@ -61,6 +61,7 @@ namespace LiveSplit.View
 
             cmbBackgroundType.SelectedItem = GetBackgroundTypeString(Settings.BackgroundType);
             originalBackgroundImage = Settings.BackgroundImage;
+            RefreshText();
         }        
 
         private string GetBackgroundTypeString(BackgroundType type)
@@ -88,13 +89,13 @@ namespace LiveSplit.View
             {
                 btnBackground2.BackgroundImage = Settings.BackgroundImage;
                 btnBackground2.BackColor = Color.Transparent;
-                lblBackground.Text = "Image:";
+                lblBackground.Text = Languages.Instance.GetText("lblBackgroundImage", "Image:");
             }
             else
             {
                 btnBackground2.BackgroundImage = null;
                 btnBackground2.DataBindings.Add("BackColor", Settings, btnBackground.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-                lblBackground.Text = "Color:";
+                lblBackground.Text = Languages.Instance.GetText("lblBackgroundColor", "Color:");
             }
             Settings.BackgroundType = (BackgroundType)Enum.Parse(typeof(BackgroundType), selectedItem.Replace(" ", ""));
         }
@@ -110,7 +111,7 @@ namespace LiveSplit.View
             {
                 var dialog = new OpenFileDialog();
                 dialog.Filter = "Image Files|*.BMP;*.JPG;*.GIF;*.JPEG;*.PNG|All files (*.*)|*.*";
-                dialog.Title = "Set Background Image...";
+                dialog.Title = Languages.Instance.GetText("SetBackgroundImage", "Set Background Image...");
                 var result = dialog.ShowDialog();
                 if (result == DialogResult.OK)
                 {
@@ -125,7 +126,11 @@ namespace LiveSplit.View
                     catch (Exception ex)
                     {
                         Log.Error(ex);
-                        MessageBox.Show("Could not load image!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(
+                            Languages.Instance.GetText("BackgroundImageText", "Could not load image!"), 
+                            Languages.Instance.GetText("Error", "Error"), 
+                            MessageBoxButtons.OK, 
+                            MessageBoxIcon.Error);
                     }
                 }
             }
@@ -179,6 +184,45 @@ namespace LiveSplit.View
         {
             chkRainbow_CheckedChanged(null, null);
             chkAntiAliasing_CheckedChanged(null, null);
+        }
+
+        private void RefreshText ()
+        {
+            chkMousePassThroughWhileRunning.Text = Languages.Instance.GetText("chkMousePassThroughWhileRunning", "Ignore Mouse While Running and Not In Focus");
+            groupBox2.Text = Languages.Instance.GetText("Colors", "Colors");
+            lblOutlines.Text = Languages.Instance.GetText("lblOutlines", "Text Outlines:");
+            label9.Text = Languages.Instance.GetText("BestSegment", "Best Segment:");
+            label5.Text = Languages.Instance.GetText("AheadGainingTime", "Ahead (Gaining Time):");
+            label6.Text = Languages.Instance.GetText("AheadLosingTime", "Ahead (Losing Time):");
+            label7.Text = Languages.Instance.GetText("BehindGainingTime", "Behind (Gaining Time):");
+            label11.Text = Languages.Instance.GetText("Text", "Text: ");
+            label8.Text = Languages.Instance.GetText("BehindLosingTime", "Behind (Losing Time):");
+            chkRainbow.Text = Languages.Instance.GetText("chkRainbow", "Use Rainbow Best Segment Color");
+            label10.Text = Languages.Instance.GetText("NotRunning", "Not Running:");
+            label2.Text = Languages.Instance.GetText("ThinSeparators", "Thin Separators:");
+            label4.Text = Languages.Instance.GetText("PersonalBest", "Personal Best:");
+            label3.Text = Languages.Instance.GetText("Separators", "Separators:");
+            label12.Text = Languages.Instance.GetText("Paused", "Paused:");
+            label14.Text = Languages.Instance.GetText("Shadows", "Shadows:");
+            chkAlwaysOnTop.Text = Languages.Instance.GetText("chkAlwaysOnTop", "Always on Top");
+            groupBox1.Text = Languages.Instance.GetText("Fonts", "Fonts");
+            chkAntiAliasing.Text = Languages.Instance.GetText("chkAntiAliasing", "Anti-Aliasing");
+            label16.Text = Languages.Instance.GetText("Timer", "Timer:");
+            label17.Text = Languages.Instance.GetText("Times", "Times:");
+            label18.Text = Languages.Instance.GetText("Text", "Text: ");
+            btnTimer.Text = Languages.Instance.GetText("btnTimer", "Choose...");
+            btnTimes.Text = Languages.Instance.GetText("btnTimes", "Choose...");
+            btnTextFont.Text = Languages.Instance.GetText("btnTextFont", "Choose...");
+            chkDropShadows.Text = Languages.Instance.GetText("chkDropShadows", "Drop Shadows");
+            lblTimer.Text = Languages.Instance.GetText("lblTimer", "something");
+            lblTimes.Text = Languages.Instance.GetText("lblTimes", "something");
+            lblText.Text = Languages.Instance.GetText("lblText", "something");
+            chkBestSegments.Text = Languages.Instance.GetText("chkBestSegments", "Show Best Segments");
+            label13.Text = Languages.Instance.GetText("Opacity", "Opacity:");
+            groupBox3.Text = Languages.Instance.GetText("Background", "Background");
+            lblBackground.Text = Languages.Instance.GetText("lblBackgroundColor", "Color:");
+            lblImageOpacity.Text = Languages.Instance.GetText("lblImageOpacity", "Image Opacity:");
+            lblBlur.Text = Languages.Instance.GetText("lblBlur", "Image Blur:");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/LayoutSettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/LayoutSettingsDialog.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Xml;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -23,6 +24,7 @@ namespace LiveSplit.View
             Components = new List<IComponent>();
             AddNewTab("Layout", new LayoutSettingsControl(settings, layout));
             AddComponents(tabComponent);
+            RefreshText();
         }
 
         private void btnOK_Click(object sender, EventArgs e)
@@ -68,6 +70,24 @@ namespace LiveSplit.View
             page.AutoScroll = true;
             page.Name = name;
             tabControl.TabPages.Add(page);
+        }
+
+        private void RefreshText()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            Text = Languages.Instance.GetText("LayoutSettingsDialog", "Layout Settings");
+            foreach (TabPage item in tabControl.TabPages)
+            {
+                if (item.Name == "Layout")
+                {
+                    item.Text = Languages.Instance.GetText("TabPageLayout", "Layout");
+                }
+                if (item.Name == "Timer")
+                {
+                    item.Text = Languages.Instance.GetText("TabPageTimer", "Timer");
+                }
+            }
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/MetadataControl.cs
+++ b/LiveSplit/LiveSplit.View/View/MetadataControl.cs
@@ -75,6 +75,7 @@ namespace LiveSplit.View
             InitializeComponent();
             dynamicControls = new List<Control>();
             variableBindings = new List<VariableBinding>();
+            RefreshText();
         }
 
         private void MetadataControl_Load(object sender, EventArgs e)
@@ -139,7 +140,7 @@ namespace LiveSplit.View
 
                     var emulatedCheckBox = new CheckBox
                     {
-                        Text = "Uses Emulator",
+                        Text = Languages.Instance.GetText("UsesEmulator", "Uses Emulator"),
                         Anchor = AnchorLeftRight,
                         Margin = new Padding(7, 3, 3, 3),
                         Height = 21,
@@ -277,19 +278,22 @@ namespace LiveSplit.View
             if (string.IsNullOrEmpty(Metadata.RunID))
             {
                 btnSubmit.Enabled = true;
-                btnAssociate.Text = "Associate with Speedrun.com...";
+                btnAssociate.Text = Languages.Instance.GetText("btnAssociate", "Associate with Speedrun.com...");
             }
             else
             {
                 btnSubmit.Enabled = false;
-                btnAssociate.Text = "Show on Speedrun.com...";
+                btnAssociate.Text = Languages.Instance.GetText("btnShowOnSpeedrunCom", "Show on Speedrun.com...");
             }
         }
 
         private void associateRun()
         {
             var url = "";
-            var result = InputBox.Show("Enter Speedrun.com URL", "Speedrun.com Run URL:", ref url);
+            var result = InputBox.Show(
+                Languages.Instance.GetText("associateRunTitle_1", "Enter Speedrun.com URL"), 
+                Languages.Instance.GetText("associateRunPromptText_1", "Speedrun.com Run URL:"), 
+                ref url);
 
             if (result == DialogResult.OK)
             {
@@ -303,13 +307,23 @@ namespace LiveSplit.View
                     }
                     else
                     {
-                        MessageBox.Show(this, "The URL provided is not a valid speedrun.com Run URL.", "Invalid URL", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(
+                            this, 
+                            Languages.Instance.GetText("associateRunText_1", "The URL provided is not a valid speedrun.com Run URL."), 
+                            Languages.Instance.GetText("InvalidURL", "Invalid URL"), 
+                            MessageBoxButtons.OK, 
+                            MessageBoxIcon.Error);
                     }
                 }
                 catch (Exception ex)
                 {
                     Log.Error(ex);
-                    MessageBox.Show(this, "The run could not be associated.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        this, 
+                        Languages.Instance.GetText("associateRunText_2", "The run could not be associated."), 
+                        Languages.Instance.GetText("Error", "Error"), 
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                 }
             }
         }
@@ -351,7 +365,11 @@ namespace LiveSplit.View
 
             if (!isValid)
             {
-                MessageBox.Show(this, reason, "Submitting Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this, reason, 
+                    Languages.Instance.GetText("SubmittingFailed", "Submitting Failed"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 return;
             }
 
@@ -380,6 +398,17 @@ namespace LiveSplit.View
             var variableComboBox = (ComboBox)sender;
             var variableBinding = (VariableBinding)variableComboBox.DataBindings[0].DataSource;
             variableBinding.Value = variableComboBox.SelectedItem.ToString();
+        }
+
+        private void RefreshText ()
+        {
+            lblRegion.Text = Languages.Instance.GetText("lblRegion", "Region:");
+            lblPlatform.Text = Languages.Instance.GetText("lblPlatform", "Platform:");
+            lblRules.Text = Languages.Instance.GetText("lblRules", "Rules:");
+            btnAssociate.Text = Languages.Instance.GetText("btnAssociate", "Associate with Speedrun.com...");
+            tbxRules.Text = Languages.Instance.GetText("tbxRules", "");
+            btnSubmit.Text = Languages.Instance.GetText("btnSubmitRun", "Submit Run...");
+
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/RaceProviderManagingDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RaceProviderManagingDialog.cs
@@ -28,6 +28,7 @@ namespace LiveSplit.View
             {
                 providerListBox.Items.Add(raceProvider.DisplayName, raceProvider.Enabled);
             }
+            RefreshText();
         }
 
         private void LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -67,6 +68,15 @@ namespace LiveSplit.View
             settingsUIPanel.Controls[0].Visible = true;
             websiteTextLabel.Visible = !string.IsNullOrEmpty(Settings[providerListBox.SelectedIndex].WebsiteLink);
             rulesTextLabel.Visible = !string.IsNullOrEmpty(Settings[providerListBox.SelectedIndex].RulesLink);
+        }
+
+        private void RefreshText()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            websiteTextLabel.Text = Languages.Instance.GetText("websiteTextLabel", "Website:");
+            rulesTextLabel.Text = Languages.Instance.GetText("rulesTextLabel", "Rules:");
+            Text = Languages.Instance.GetText("RaceProviderManagingDialog", "Manage Racing Services");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -218,10 +218,73 @@ namespace LiveSplit.View
 
             SelectedMethod = state.CurrentTimingMethod;
 
+            RefreshText();
             RefreshCategoryAutoCompleteList();
             UpdateSegmentList();
             RefreshAutoSplittingUI();
             SetClickEvents(this);
+        }
+
+        private void RefreshText ()
+        {
+            label2.Text = Languages.Instance.GetText("GameName", "Game Name:");
+            label3.Text = Languages.Instance.GetText("RunCategory", "Run Category:");
+            label1.Text = Languages.Instance.GetText("StartTimerAt", "Start Timer at:");
+            RealTime.Text = Languages.Instance.GetText("RealTime", "Real Time");
+            GameTime.Text = Languages.Instance.GetText("GameTime", "Game Time");
+            Metadata.Text = Languages.Instance.GetText("Metadata", "Additional Info");
+            label4.Text = Languages.Instance.GetText("Attempts", "Attempts:");
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            btnOther.Text = Languages.Instance.GetText("btnOther", "Other...");
+            btnImportComparison.Text = Languages.Instance.GetText("btnImportComparison", "Import Comparison...");
+            btnAddComparison.Text = Languages.Instance.GetText("btnAddComparison", "Add Comparison");
+            btnMoveDown.Text = Languages.Instance.GetText("btnMoveDown", "Move Down");
+            btnMoveUp.Text = Languages.Instance.GetText("btnMoveUp", "Move Up");
+            btnRemove.Text = Languages.Instance.GetText("btnRemove", "Remove Segment");
+            btnAdd.Text = Languages.Instance.GetText("btnAdd", "Insert Below");
+            btnInsert.Text = Languages.Instance.GetText("btnInsert", "Insert Above");
+            btnBrowseLayout.Text = Languages.Instance.GetText("btnBrowseLayout", "Browse");
+            chkbxUseLayout.Text = Languages.Instance.GetText("chkbxUseLayout", "Use Layout");
+            btnWebsite.Text = Languages.Instance.GetText("btnWebsite", "Website");
+            btnSettings.Text = Languages.Instance.GetText("btnSettings", "Settings");
+            btnActivate.Text = Languages.Instance.GetText("btnActivate", "Activate");
+            lblDescription.Text = Languages.Instance.GetText("lblDescription", "Description");
+            setIconToolStripMenuItem.Text = Languages.Instance.GetText("setIconToolStripMenuItem", "Set Icon...");
+            downloadBoxartToolStripMenuItem.Text = Languages.Instance.GetText("downloadBoxartToolStripMenuItem", "Download Box Art");
+            downloadIconToolStripMenuItem.Text = Languages.Instance.GetText("downloadIconToolStripMenuItem", "Download Icon");
+            openFromURLMenuItem.Text = Languages.Instance.GetText("openFromURLMenuItem", "Open from URL...");
+            removeIconToolStripMenuItem.Text = Languages.Instance.GetText("removeIconToolStripMenuItem", "Remove Icon");
+            fromFileToolStripMenuItem.Text = Languages.Instance.GetText("fromFileToolStripMenuItem", "From File...");
+            fromSpeedruncomToolStripMenuItem.Text = Languages.Instance.GetText("fromSpeedruncomToolStripMenuItem", "From Speedrun.com...");
+            clearHistoryToolStripMenuItem.Text = Languages.Instance.GetText("clearHistoryToolStripMenuItem", "Clear History");
+            clearTimesToolStripMenuItem.Text = Languages.Instance.GetText("clearTimesToolStripMenuItem", "Clear Times");
+            cleanSumOfBestToolStripMenuItem.Text = Languages.Instance.GetText("cleanSumOfBestToolStripMenuItem", "Clean Sum of Best");
+            Text = Languages.Instance.GetText("RunEditorDialog", "Splits Editor");
+            foreach (DataGridViewColumn item in runGrid.Columns)
+            {
+                Console.WriteLine("表格名：", item.Name);
+                if (item.Name == "Icon")
+                {
+                    item.Name = Languages.Instance.GetText("Icon", "Icon");
+                }
+                if (item.Name == "Segment Name")
+                {
+                    item.Name = Languages.Instance.GetText("SegmentName", "Segment Name");
+                }
+                if (item.Name == "Split Time")
+                {
+                    item.Name = Languages.Instance.GetText("btnInsertSplitTime", "Split Time");
+                }
+                if (item.Name == "Segment Time")
+                {
+                    item.Name = Languages.Instance.GetText("SegmentTime", "Segment Time");
+                }
+                if (item.Name == "Best Segment")
+                {
+                    item.Name = Languages.Instance.GetText("BestSegment", "Best Segment");
+                }
+            }
         }
 
         private IEnumerable<string> SearchForGameName(string name)
@@ -661,7 +724,11 @@ namespace LiveSplit.View
             catch (Exception ex)
             {
                 Log.Error(ex);
-                MessageBox.Show("Could not load image!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    Languages.Instance.GetText("BackgroundImageText", "Could not load image!"), 
+                    Languages.Instance.GetText("Error", "Error"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -708,7 +775,11 @@ namespace LiveSplit.View
                 catch (Exception ex)
                 {
                     Log.Error(ex);
-                    MessageBox.Show("Could not load image!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        Languages.Instance.GetText("BackgroundImageText", "Could not load image!"),
+                        Languages.Instance.GetText("Error", "Error"),
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                 }
             }
         }
@@ -1236,7 +1307,11 @@ namespace LiveSplit.View
             catch (Exception ex)
             {
                 Log.Error(ex);
-                MessageBox.Show("Could not download the icon of the game!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    Languages.Instance.GetText("DownloadIconText", "Could not download the icon of the game!"), 
+                    Languages.Instance.GetText("Error", "Error"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -1277,7 +1352,11 @@ namespace LiveSplit.View
             catch (Exception ex)
             {
                 Log.Error(ex);
-                MessageBox.Show("Could not download the box art of the game!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    Languages.Instance.GetText("DownloadBoxArtText", "Could not download the box art of the game!"), 
+                    Languages.Instance.GetText("Error", "Error"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -1285,7 +1364,10 @@ namespace LiveSplit.View
         {
             string url = null;
 
-            if (DialogResult.OK == InputBox.Show("Open Game Icon from URL", "URL:", ref url))
+            if (DialogResult.OK == InputBox.Show(
+                Languages.Instance.GetText("OpenGameIconFromURL", "Open Game Icon from URL"), 
+                "URL:", 
+                ref url))
             {
                 try
                 {
@@ -1305,14 +1387,22 @@ namespace LiveSplit.View
                         catch (Exception ex)
                         {
                             Log.Error(ex);
-                            MessageBox.Show("The URL was not recognized as an image.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            MessageBox.Show(
+                                Languages.Instance.GetText("OpenIconText", "The URL was not recognized as an image."), 
+                                Languages.Instance.GetText("Error", "Error"), 
+                                MessageBoxButtons.OK, 
+                                MessageBoxIcon.Error);
                         }
                     }
                 }
                 catch (Exception ex)
                 {
                     Log.Error(ex);
-                    MessageBox.Show("The Game Icon couldn't be downloaded.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        Languages.Instance.GetText("OpenIconText_1", "The Game Icon couldn't be downloaded."),
+                        Languages.Instance.GetText("Error", "Error"),
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                 }
             }
         }
@@ -1360,7 +1450,10 @@ namespace LiveSplit.View
         {
             var name = column.Name;
             var newName = name;
-            var dialogResult = InputBox.Show("Rename Comparison", "Comparison Name:", ref newName);
+            var dialogResult = InputBox.Show(
+                Languages.Instance.GetText("RenameComparison", "Rename Comparison"),
+                Languages.Instance.GetText("ComparisonName", "Comparison Name:"), 
+                ref newName);
             if (dialogResult == DialogResult.OK)
             {
                 if (!Run.Comparisons.Contains(newName))
@@ -1384,14 +1477,24 @@ namespace LiveSplit.View
                     }
                     else
                     {
-                        var result = MessageBox.Show(this, "A Comparison name cannot start with [Race].", "Invalid Comparison Name", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                        var result = MessageBox.Show(
+                            this,
+                            Languages.Instance.GetText("ComparisonText", "A Comparison name cannot start with [Race]."),
+                            Languages.Instance.GetText("InvalidComparisonName", "Invalid Comparison Name"),
+                            MessageBoxButtons.RetryCancel, 
+                            MessageBoxIcon.Error);
                         if (result == DialogResult.Retry)
                             RenameComparison(column);
                     }
                 }
                 else if (newName != name)
                 {
-                    var result = MessageBox.Show(this, "A Comparison with this name already exists.", "Comparison Already Exists", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                    var result = MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("ComparisonText_1", "A Comparison with this name already exists."),
+                        Languages.Instance.GetText("ComparisonAlreadyExists", "Comparison Already Exists"),
+                        MessageBoxButtons.RetryCancel, 
+                        MessageBoxIcon.Error);
                     if (result == DialogResult.Retry)
                         RenameComparison(column);
                 }
@@ -1421,7 +1524,10 @@ namespace LiveSplit.View
         private void btnAddComparison_Click(object sender, EventArgs e)
         {
             var name = "";
-            var result = InputBox.Show("New Comparison", "Comparison Name:", ref name);
+            var result = InputBox.Show(
+                Languages.Instance.GetText("NewComparison", "New Comparison"), 
+                Languages.Instance.GetText("ComparisonName", "Comparison Name:"), 
+                ref name);
             if (result == DialogResult.OK)
             {
                 if (!Run.Comparisons.Contains(name))
@@ -1433,14 +1539,24 @@ namespace LiveSplit.View
                     }
                     else
                     {
-                        result = MessageBox.Show(this, "A Comparison name cannot start with [Race].", "Invalid Comparison Name", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                        result = MessageBox.Show(
+                            this, 
+                            Languages.Instance.GetText("ComparisonText", "A Comparison name cannot start with [Race]."), 
+                            Languages.Instance.GetText("InvalidComparisonName", "Invalid Comparison Name"), 
+                            MessageBoxButtons.RetryCancel, 
+                            MessageBoxIcon.Error);
                         if (result == DialogResult.Retry)
                             btnAddComparison_Click(sender, e);
                     }
                 }
                 else
                 {
-                    result = MessageBox.Show(this, "A Comparison with this name already exists.", "Comparison Already Exists", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                    result = MessageBox.Show(
+                        this, 
+                        Languages.Instance.GetText("ComparisonText_1", "A Comparison with this name already exists."), 
+                        Languages.Instance.GetText("ComparisonAlreadyExists", "Comparison Already Exists"), 
+                        MessageBoxButtons.RetryCancel, 
+                        MessageBoxIcon.Error);
                     if (result == DialogResult.Retry)
                         btnAddComparison_Click(sender, e);
                 }
@@ -1472,11 +1588,11 @@ namespace LiveSplit.View
         protected void RefreshAutoSplittingUI()
         {
             lblDescription.Text = Run.AutoSplitter == null
-                ? "There is no Auto Splitter available for this game."
+                ? Languages.Instance.GetText("AutoSplitterTip", "There is no Auto Splitter available for this game.")
                 : Run.AutoSplitter.Description;
             btnActivate.Text = Run.IsAutoSplitterActive()
-                ? "Deactivate"
-                : "Activate";
+                ? Languages.Instance.GetText("btnDeactivate", "Deactivate")
+                : Languages.Instance.GetText("btnActivate", "Activate");
             btnActivate.Enabled = Run.AutoSplitter != null;
             btnSettings.Enabled = Run.IsAutoSplitterActive() && Run.AutoSplitter.Component.GetSettingsControl(LayoutMode.Vertical) != null;
             btnWebsite.Visible = Run.AutoSplitter != null && Run.AutoSplitter.Website != null;

--- a/LiveSplit/LiveSplit.View/View/SetSizeForm.cs
+++ b/LiveSplit/LiveSplit.View/View/SetSizeForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -43,7 +44,7 @@ namespace LiveSplit.View
             nmWidth.DataBindings.Add("Value", this, "FormWidth", false, DataSourceUpdateMode.OnPropertyChanged);
             nmHeight.DataBindings.Add("Value", this, "FormHeight", false, DataSourceUpdateMode.OnPropertyChanged);
             chkKeepAspectRatio.DataBindings.Add("Checked", this, "KeepAspectRatio", false, DataSourceUpdateMode.OnPropertyChanged);
-
+            RefreshText();
         }
 
         protected void HeightChanged()
@@ -83,6 +84,16 @@ namespace LiveSplit.View
         {
             DialogResult = DialogResult.Cancel;
             Close();
+        }
+
+        private void RefreshText ()
+        {
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            label1.Text = Languages.Instance.GetText("Width", "Width:");
+            label2.Text = Languages.Instance.GetText("Height", "Height:");
+            chkKeepAspectRatio.Text = Languages.Instance.GetText("chkKeepAspectRatio", "Keep Aspect Ratio");
+            Text = Languages.Instance.GetText("SetSizeForm", "Set Layout Size");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace LiveSplit.View
+﻿using LiveSplit.Options;
+
+namespace LiveSplit.View
 {
     partial class SettingsDialog
     {
@@ -76,6 +78,8 @@
             this.panelRefreshRate = new System.Windows.Forms.Panel();
             this.txtRefreshRate = new System.Windows.Forms.TextBox();
             this.labelRefreshRate = new System.Windows.Forms.Label();
+            this.label14 = new System.Windows.Forms.Label();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -87,16 +91,16 @@
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 4;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 184F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 245F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 26F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 55F));
-            this.tableLayoutPanel1.Controls.Add(this.btnChooseRaceProvider, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.btnOK, 0, 7);
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 35F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 73F));
+            this.tableLayoutPanel1.Controls.Add(this.comboBox1, 1, 7);
+            this.tableLayoutPanel1.Controls.Add(this.btnChooseRaceProvider, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.label5, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.btnLogOut, 1, 5);
             this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.btnCancel, 2, 7);
+            this.tableLayoutPanel1.Controls.Add(this.btnCancel, 2, 8);
             this.tableLayoutPanel1.Controls.Add(this.cbxRaceViewer, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.label11, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.label12, 0, 4);
@@ -105,28 +109,36 @@
             this.tableLayoutPanel1.Controls.Add(this.chkSimpleSOB, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.chkWarnOnReset, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.panelRefreshRate, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.btnOK, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.label14, 0, 7);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(9, 8);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 8;
+            this.tableLayoutPanel1.RowCount = 9;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(380, 630);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 36F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(507, 762);
             this.tableLayoutPanel1.TabIndex = 0;
+            this.tableLayoutPanel1.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel1_Paint);
             // 
             // btnChooseRaceProvider
             // 
             this.btnChooseRaceProvider.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnChooseRaceProvider, 3);
-            this.btnChooseRaceProvider.Location = new System.Drawing.Point(187, 488);
+            this.btnChooseRaceProvider.Location = new System.Drawing.Point(249, 561);
+            this.btnChooseRaceProvider.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnChooseRaceProvider.Name = "btnChooseRaceProvider";
-            this.btnChooseRaceProvider.Size = new System.Drawing.Size(190, 23);
+            this.btnChooseRaceProvider.Size = new System.Drawing.Size(254, 27);
             this.btnChooseRaceProvider.TabIndex = 6;
             this.btnChooseRaceProvider.Text = "Manage Racing Services...";
             this.btnChooseRaceProvider.UseVisualStyleBackColor = true;
@@ -148,9 +160,10 @@
             // 
             this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 551);
+            this.label5.Location = new System.Drawing.Point(4, 633);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(178, 13);
+            this.label5.Size = new System.Drawing.Size(237, 15);
             this.label5.TabIndex = 10;
             this.label5.Text = "Saved Accounts:";
             // 
@@ -158,9 +171,10 @@
             // 
             this.btnLogOut.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnLogOut, 3);
-            this.btnLogOut.Location = new System.Drawing.Point(187, 546);
+            this.btnLogOut.Location = new System.Drawing.Point(249, 627);
+            this.btnLogOut.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnLogOut.Name = "btnLogOut";
-            this.btnLogOut.Size = new System.Drawing.Size(190, 23);
+            this.btnLogOut.Size = new System.Drawing.Size(254, 27);
             this.btnLogOut.TabIndex = 8;
             this.btnLogOut.Text = "Log Out of All Accounts";
             this.btnLogOut.UseVisualStyleBackColor = true;
@@ -171,9 +185,11 @@
             this.tableLayoutPanel1.SetColumnSpan(this.groupBox1, 4);
             this.groupBox1.Controls.Add(this.tableLayoutPanel2);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(3, 3);
+            this.groupBox1.Location = new System.Drawing.Point(4, 3);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(374, 421);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.groupBox1.Size = new System.Drawing.Size(499, 486);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Hotkeys";
@@ -181,9 +197,9 @@
             // tableLayoutPanel2
             // 
             this.tableLayoutPanel2.ColumnCount = 3;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 178F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 237F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 56F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 75F));
             this.tableLayoutPanel2.Controls.Add(this.chkDeactivateForOtherPrograms, 1, 8);
             this.tableLayoutPanel2.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.chkGlobalHotkeys, 0, 8);
@@ -208,23 +224,24 @@
             this.tableLayoutPanel2.Controls.Add(this.grpHotkeyProfiles, 0, 11);
             this.tableLayoutPanel2.Controls.Add(this.chkAllowGamepads, 0, 10);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(4, 21);
+            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 12;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 83F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(368, 402);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 96F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(491, 462);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // chkDeactivateForOtherPrograms
@@ -233,10 +250,10 @@
             | System.Windows.Forms.AnchorStyles.Left)));
             this.chkDeactivateForOtherPrograms.AutoSize = true;
             this.tableLayoutPanel2.SetColumnSpan(this.chkDeactivateForOtherPrograms, 2);
-            this.chkDeactivateForOtherPrograms.Location = new System.Drawing.Point(185, 235);
-            this.chkDeactivateForOtherPrograms.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkDeactivateForOtherPrograms.Location = new System.Drawing.Point(246, 267);
+            this.chkDeactivateForOtherPrograms.Margin = new System.Windows.Forms.Padding(9, 3, 4, 3);
             this.chkDeactivateForOtherPrograms.Name = "chkDeactivateForOtherPrograms";
-            this.chkDeactivateForOtherPrograms.Size = new System.Drawing.Size(172, 23);
+            this.chkDeactivateForOtherPrograms.Size = new System.Drawing.Size(119, 27);
             this.chkDeactivateForOtherPrograms.TabIndex = 10;
             this.chkDeactivateForOtherPrograms.Text = "Deactivate For Other Programs";
             this.chkDeactivateForOtherPrograms.UseVisualStyleBackColor = true;
@@ -245,9 +262,10 @@
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 8);
+            this.label1.Location = new System.Drawing.Point(4, 9);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(172, 13);
+            this.label1.Size = new System.Drawing.Size(229, 15);
             this.label1.TabIndex = 4;
             this.label1.Text = "Start / Split:";
             // 
@@ -256,10 +274,10 @@
             this.chkGlobalHotkeys.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.chkGlobalHotkeys.AutoSize = true;
-            this.chkGlobalHotkeys.Location = new System.Drawing.Point(7, 235);
-            this.chkGlobalHotkeys.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkGlobalHotkeys.Location = new System.Drawing.Point(9, 267);
+            this.chkGlobalHotkeys.Margin = new System.Windows.Forms.Padding(9, 3, 4, 3);
             this.chkGlobalHotkeys.Name = "chkGlobalHotkeys";
-            this.chkGlobalHotkeys.Size = new System.Drawing.Size(98, 23);
+            this.chkGlobalHotkeys.Size = new System.Drawing.Size(89, 27);
             this.chkGlobalHotkeys.TabIndex = 9;
             this.chkGlobalHotkeys.Text = "Global Hotkeys";
             this.chkGlobalHotkeys.UseVisualStyleBackColor = true;
@@ -269,10 +287,10 @@
             // 
             this.chkDoubleTap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkDoubleTap.AutoSize = true;
-            this.chkDoubleTap.Location = new System.Drawing.Point(7, 267);
-            this.chkDoubleTap.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkDoubleTap.Location = new System.Drawing.Point(9, 304);
+            this.chkDoubleTap.Margin = new System.Windows.Forms.Padding(9, 3, 4, 3);
             this.chkDoubleTap.Name = "chkDoubleTap";
-            this.chkDoubleTap.Size = new System.Drawing.Size(168, 17);
+            this.chkDoubleTap.Size = new System.Drawing.Size(224, 19);
             this.chkDoubleTap.TabIndex = 11;
             this.chkDoubleTap.Text = "Double Tap Prevention";
             this.chkDoubleTap.UseVisualStyleBackColor = true;
@@ -281,10 +299,11 @@
             // 
             this.txtStartSplit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtStartSplit, 2);
-            this.txtStartSplit.Location = new System.Drawing.Point(181, 4);
+            this.txtStartSplit.Location = new System.Drawing.Point(241, 4);
+            this.txtStartSplit.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtStartSplit.Name = "txtStartSplit";
             this.txtStartSplit.ReadOnly = true;
-            this.txtStartSplit.Size = new System.Drawing.Size(184, 20);
+            this.txtStartSplit.Size = new System.Drawing.Size(246, 25);
             this.txtStartSplit.TabIndex = 1;
             this.txtStartSplit.Enter += new System.EventHandler(this.Split_Set_Enter);
             // 
@@ -292,9 +311,10 @@
             // 
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 37);
+            this.label2.Location = new System.Drawing.Point(4, 42);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(172, 13);
+            this.label2.Size = new System.Drawing.Size(229, 15);
             this.label2.TabIndex = 5;
             this.label2.Text = "Reset:";
             // 
@@ -302,9 +322,10 @@
             // 
             this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(3, 124);
+            this.label6.Location = new System.Drawing.Point(4, 141);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(172, 13);
+            this.label6.Size = new System.Drawing.Size(229, 15);
             this.label6.TabIndex = 8;
             this.label6.Text = "Pause:";
             // 
@@ -312,10 +333,11 @@
             // 
             this.txtReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtReset, 2);
-            this.txtReset.Location = new System.Drawing.Point(181, 33);
+            this.txtReset.Location = new System.Drawing.Point(241, 37);
+            this.txtReset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtReset.Name = "txtReset";
             this.txtReset.ReadOnly = true;
-            this.txtReset.Size = new System.Drawing.Size(184, 20);
+            this.txtReset.Size = new System.Drawing.Size(246, 25);
             this.txtReset.TabIndex = 2;
             this.txtReset.Enter += new System.EventHandler(this.Reset_Set_Enter);
             // 
@@ -323,10 +345,11 @@
             // 
             this.txtPause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtPause, 2);
-            this.txtPause.Location = new System.Drawing.Point(181, 120);
+            this.txtPause.Location = new System.Drawing.Point(241, 136);
+            this.txtPause.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtPause.Name = "txtPause";
             this.txtPause.ReadOnly = true;
-            this.txtPause.Size = new System.Drawing.Size(184, 20);
+            this.txtPause.Size = new System.Drawing.Size(246, 25);
             this.txtPause.TabIndex = 5;
             this.txtPause.Enter += new System.EventHandler(this.Pause_Set_Enter);
             // 
@@ -334,9 +357,10 @@
             // 
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 95);
+            this.label3.Location = new System.Drawing.Point(4, 108);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(172, 13);
+            this.label3.Size = new System.Drawing.Size(229, 15);
             this.label3.TabIndex = 6;
             this.label3.Text = "Skip Split:";
             // 
@@ -344,9 +368,10 @@
             // 
             this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 66);
+            this.label4.Location = new System.Drawing.Point(4, 75);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(172, 13);
+            this.label4.Size = new System.Drawing.Size(229, 15);
             this.label4.TabIndex = 7;
             this.label4.Text = "Undo Split:";
             // 
@@ -354,10 +379,11 @@
             // 
             this.txtSkip.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtSkip, 2);
-            this.txtSkip.Location = new System.Drawing.Point(181, 91);
+            this.txtSkip.Location = new System.Drawing.Point(241, 103);
+            this.txtSkip.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtSkip.Name = "txtSkip";
             this.txtSkip.ReadOnly = true;
-            this.txtSkip.Size = new System.Drawing.Size(184, 20);
+            this.txtSkip.Size = new System.Drawing.Size(246, 25);
             this.txtSkip.TabIndex = 4;
             this.txtSkip.Enter += new System.EventHandler(this.Skip_Set_Enter);
             // 
@@ -365,10 +391,11 @@
             // 
             this.txtUndo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtUndo, 2);
-            this.txtUndo.Location = new System.Drawing.Point(181, 62);
+            this.txtUndo.Location = new System.Drawing.Point(241, 70);
+            this.txtUndo.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtUndo.Name = "txtUndo";
             this.txtUndo.ReadOnly = true;
-            this.txtUndo.Size = new System.Drawing.Size(184, 20);
+            this.txtUndo.Size = new System.Drawing.Size(246, 25);
             this.txtUndo.TabIndex = 3;
             this.txtUndo.Enter += new System.EventHandler(this.Undo_Set_Enter);
             // 
@@ -376,9 +403,10 @@
             // 
             this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 211);
+            this.label7.Location = new System.Drawing.Point(4, 240);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(172, 13);
+            this.label7.Size = new System.Drawing.Size(229, 15);
             this.label7.TabIndex = 9;
             this.label7.Text = "Toggle Global Hotkeys:";
             // 
@@ -386,10 +414,11 @@
             // 
             this.txtToggle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtToggle, 2);
-            this.txtToggle.Location = new System.Drawing.Point(181, 207);
+            this.txtToggle.Location = new System.Drawing.Point(241, 235);
+            this.txtToggle.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtToggle.Name = "txtToggle";
             this.txtToggle.ReadOnly = true;
-            this.txtToggle.Size = new System.Drawing.Size(184, 20);
+            this.txtToggle.Size = new System.Drawing.Size(246, 25);
             this.txtToggle.TabIndex = 8;
             this.txtToggle.Enter += new System.EventHandler(this.Toggle_Set_Enter);
             // 
@@ -397,9 +426,10 @@
             // 
             this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(3, 153);
+            this.label8.Location = new System.Drawing.Point(4, 174);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(172, 13);
+            this.label8.Size = new System.Drawing.Size(229, 15);
             this.label8.TabIndex = 10;
             this.label8.Text = "Switch Comparison (Previous):";
             // 
@@ -407,9 +437,10 @@
             // 
             this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(3, 182);
+            this.label9.Location = new System.Drawing.Point(4, 207);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(172, 13);
+            this.label9.Size = new System.Drawing.Size(229, 15);
             this.label9.TabIndex = 12;
             this.label9.Text = "Switch Comparison (Next):";
             // 
@@ -417,10 +448,11 @@
             // 
             this.txtSwitchPrevious.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchPrevious, 2);
-            this.txtSwitchPrevious.Location = new System.Drawing.Point(181, 149);
+            this.txtSwitchPrevious.Location = new System.Drawing.Point(241, 169);
+            this.txtSwitchPrevious.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtSwitchPrevious.Name = "txtSwitchPrevious";
             this.txtSwitchPrevious.ReadOnly = true;
-            this.txtSwitchPrevious.Size = new System.Drawing.Size(184, 20);
+            this.txtSwitchPrevious.Size = new System.Drawing.Size(246, 25);
             this.txtSwitchPrevious.TabIndex = 6;
             this.txtSwitchPrevious.Enter += new System.EventHandler(this.Switch_Previous_Set_Enter);
             // 
@@ -428,10 +460,11 @@
             // 
             this.txtSwitchNext.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.SetColumnSpan(this.txtSwitchNext, 2);
-            this.txtSwitchNext.Location = new System.Drawing.Point(181, 178);
+            this.txtSwitchNext.Location = new System.Drawing.Point(241, 202);
+            this.txtSwitchNext.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtSwitchNext.Name = "txtSwitchNext";
             this.txtSwitchNext.ReadOnly = true;
-            this.txtSwitchNext.Size = new System.Drawing.Size(184, 20);
+            this.txtSwitchNext.Size = new System.Drawing.Size(246, 25);
             this.txtSwitchNext.TabIndex = 7;
             this.txtSwitchNext.Enter += new System.EventHandler(this.Switch_Next_Set_Enter);
             // 
@@ -439,18 +472,20 @@
             // 
             this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(181, 269);
+            this.label10.Location = new System.Drawing.Point(241, 306);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(128, 13);
+            this.label10.Size = new System.Drawing.Size(171, 15);
             this.label10.TabIndex = 14;
             this.label10.Text = "Hotkey Delay (Seconds):";
             // 
             // txtDelay
             // 
             this.txtDelay.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtDelay.Location = new System.Drawing.Point(315, 265);
+            this.txtDelay.Location = new System.Drawing.Point(420, 301);
+            this.txtDelay.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtDelay.Name = "txtDelay";
-            this.txtDelay.Size = new System.Drawing.Size(50, 20);
+            this.txtDelay.Size = new System.Drawing.Size(67, 25);
             this.txtDelay.TabIndex = 12;
             this.txtDelay.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
@@ -459,9 +494,11 @@
             this.tableLayoutPanel2.SetColumnSpan(this.grpHotkeyProfiles, 3);
             this.grpHotkeyProfiles.Controls.Add(this.tableLayoutPanel3);
             this.grpHotkeyProfiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.grpHotkeyProfiles.Location = new System.Drawing.Point(3, 322);
+            this.grpHotkeyProfiles.Location = new System.Drawing.Point(4, 366);
+            this.grpHotkeyProfiles.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.grpHotkeyProfiles.Name = "grpHotkeyProfiles";
-            this.grpHotkeyProfiles.Size = new System.Drawing.Size(362, 77);
+            this.grpHotkeyProfiles.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.grpHotkeyProfiles.Size = new System.Drawing.Size(483, 93);
             this.grpHotkeyProfiles.TabIndex = 13;
             this.grpHotkeyProfiles.TabStop = false;
             this.grpHotkeyProfiles.Text = "Hotkey Profiles";
@@ -471,29 +508,31 @@
             this.tableLayoutPanel3.ColumnCount = 4;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 89.11917F));
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 10.88083F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 81F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 82F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 108F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 113F));
             this.tableLayoutPanel3.Controls.Add(this.lblProfile, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.cmbHotkeyProfiles, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.btnRemoveProfile, 3, 1);
             this.tableLayoutPanel3.Controls.Add(this.btnRenameProfile, 2, 1);
             this.tableLayoutPanel3.Controls.Add(this.btnNewProfile, 0, 1);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(4, 21);
+            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 2;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(356, 58);
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(475, 69);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // lblProfile
             // 
             this.lblProfile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.lblProfile.AutoSize = true;
-            this.lblProfile.Location = new System.Drawing.Point(3, 8);
+            this.lblProfile.Location = new System.Drawing.Point(4, 9);
+            this.lblProfile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblProfile.Name = "lblProfile";
-            this.lblProfile.Size = new System.Drawing.Size(166, 13);
+            this.lblProfile.Size = new System.Drawing.Size(218, 15);
             this.lblProfile.TabIndex = 0;
             this.lblProfile.Text = "Active Hotkey Profile:";
             // 
@@ -503,18 +542,20 @@
             this.tableLayoutPanel3.SetColumnSpan(this.cmbHotkeyProfiles, 3);
             this.cmbHotkeyProfiles.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbHotkeyProfiles.FormattingEnabled = true;
-            this.cmbHotkeyProfiles.Location = new System.Drawing.Point(175, 4);
+            this.cmbHotkeyProfiles.Location = new System.Drawing.Point(230, 5);
+            this.cmbHotkeyProfiles.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cmbHotkeyProfiles.Name = "cmbHotkeyProfiles";
-            this.cmbHotkeyProfiles.Size = new System.Drawing.Size(178, 21);
+            this.cmbHotkeyProfiles.Size = new System.Drawing.Size(241, 23);
             this.cmbHotkeyProfiles.TabIndex = 0;
             this.cmbHotkeyProfiles.SelectedIndexChanged += new System.EventHandler(this.cmbHotkeyProfiles_SelectedIndexChanged);
             // 
             // btnRemoveProfile
             // 
             this.btnRemoveProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnRemoveProfile.Location = new System.Drawing.Point(278, 32);
+            this.btnRemoveProfile.Location = new System.Drawing.Point(371, 37);
+            this.btnRemoveProfile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnRemoveProfile.Name = "btnRemoveProfile";
-            this.btnRemoveProfile.Size = new System.Drawing.Size(75, 23);
+            this.btnRemoveProfile.Size = new System.Drawing.Size(100, 27);
             this.btnRemoveProfile.TabIndex = 3;
             this.btnRemoveProfile.Text = "Remove";
             this.btnRemoveProfile.UseVisualStyleBackColor = true;
@@ -523,9 +564,10 @@
             // btnRenameProfile
             // 
             this.btnRenameProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.btnRenameProfile.Location = new System.Drawing.Point(196, 32);
+            this.btnRenameProfile.Location = new System.Drawing.Point(257, 37);
+            this.btnRenameProfile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnRenameProfile.Name = "btnRenameProfile";
-            this.btnRenameProfile.Size = new System.Drawing.Size(75, 23);
+            this.btnRenameProfile.Size = new System.Drawing.Size(100, 27);
             this.btnRenameProfile.TabIndex = 2;
             this.btnRenameProfile.Text = "Rename";
             this.btnRenameProfile.UseVisualStyleBackColor = true;
@@ -535,9 +577,10 @@
             // 
             this.btnNewProfile.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.tableLayoutPanel3.SetColumnSpan(this.btnNewProfile, 2);
-            this.btnNewProfile.Location = new System.Drawing.Point(115, 32);
+            this.btnNewProfile.Location = new System.Drawing.Point(149, 37);
+            this.btnNewProfile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnNewProfile.Name = "btnNewProfile";
-            this.btnNewProfile.Size = new System.Drawing.Size(75, 23);
+            this.btnNewProfile.Size = new System.Drawing.Size(100, 27);
             this.btnNewProfile.TabIndex = 1;
             this.btnNewProfile.Text = "New";
             this.btnNewProfile.UseVisualStyleBackColor = true;
@@ -547,10 +590,10 @@
             // 
             this.chkAllowGamepads.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkAllowGamepads.AutoSize = true;
-            this.chkAllowGamepads.Location = new System.Drawing.Point(7, 296);
-            this.chkAllowGamepads.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkAllowGamepads.Location = new System.Drawing.Point(9, 337);
+            this.chkAllowGamepads.Margin = new System.Windows.Forms.Padding(9, 3, 4, 3);
             this.chkAllowGamepads.Name = "chkAllowGamepads";
-            this.chkAllowGamepads.Size = new System.Drawing.Size(168, 17);
+            this.chkAllowGamepads.Size = new System.Drawing.Size(224, 19);
             this.chkAllowGamepads.TabIndex = 15;
             this.chkAllowGamepads.Text = "Allow Gamepads as Hotkeys";
             this.chkAllowGamepads.UseVisualStyleBackColor = true;
@@ -561,9 +604,10 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnCancel, 2);
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(302, 604);
+            this.btnCancel.Location = new System.Drawing.Point(403, 732);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Size = new System.Drawing.Size(100, 27);
             this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -580,18 +624,20 @@
             "MultiTwitch",
             "Kadgar",
             "Speedrun.tv"});
-            this.cbxRaceViewer.Location = new System.Drawing.Point(187, 460);
+            this.cbxRaceViewer.Location = new System.Drawing.Point(249, 530);
+            this.cbxRaceViewer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cbxRaceViewer.Name = "cbxRaceViewer";
-            this.cbxRaceViewer.Size = new System.Drawing.Size(190, 21);
+            this.cbxRaceViewer.Size = new System.Drawing.Size(254, 23);
             this.cbxRaceViewer.TabIndex = 5;
             // 
             // label11
             // 
             this.label11.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(3, 464);
+            this.label11.Location = new System.Drawing.Point(4, 534);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(178, 13);
+            this.label11.Size = new System.Drawing.Size(237, 15);
             this.label11.TabIndex = 15;
             this.label11.Text = "Race Viewer:";
             // 
@@ -599,9 +645,10 @@
             // 
             this.label12.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(3, 522);
+            this.label12.Location = new System.Drawing.Point(4, 600);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(178, 13);
+            this.label12.Size = new System.Drawing.Size(237, 15);
             this.label12.TabIndex = 17;
             this.label12.Text = "Active Comparisons:";
             // 
@@ -609,9 +656,10 @@
             // 
             this.label13.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(3, 493);
+            this.label13.Location = new System.Drawing.Point(4, 567);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(178, 13);
+            this.label13.Size = new System.Drawing.Size(237, 15);
             this.label13.TabIndex = 18;
             this.label13.Text = "Racing Services:";
             // 
@@ -619,9 +667,10 @@
             // 
             this.btnChooseComparisons.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.SetColumnSpan(this.btnChooseComparisons, 3);
-            this.btnChooseComparisons.Location = new System.Drawing.Point(187, 517);
+            this.btnChooseComparisons.Location = new System.Drawing.Point(249, 594);
+            this.btnChooseComparisons.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnChooseComparisons.Name = "btnChooseComparisons";
-            this.btnChooseComparisons.Size = new System.Drawing.Size(190, 23);
+            this.btnChooseComparisons.Size = new System.Drawing.Size(254, 27);
             this.btnChooseComparisons.TabIndex = 7;
             this.btnChooseComparisons.Text = "Choose Active Comparisons...";
             this.btnChooseComparisons.UseVisualStyleBackColor = true;
@@ -631,10 +680,10 @@
             // 
             this.chkSimpleSOB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkSimpleSOB.AutoSize = true;
-            this.chkSimpleSOB.Location = new System.Drawing.Point(7, 433);
-            this.chkSimpleSOB.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkSimpleSOB.Location = new System.Drawing.Point(9, 499);
+            this.chkSimpleSOB.Margin = new System.Windows.Forms.Padding(9, 3, 4, 3);
             this.chkSimpleSOB.Name = "chkSimpleSOB";
-            this.chkSimpleSOB.Size = new System.Drawing.Size(174, 17);
+            this.chkSimpleSOB.Size = new System.Drawing.Size(232, 19);
             this.chkSimpleSOB.TabIndex = 3;
             this.chkSimpleSOB.Text = "Simple Sum of Best Calculation";
             this.chkSimpleSOB.UseVisualStyleBackColor = true;
@@ -645,10 +694,10 @@
             this.chkWarnOnReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.chkWarnOnReset.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.chkWarnOnReset, 3);
-            this.chkWarnOnReset.Location = new System.Drawing.Point(191, 433);
-            this.chkWarnOnReset.Margin = new System.Windows.Forms.Padding(7, 3, 3, 3);
+            this.chkWarnOnReset.Location = new System.Drawing.Point(254, 499);
+            this.chkWarnOnReset.Margin = new System.Windows.Forms.Padding(9, 3, 4, 3);
             this.chkWarnOnReset.Name = "chkWarnOnReset";
-            this.chkWarnOnReset.Size = new System.Drawing.Size(186, 17);
+            this.chkWarnOnReset.Size = new System.Drawing.Size(249, 19);
             this.chkWarnOnReset.TabIndex = 4;
             this.chkWarnOnReset.Text = "Warn On Reset If Better Times";
             this.chkWarnOnReset.UseVisualStyleBackColor = true;
@@ -657,19 +706,20 @@
             // 
             this.panelRefreshRate.Controls.Add(this.txtRefreshRate);
             this.panelRefreshRate.Controls.Add(this.labelRefreshRate);
-            this.panelRefreshRate.Location = new System.Drawing.Point(0, 572);
+            this.panelRefreshRate.Location = new System.Drawing.Point(0, 657);
             this.panelRefreshRate.Margin = new System.Windows.Forms.Padding(0);
             this.panelRefreshRate.Name = "panelRefreshRate";
-            this.panelRefreshRate.Size = new System.Drawing.Size(184, 29);
+            this.panelRefreshRate.Size = new System.Drawing.Size(245, 33);
             this.panelRefreshRate.TabIndex = 19;
             // 
             // txtRefreshRate
             // 
             this.txtRefreshRate.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.txtRefreshRate.Location = new System.Drawing.Point(128, 6);
+            this.txtRefreshRate.Location = new System.Drawing.Point(171, 7);
+            this.txtRefreshRate.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.txtRefreshRate.Name = "txtRefreshRate";
-            this.txtRefreshRate.Size = new System.Drawing.Size(51, 20);
+            this.txtRefreshRate.Size = new System.Drawing.Size(67, 25);
             this.txtRefreshRate.TabIndex = 15;
             this.txtRefreshRate.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
@@ -677,22 +727,59 @@
             // 
             this.labelRefreshRate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.labelRefreshRate.AutoSize = true;
-            this.labelRefreshRate.Location = new System.Drawing.Point(3, 8);
+            this.labelRefreshRate.Location = new System.Drawing.Point(4, 9);
+            this.labelRefreshRate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelRefreshRate.Name = "labelRefreshRate";
-            this.labelRefreshRate.Size = new System.Drawing.Size(93, 13);
+            this.labelRefreshRate.Size = new System.Drawing.Size(151, 15);
             this.labelRefreshRate.TabIndex = 19;
             this.labelRefreshRate.Text = "Refresh Rate (Hz):";
             // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.SetColumnSpan(this.btnOK, 2);
+            this.btnOK.Location = new System.Drawing.Point(295, 732);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(100, 27);
+            this.btnOK.TabIndex = 0;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // label14
+            // 
+            this.label14.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(3, 703);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(239, 15);
+            this.label14.TabIndex = 20;
+            this.label14.Text = "Language:";
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Location = new System.Drawing.Point(249, 699);
+            this.comboBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(146, 23);
+            this.comboBox1.TabIndex = 0;
+            this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
+            // 
             // SettingsDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(394, 644);
+            this.ClientSize = new System.Drawing.Size(525, 778);
             this.Controls.Add(this.tableLayoutPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.Name = "SettingsDialog";
-            this.Padding = new System.Windows.Forms.Padding(7);
+            this.Padding = new System.Windows.Forms.Padding(9, 8, 9, 8);
             this.Text = "Settings";
             this.Load += new System.EventHandler(this.SettingsDialog_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -757,5 +844,7 @@
         private System.Windows.Forms.Label labelRefreshRate;
         private System.Windows.Forms.Panel panelRefreshRate;
         private System.Windows.Forms.TextBox txtRefreshRate;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.ComboBox comboBox1;
     }
 }

--- a/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/SettingsDialog.cs
@@ -70,6 +70,8 @@ namespace LiveSplit.View
             Hook = hook;
 
             InitializeHotkeyProfiles(hotkeyProfile);
+            InitializeLanguages(Languages.Instance.GetLanguage());
+            RefreshText();
             SetClickEvents(this);
 
             chkGlobalHotkeys.DataBindings.Add("Checked", this, "GlobalHotkeysEnabled");
@@ -90,6 +92,12 @@ namespace LiveSplit.View
         {
             cmbHotkeyProfiles.Items.AddRange(Settings.HotkeyProfiles.Keys.ToArray());
             cmbHotkeyProfiles.SelectedItem = hotkeyProfile;
+        }
+
+        private void InitializeLanguages(string language)
+        {
+            comboBox1.Items.AddRange(Languages.Instance.GetLanguagesList());
+            comboBox1.SelectedItem = Languages.Instance.replaceStr(language);
         }
 
         private void UpdateDisplayedHotkeyValues()
@@ -171,7 +179,7 @@ namespace LiveSplit.View
         private void SetHotkeyHandlers(TextBox txtBox, Action<KeyOrButton> keySetCallback)
         {
             var oldText = txtBox.Text;
-            txtBox.Text = "Set Hotkey...";
+            txtBox.Text = Languages.Instance.GetText("SetHotkey", "Set Hotkey...");
             txtBox.Select(0, 0);
             KeyEventHandler handlerDown = null;
             KeyEventHandler handlerUp = null;
@@ -344,7 +352,10 @@ namespace LiveSplit.View
         private void btnRenameProfile_Click(object sender, EventArgs e)
         {
             var newName = SelectedHotkeyProfile;
-            var result = InputBox.Show("Rename Hotkey Profile", "Hotkey Profile Name:", ref newName);
+            var result = InputBox.Show(
+                Languages.Instance.GetText("RenameProfileTitle", "Rename Hotkey Profile"), 
+                Languages.Instance.GetText("HotkeyProfileName", "Hotkey Profile Name:"), 
+                ref newName);
             if (result == DialogResult.OK)
             {
                 if (!Settings.HotkeyProfiles.ContainsKey(newName))
@@ -369,7 +380,12 @@ namespace LiveSplit.View
                 }
                 else if (newName != SelectedHotkeyProfile)
                 {
-                    result = MessageBox.Show(this, "A Hotkey Profile with this name already exists.", "Hotkey Profile Already Exists", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                    result = MessageBox.Show(
+                        this, 
+                        Languages.Instance.GetText("ProfileText", "A Hotkey Profile with this name already exists."), 
+                        Languages.Instance.GetText("ProfileCaption", "Hotkey Profile Already Exists"), 
+                        MessageBoxButtons.RetryCancel, 
+                        MessageBoxIcon.Error);
                     if (result == DialogResult.Retry)
                         btnRenameProfile_Click(sender, e);
                 }
@@ -379,7 +395,10 @@ namespace LiveSplit.View
         private void btnNewProfile_Click(object sender, EventArgs e)
         {
             var name = "";
-            var result = InputBox.Show("New Hotkey Profile", "Hotkey Profile Name:", ref name);
+            var result = InputBox.Show(
+                Languages.Instance.GetText("NewProfileTitle", "New Hotkey Profile"), 
+                Languages.Instance.GetText("HotkeyProfileName", "Hotkey Profile Name:"), 
+                ref name);
             if (result == DialogResult.OK)
             {
                 if (!Settings.HotkeyProfiles.ContainsKey(name))
@@ -392,7 +411,12 @@ namespace LiveSplit.View
                 }
                 else
                 {
-                    result = MessageBox.Show(this, "A Hotkey Profile with this name already exists.", "Hotkey Profile Already Exists", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                    result = MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("ProfileText", "A Hotkey Profile with this name already exists."),
+                        Languages.Instance.GetText("ProfileCaption", "Hotkey Profile Already Exists"),
+                        MessageBoxButtons.RetryCancel, 
+                        MessageBoxIcon.Error);
                     if (result == DialogResult.Retry)
                         btnNewProfile_Click(sender, e);
                 }
@@ -414,6 +438,67 @@ namespace LiveSplit.View
                 Settings.RaceProvider = newSettings;                
             }
            
+        }
+
+        private void tableLayoutPanel1_Paint(object sender, PaintEventArgs e)
+        {
+
+        }
+
+        private void label14_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var nowLang = comboBox1.SelectedItem.ToString();
+            var langString = Languages.Instance.langString;
+            foreach (var key in langString.Keys)
+            {
+                if (langString[key] == nowLang)
+                {
+                    Languages.Instance.nowLanguage = key;
+                    RefreshText();
+                }
+            }
+        }
+
+        private void RefreshText ()
+        {
+            btnChooseRaceProvider.Text = Languages.Instance.GetText("btnChooseRaceProvider", "Manage Racing Services...");
+            btnOK.Text = Languages.Instance.GetText("btnOK", "OK");
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            label5.Text = Languages.Instance.GetText("SavedAccounts", "Saved Accounts:");
+            btnLogOut.Text = Languages.Instance.GetText("btnLogOut", "Log Out of All Accounts");
+            groupBox1.Text = Languages.Instance.GetText("Hotkeys", "Hotkeys");
+            chkDeactivateForOtherPrograms.Text = Languages.Instance.GetText("chkDeactivateForOtherPrograms", "Deactivate For Other Programs");
+            label1.Text = Languages.Instance.GetText("StartOrSplit", "Start / Split:");
+            chkGlobalHotkeys.Text = Languages.Instance.GetText("chkGlobalHotkeys", "Global Hotkeys");
+            chkDoubleTap.Text = Languages.Instance.GetText("chkDoubleTap", "Double Tap Prevention");
+            label2.Text = Languages.Instance.GetText("Reset", "Reset:");
+            label6.Text = Languages.Instance.GetText("Pause", "Pause:");
+            label3.Text = Languages.Instance.GetText("SkipSplit", "Skip Split:");
+            label4.Text = Languages.Instance.GetText("UndoSplit", "Undo Split:");
+            label7.Text = Languages.Instance.GetText("ToggleGlobalHotkeys", "Toggle Global Hotkeys");
+            label8.Text = Languages.Instance.GetText("SwitchComparisonPrevious", "Switch Comparison (Previous):");
+            label9.Text = Languages.Instance.GetText("SwitchComparisonNext", "Switch Comparison (Next):");
+            label10.Text = Languages.Instance.GetText("HotkeyDelaySeconds", "Hotkey Delay (Seconds):");
+            grpHotkeyProfiles.Text = Languages.Instance.GetText("grpHotkeyProfiles", "Hotkey Profiles");
+            lblProfile.Text = Languages.Instance.GetText("lblProfile", "Active Hotkey Profile:");
+            btnRemoveProfile.Text = Languages.Instance.GetText("btnRemoveProfile", "Remove");
+            btnRenameProfile.Text = Languages.Instance.GetText("btnRenameProfile", "Rename");
+            btnNewProfile.Text = Languages.Instance.GetText("btnNewProfile", "New");
+            chkAllowGamepads.Text = Languages.Instance.GetText("chkAllowGamepads", "Allow Gamepads as Hotkeys");
+            label11.Text = Languages.Instance.GetText("RaceViewer", "Race Viewer:");
+            label12.Text = Languages.Instance.GetText("ActiveComparisons", "Active Comparisons:");
+            label13.Text = Languages.Instance.GetText("RacingServices", "Racing Services:");
+            btnChooseComparisons.Text = Languages.Instance.GetText("btnChooseComparisons", "Choose Active Comparisons...");
+            chkSimpleSOB.Text = Languages.Instance.GetText("chkSimpleSOB", "Simple Sum of Best Calculation");
+            chkWarnOnReset.Text = Languages.Instance.GetText("chkWarnOnReset", "Warn On Reset If Better Times");
+            labelRefreshRate.Text = Languages.Instance.GetText("labelRefreshRate", "Refresh Rate (Hz):");
+            label14.Text = Languages.Instance.GetText("labelLanguage", "Language");
+            Text = Languages.Instance.GetText("settingsMenuItem", "Settings");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/ShareRunDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/ShareRunDialog.cs
@@ -35,6 +35,7 @@ namespace LiveSplit.View
             ScreenShotFunction = screenShotFunction;
             Settings = settings;
             InitializeComponent();
+            RefreshText();
         }
 
         void RefreshCategoryList(string gameName)
@@ -345,7 +346,11 @@ namespace LiveSplit.View
 
                 if (!CurrentPlatform.VerifyLogin(username, password))
                 {
-                    MessageBox.Show("Your login information seems to be incorrect.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        Languages.Instance.GetText("SubmitText", "Your login information seems to be incorrect."), 
+                        Languages.Instance.GetText("Error", "Error"), 
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                     return;
                 }
 
@@ -376,7 +381,11 @@ namespace LiveSplit.View
                 Cursor = Cursors.Default;
             }
 
-            MessageBox.Show("The run could not be shared.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBox.Show(
+                Languages.Instance.GetText("SubmitText_1", "The run could not be shared."), 
+                Languages.Instance.GetText("Error", "Error"), 
+                MessageBoxButtons.OK, 
+                MessageBoxIcon.Error);
         }
 
         private void btnClose_Click(object sender, EventArgs e)
@@ -436,6 +445,33 @@ namespace LiveSplit.View
         private void btnInsertStreamLink_Click(object sender, EventArgs e)
         {
             Insert("$stream");
+        }
+
+        private void RefreshText ()
+        {
+            label1.Text = Languages.Instance.GetText("lblPlatform", "Platform:");
+            label2.Text = Languages.Instance.GetText("Username", "Username:");
+            label3.Text = Languages.Instance.GetText("Password", "Password:");
+            label4.Text = Languages.Instance.GetText("Game", "Game:");
+            label5.Text = Languages.Instance.GetText("Category", "Category:");
+            label6.Text = Languages.Instance.GetText("Version", "Version:");
+            label7.Text = Languages.Instance.GetText("VideoURL", "Video URL:");
+            label8.Text = Languages.Instance.GetText("Text", "Text:");
+            btnClose.Text = Languages.Instance.GetText("btnClose", "Close");
+            label9.Text = Languages.Instance.GetText("Insert", "Insert:");
+            btnInsertGame.Text = Languages.Instance.GetText("btnInsertGame", "Game");
+            btnInsertCategory.Text = Languages.Instance.GetText("btnInsertCategory", "Category");
+            btnInsertTitle.Text = Languages.Instance.GetText("btnInsertTitle", "Title");
+            btnInsertPB.Text = Languages.Instance.GetText("btnInsertPB", "PB");
+            btnPreview.Text = Languages.Instance.GetText("btnPreview", "Preview...");
+            btnInsertSplitName.Text = Languages.Instance.GetText("btnInsertSplitName", "Split Name");
+            btnInsertDeltaTime.Text = Languages.Instance.GetText("btnInsertDeltaTime", "Delta Time");
+            btnInsertSplitTime.Text = Languages.Instance.GetText("btnInsertSplitTime", "Split Time");
+            btnInsertStreamLink.Text = Languages.Instance.GetText("btnInsertStreamLink", "Stream Link");
+            chkAttachSplits.Text = Languages.Instance.GetText("chkAttachSplits", "Attach Splits");
+            btnShare.Text = Languages.Instance.GetText("btnShare", "Share");
+            Text = Languages.Instance.GetText("ShareRunDialog", "Run Sharer");
+
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/SpeedRunsLiveForm.cs
+++ b/LiveSplit/LiveSplit.View/View/SpeedRunsLiveForm.cs
@@ -55,7 +55,12 @@ namespace LiveSplit.View
             {
                 if (!FormIsClosing)
                 {
-                    MessageBox.Show(this, "You have been kicked from the IRC Channel.", "Kicked From Channel", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        this, 
+                        Languages.Instance.GetText("KickedText", "You have been kicked from the IRC Channel."), 
+                        Languages.Instance.GetText("KickedFromChannel", "Kicked From Channel"), 
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                     Close();
                 }
             });
@@ -72,7 +77,12 @@ namespace LiveSplit.View
                 {
                     if (!FormIsClosing)
                     {
-                        MessageBox.Show(this, "You have been disconnected from the IRC server.", "Disconnected", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(
+                            this, 
+                            Languages.Instance.GetText("DisconnectedText", "You have been disconnected from the IRC server."),
+                            Languages.Instance.GetText("Disconnected", "Disconnected"), 
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
                         Close();
                     }
                 });
@@ -89,7 +99,12 @@ namespace LiveSplit.View
 
             this.InvokeIfRequired(() =>
             {
-                MessageBox.Show(this, "Your nickname is already in use.", "Nickname In Use", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this, 
+                    Languages.Instance.GetText("NicknameInUseText", "Your nickname is already in use."),
+                    Languages.Instance.GetText("NicknameInUse", "Nickname In Use"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 Close();
             });
         }
@@ -103,7 +118,12 @@ namespace LiveSplit.View
 
             this.InvokeIfRequired(() =>
             {
-                MessageBox.Show(this, "The password is incorrect.", "Password Incorrect", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("PasswordIncorrectText", "The password is incorrect."),
+                    Languages.Instance.GetText("PasswordIncorrect", "Password Incorrect"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 Close();
             });
         }
@@ -160,35 +180,35 @@ namespace LiveSplit.View
                 {
                     chkReady.Enabled = true;
                     chkReady.Checked = false;
-                    btnJoinQuit.Text = "Quit Race";
+                    btnJoinQuit.Text = Languages.Instance.GetText("QuitRace", "Quit Race");
                     btnJoinQuit.Enabled = true;
                 }
                 else if (state == RaceState.EnteredRaceAndReady)
                 {
                     chkReady.Enabled = true;
                     chkReady.Checked = true;
-                    btnJoinQuit.Text = "Quit Race";
+                    btnJoinQuit.Text = Languages.Instance.GetText("QuitRace", "Quit Race");
                     btnJoinQuit.Enabled = true;
                 }
                 else if (state == RaceState.NotInRace)
                 {
                     chkReady.Enabled = false;
                     chkReady.Checked = false;
-                    btnJoinQuit.Text = "Enter Race";
+                    btnJoinQuit.Text = Languages.Instance.GetText("EnterRace", "Enter Race");
                     btnJoinQuit.Enabled = true;
                 }
                 else if (state == RaceState.RaceEnded)
                 {
                     chkReady.Enabled = false;
                     chkReady.Checked = true;
-                    btnJoinQuit.Text = "Rejoin Race";
+                    btnJoinQuit.Text = Languages.Instance.GetText("RejoinRace", "Rejoin Race");
                     btnJoinQuit.Enabled = true;
                 }
                 else if (state == RaceState.RaceStarted)
                 {
                     chkReady.Enabled = false;
                     chkReady.Checked = true;
-                    btnJoinQuit.Text = "Forfeit Race";
+                    btnJoinQuit.Text = Languages.Instance.GetText("ForfeitRace", "Forfeit Race");
                     btnJoinQuit.Enabled = true;
                 }
             });
@@ -303,7 +323,12 @@ namespace LiveSplit.View
 
             this.InvokeIfRequired(() =>
             {
-                MessageBox.Show(this, "RaceBot did not respond to your message. If you created a race within the last 5 minutes, you are not allowed to create another race.", "RaceBot Did Not Respond", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("RaceBotDidNotRespondText", "RaceBot did not respond to your message. If you created a race within the last 5 minutes, you are not allowed to create another race."), 
+                    Languages.Instance.GetText("RaceBotDidNotRespond", "RaceBot Did Not Respond"),
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 Close();
             });
         }
@@ -357,7 +382,12 @@ namespace LiveSplit.View
                     var race = SpeedRunsLiveAPI.Instance.GetRace(RaceId);
                     if (race.statetext == "In Progress" && ((IDictionary<string, dynamic>)race.entrants.Properties).First(x => x.Key.ToLower() == SRLClient.Username.ToLower()).Value.statetext == "Finished")
                     {
-                        var result = MessageBox.Show(this, "Due to SpeedRunsLive rules, you need to confirm that you have completed the race before leaving an unfinished race. Do you confirm that you legitimately finished the race?", "Confirmation Required", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+                        var result = MessageBox.Show(
+                            this,
+                            Languages.Instance.GetText("ConfirmationRequiredText", "Due to SpeedRunsLive rules, you need to confirm that you have completed the race before leaving an unfinished race. Do you confirm that you legitimately finished the race?"), 
+                            Languages.Instance.GetText("ConfirmationRequired", "Confirmation Required"), 
+                            MessageBoxButtons.YesNoCancel,
+                            MessageBoxIcon.Question);
                         if (result == DialogResult.Cancel)
                         {
                             e.Cancel = true;
@@ -617,6 +647,14 @@ namespace LiveSplit.View
             {
                 SRLClient.Unready();
             }
+        }
+
+        private void RefreshText ()
+        {
+            chatBox.Text = Languages.Instance.GetText("chatBox", "");
+            chkReady.Text = Languages.Instance.GetText("chkReady", "Ready");
+            btnJoinQuit.Text = Languages.Instance.GetText("btnJoinQuit", "Enter Race");
+            Text = Languages.Instance.GetText("SpeedRunsLiveForm", "Joining Channel...");
         }
     }
 

--- a/LiveSplit/LiveSplit.View/View/SpeedrunComSubmitDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/SpeedrunComSubmitDialog.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows.Forms;
 using LiveSplit.Model;
 using LiveSplit.Web.Share;
+using LiveSplit.Options;
 
 namespace LiveSplit.View
 {
@@ -21,6 +22,7 @@ namespace LiveSplit.View
             this.metadata = metadata;
 
             InitializeComponent();
+            RefreshText();
 
             hasPersonalBestDateTime = SpeedrunCom.FindPersonalBestAttemptDate(metadata.LiveSplitRun).HasValue;
 
@@ -117,7 +119,12 @@ namespace LiveSplit.View
                 }
                 else
                 {
-                    MessageBox.Show(this, "You didn't provide a valid Video URL.", "Submitting Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        this, 
+                        Languages.Instance.GetText("SubmitVideoText", "You didn't provide a valid Video URL."), 
+                        Languages.Instance.GetText("SubmittingFailed", "Submitting Failed"), 
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                     return;
                 }
             }
@@ -140,7 +147,12 @@ namespace LiveSplit.View
                 }
                 catch
                 {
-                    MessageBox.Show(this, "You didn't enter a valid Game Time.", "Submitting Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("SubmitVideoText_1", "You didn't enter a valid Game Time."),
+                        Languages.Instance.GetText("SubmittingFailed", "Submitting Failed"),
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                     return;
                 }
             }
@@ -156,7 +168,12 @@ namespace LiveSplit.View
                 }
                 catch
                 {
-                    MessageBox.Show(this, "You didn't enter a valid Real Time without Loads.", "Submitting Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("SubmitVideoText_2", "You didn't enter a valid Real Time without Loads."),
+                        Languages.Instance.GetText("SubmittingFailed", "Submitting Failed"),
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                     return;
                 }
             }
@@ -173,7 +190,12 @@ namespace LiveSplit.View
             }
             else
             {
-                MessageBox.Show(this, reason, "Submitting Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this, 
+                    reason,
+                    Languages.Instance.GetText("SubmittingFailed", "Submitting Failed"),
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
             }
         }
 
@@ -205,6 +227,15 @@ namespace LiveSplit.View
             }
 
             lastSplit.PersonalBestSplitTime = runTime;
+        }
+
+        private void RefreshText ()
+        {
+            label1.Text = Languages.Instance.GetText("Video", "Video:");
+            label2.Text = Languages.Instance.GetText("Comment", "Comment:");
+            btnSubmit.Text = Languages.Instance.GetText("btnSubmit", "Submit");
+            btnCancel.Text = Languages.Instance.GetText("btnCancel", "Cancel");
+            Text = Languages.Instance.GetText("SpeedrunComSubmitDialog", "Submitting to Speedrun.com");
         }
     }
 }

--- a/LiveSplit/LiveSplit.View/View/TimerForm.cs
+++ b/LiveSplit/LiveSplit.View/View/TimerForm.cs
@@ -320,6 +320,7 @@ namespace LiveSplit.View
 
             new System.Timers.Timer(1000) { Enabled = true }.Elapsed += RaceRefreshTimer_Elapsed;
 
+            RefreshText();
             InitDragAndDrop();
         }
 
@@ -362,7 +363,7 @@ namespace LiveSplit.View
                 ToolStripMenuItem raceProviderItem = new ToolStripMenuItem()
                 {
                     Name = $"{raceProvider.ProviderName}racesMenuItem",
-                    Text = $"{raceProvider.ProviderName} Races",
+                    Text = $"{raceProvider.ProviderName} {Languages.Instance.GetText("Races", "Races")}",
                     Tag = raceProvider
                 };
                 raceProviderItem.MouseHover += racingMenuItem_MouseHover;
@@ -411,7 +412,8 @@ namespace LiveSplit.View
                     if (numSeparators == 0)
                         toolItem.Checked = toolItem.Name == CurrentState.CurrentTimingMethod.ToString();
                     else
-                        toolItem.Checked = toolItem.Text == CurrentState.CurrentComparison.EscapeMenuItemText();
+                        // toolItem.Checked = toolItem.Text == CurrentState.CurrentComparison.EscapeMenuItemText();
+                        toolItem.Checked = toolItem.Name == CurrentState.CurrentComparison.EscapeMenuItemText().Replace(" ", "");
                 }
             }
         }
@@ -569,7 +571,7 @@ namespace LiveSplit.View
                 addItem(new ToolStripSeparator());
 
             var newRaceItem = new ToolStripMenuItem();
-            newRaceItem.Text = "New Race...";
+            newRaceItem.Text = Languages.Instance.GetText("NewRace", "New Race...");
             newRaceItem.Click += (s, e) => { raceProvider.CreateRace?.Invoke(Model); };
             addItem(newRaceItem);
         }
@@ -714,7 +716,7 @@ namespace LiveSplit.View
                 resetMenuItem.Enabled = true;
                 undoSplitMenuItem.Enabled = false;
                 skipSplitMenuItem.Enabled = true;
-                splitMenuItem.Text = "Split";
+                splitMenuItem.Text = Languages.Instance.GetText("splitMenuItem_Split", "Split");
             });
         }
 
@@ -737,7 +739,7 @@ namespace LiveSplit.View
                 undoSplitMenuItem.Enabled = false;
                 skipSplitMenuItem.Enabled = false;
                 splitMenuItem.Enabled = true;
-                splitMenuItem.Text = "Start";
+                splitMenuItem.Text = Languages.Instance.GetText("splitMenuItem_Start", "Start");
             });
         }
 
@@ -745,7 +747,7 @@ namespace LiveSplit.View
         {
             this.InvokeIfRequired(() =>
             {
-                splitMenuItem.Text = "Split";
+                splitMenuItem.Text = Languages.Instance.GetText("splitMenuItem_Split", "Split");
                 pauseMenuItem.Enabled = true;
             });
         }
@@ -754,7 +756,7 @@ namespace LiveSplit.View
         {
             this.InvokeIfRequired(() =>
             {
-                splitMenuItem.Text = "Resume";
+                splitMenuItem.Text = Languages.Instance.GetText("splitMenuItem_Resume", "Resume");
                 undoPausesMenuItem.Enabled = true;
                 pauseMenuItem.Enabled = false;
             });
@@ -880,16 +882,20 @@ namespace LiveSplit.View
             if (openSplitsMenuItem.DropDownItems.Count > 0)
                 openSplitsMenuItem.DropDownItems.Add(new ToolStripSeparator());
             var openFromFileMenuItem = new ToolStripMenuItem("From File...");
+            openFromFileMenuItem.Name = "fromFileToolStripMenuItem";
             openFromFileMenuItem.Click += openSplitsFromFileMenuItem_Click;
             openSplitsMenuItem.DropDownItems.Add(openFromFileMenuItem);
             var openFromURLMenuItem = new ToolStripMenuItem("From URL...");
+            openFromURLMenuItem.Name = "openFromURLMenuItem_1";
             openFromURLMenuItem.Click += openSplitsFromURLMenuItem_Click;
             openSplitsMenuItem.DropDownItems.Add(openFromURLMenuItem);
             var openFromSpeedrunComMenuItem = new ToolStripMenuItem("From Speedrun.com...");
+            openFromSpeedrunComMenuItem.Name = "fromSpeedruncomToolStripMenuItem";
             openFromSpeedrunComMenuItem.Click += openFromSpeedrunComMenuItem_Click;
             openSplitsMenuItem.DropDownItems.Add(openFromSpeedrunComMenuItem);
             openSplitsMenuItem.DropDownItems.Add(new ToolStripSeparator());
             var editSplitHistoryMenuItem = new ToolStripMenuItem("Edit History");
+            editSplitHistoryMenuItem.Name = "editSplitHistoryMenuItem";
             editSplitHistoryMenuItem.Click += editSplitHistoryMenuItem_Click;
             openSplitsMenuItem.DropDownItems.Add(editSplitHistoryMenuItem);
         }
@@ -946,16 +952,20 @@ namespace LiveSplit.View
             if (openLayoutMenuItem.DropDownItems.Count > 0)
                 openLayoutMenuItem.DropDownItems.Add(new ToolStripSeparator());
             var openLayoutFromFileMenuItem = new ToolStripMenuItem("From File...");
+            openLayoutFromFileMenuItem.Name = "fromFileToolStripMenuItem";
             openLayoutFromFileMenuItem.Click += openLayoutFromFileMenuItem_Click;
             openLayoutMenuItem.DropDownItems.Add(openLayoutFromFileMenuItem);
             var openFromURLMenuItem = new ToolStripMenuItem("From URL...");
+            openFromURLMenuItem.Name = "openFromURLMenuItem_1";
             openFromURLMenuItem.Click += openLayoutFromURLMenuItem_Click;
             openLayoutMenuItem.DropDownItems.Add(openFromURLMenuItem);
             var defaultLayoutMenuItem = new ToolStripMenuItem("Default");
+            defaultLayoutMenuItem.Name = "defaultLayoutMenuItem";
             defaultLayoutMenuItem.Click += (x, y) => { LoadDefaultLayout(); };
             openLayoutMenuItem.DropDownItems.Add(defaultLayoutMenuItem);
             openLayoutMenuItem.DropDownItems.Add(new ToolStripSeparator());
             var editLayoutHistoryMenuItem = new ToolStripMenuItem("Edit History");
+            editLayoutHistoryMenuItem.Name = "editSplitHistoryMenuItem";
             editLayoutHistoryMenuItem.Click += editLayoutHistoryMenuItem_Click;
             openLayoutMenuItem.DropDownItems.Add(editLayoutHistoryMenuItem);
         }
@@ -979,7 +989,7 @@ namespace LiveSplit.View
                 TopMost = false;
                 string url = null;
 
-                if (DialogResult.OK == InputBox.Show("Open Layout from URL", "URL:", ref url))
+                if (DialogResult.OK == InputBox.Show(Languages.Instance.GetText("OpenLayoutFromURL", "Open Layout from URL"), "URL:", ref url))
                 {
                     try
                     {
@@ -1010,7 +1020,12 @@ namespace LiveSplit.View
                             {
                                 Log.Error(ex);
                                 DontRedraw = true;
-                                MessageBox.Show(this, "The selected file was not recognized as a layout file. (" + ex.Message + ")", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                MessageBox.Show(
+                                    this,
+                                    Languages.Instance.GetText("OpenLayoutText", "The selected file was not recognized as a layout file. (") + ex.Message + ")", 
+                                    Languages.Instance.GetText("Error", "Error"),
+                                    MessageBoxButtons.OK,
+                                    MessageBoxIcon.Error);
                                 DontRedraw = false;
                             }
                         }
@@ -1019,7 +1034,12 @@ namespace LiveSplit.View
                     {
                         Log.Error(ex);
                         DontRedraw = true;
-                        MessageBox.Show(this, "The layout file couldn't be downloaded.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(
+                            this,
+                            Languages.Instance.GetText("OpenLayoutText_1", "The layout file couldn't be downloaded."),
+                            Languages.Instance.GetText("Error", "Error"),
+                            MessageBoxButtons.OK, 
+                            MessageBoxIcon.Error);
                         DontRedraw = false;
                     }
                 }
@@ -1504,7 +1524,12 @@ namespace LiveSplit.View
             if (!Settings.AgreedToSRLRules)
             {
                 Process.Start("http://speedrunslive.com/faq/rules/");
-                var result = MessageBox.Show(this, "Please read through the rules of SpeedRunsLive carefully.\r\nDo you agree to these rules?", "SpeedRunsLive Rules", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                var result = MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("SpeedRunsLiveRulesText", "Please read through the rules of SpeedRunsLive carefully.\r\nDo you agree to these rules?"), 
+                    Languages.Instance.GetText("SpeedRunsLiveRules", "SpeedRunsLive Rules"), 
+                    MessageBoxButtons.YesNo, 
+                    MessageBoxIcon.Question);
                 if (result == DialogResult.Yes)
                 {
                     Settings.AgreedToSRLRules = true;
@@ -1793,7 +1818,12 @@ namespace LiveSplit.View
             {
                 Log.Error(e);
                 DontRedraw = true;
-                MessageBox.Show(this, "The selected file was not recognized as a splits file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("OpenRunText", "The selected file was not recognized as a splits file."),
+                    Languages.Instance.GetText("Error", "Error"),
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 DontRedraw = false;
             }
             Cursor.Current = Cursors.Arrow;
@@ -1884,7 +1914,12 @@ namespace LiveSplit.View
                 || CurrentState.CurrentPhase == TimerPhase.Paused))
             {
                 DontRedraw = true;
-                result = MessageBox.Show(this, "This run did not beat your current splits. Would you like to save this run as a Personal Best?", "Save as Personal Best?", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+                result = MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("SaveAsPersonalBestText", "This run did not beat your current splits. Would you like to save this run as a Personal Best?"), 
+                    Languages.Instance.GetText("SaveAsPersonalBest", "Save as Personal Best?"), 
+                    MessageBoxButtons.YesNoCancel, 
+                    MessageBoxIcon.Question);
                 DontRedraw = false;
                 if (result == DialogResult.Yes)
                 {
@@ -1925,7 +1960,12 @@ namespace LiveSplit.View
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, "Splits could not be saved!", "Save Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("SaveFailedText", "Splits could not be saved!"), 
+                    Languages.Instance.GetText("SaveFailed", "Save Failed"), 
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 Log.Error(ex);
                 return false;
             }
@@ -1975,7 +2015,12 @@ namespace LiveSplit.View
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, "Layout could not be saved!", "Save Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("SaveFailedText_1", "Layout could not be saved!"),
+                    Languages.Instance.GetText("SaveFailed", "Save Failed"),
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 Log.Error(ex);
                 return false;
             }
@@ -2262,7 +2307,12 @@ namespace LiveSplit.View
                 {
                     Log.Error(e);
                     DontRedraw = true;
-                    MessageBox.Show(this, "The selected file was not recognized as a layout file. (" + e.Message + ")", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("OpenLayoutText", "The selected file was not recognized as a layout file. (") + e.Message + ")",
+                        Languages.Instance.GetText("Error", "Error"),
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Error);
                     DontRedraw = false;
                 }
                 Cursor.Current = Cursors.Arrow;
@@ -2410,7 +2460,12 @@ namespace LiveSplit.View
                 try
                 {
                     DontRedraw = true;
-                    var result = MessageBox.Show(this, "Your splits have been updated but not yet saved.\nDo you want to save your splits now?", "Save Splits?", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+                    var result = MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("SaveSplitsText", "Your splits have been updated but not yet saved.\nDo you want to save your splits now?"), 
+                        Languages.Instance.GetText("SaveSplits", "Save Splits?"), 
+                        MessageBoxButtons.YesNoCancel,
+                        MessageBoxIcon.Question);
                     if (result == DialogResult.Yes)
                     {
                         safeToContinue = SaveSplits(false);
@@ -2441,7 +2496,12 @@ namespace LiveSplit.View
                 {
                     DontRedraw = true;
                     var buttons = canCancel ? MessageBoxButtons.YesNoCancel : MessageBoxButtons.YesNo;
-                    var result = MessageBox.Show(this, "Your layout has been updated but not yet saved.\nDo you want to save your layout now?", "Save Layout?", buttons, MessageBoxIcon.Question);
+                    var result = MessageBox.Show(
+                        this,
+                        Languages.Instance.GetText("SaveLayoutText", "Your layout has been updated but not yet saved.\nDo you want to save your layout now?"), 
+                        Languages.Instance.GetText("SaveLayout", "Save Layout?"), 
+                        buttons, 
+                        MessageBoxIcon.Question);
                     if (result == DialogResult.Yes)
                     {
                         safeToContinue = SaveLayout();
@@ -2494,7 +2554,12 @@ namespace LiveSplit.View
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, "Settings could not be saved!", "Save Failed", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("FormClosingText", "Settings could not be saved!"),
+                    Languages.Instance.GetText("SaveFailed", "Save Failed"),
+                    MessageBoxButtons.OK, 
+                    MessageBoxIcon.Error);
                 Log.Error(ex);
             }
 
@@ -2642,7 +2707,12 @@ namespace LiveSplit.View
             if (warnUser)
             {
                 DontRedraw = true;
-                var result = MessageBox.Show(this, "You have beaten some of your best times.\r\nDo you want to update them?", "Update Times?", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+                var result = MessageBox.Show(
+                    this,
+                    Languages.Instance.GetText("UpdateTimesText", "You have beaten some of your best times.\r\nDo you want to update them?"), 
+                    Languages.Instance.GetText("UpdateTimes", "Update Times?"), 
+                    MessageBoxButtons.YesNoCancel, 
+                    MessageBoxIcon.Question);
                 DontRedraw = false;
                 return result;
             }
@@ -2785,6 +2855,7 @@ namespace LiveSplit.View
             comparisonMenuItem.DropDownItems.Add(gameTimeMenuItem);
 
             RefreshComparisonItems();
+            RefreshText();
         }
 
         void gameTimeMenuItem_Click(object sender, EventArgs e)
@@ -2835,8 +2906,10 @@ namespace LiveSplit.View
         private void AddActionToComparisonsMenu(string name)
         {
             var menuItem = new ToolStripMenuItem(name.EscapeMenuItemText());
+            menuItem.Name = name.EscapeMenuItemText().Replace(" ", "");
             menuItem.Click += (s, e) => SwitchComparison(name);
             comparisonMenuItem.DropDownItems.Add(menuItem);
+            RefreshText();
         }
 
         private void AddActionToControlMenu(string name, Action action)
@@ -2884,6 +2957,7 @@ namespace LiveSplit.View
 
         private void RightClickMenu_Opening(object sender, CancelEventArgs e)
         {
+            RefreshText();
             RebuildControlMenu();
             RebuildComparisonsMenu();
         }
@@ -2936,6 +3010,93 @@ namespace LiveSplit.View
             else
             {
                 e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void RefreshText ()
+        {
+            editSplitsMenuItem.Text = Languages.Instance.GetText("editSplitsMenuItem", "Edit Splits...");
+            openSplitsMenuItem.Text = Languages.Instance.GetText("openSplitsMenuItem", "Open Splits");
+            saveSplitsMenuItem.Text = Languages.Instance.GetText("saveSplitsMenuItem", "Save Splits");
+            saveSplitsAsMenuItem.Text = Languages.Instance.GetText("saveSplitsAsMenuItem", "Save Splits As...");
+            closeSplitsMenuItem.Text = Languages.Instance.GetText("closeSplitsMenuItem", "Close Splits");
+            controlMenuItem.Text = Languages.Instance.GetText("controlMenuItem", "Control");
+            shareMenuItem.Text = Languages.Instance.GetText("shareMenuItem", "Share...");
+            editLayoutMenuItem.Text = Languages.Instance.GetText("editLayoutMenuItem", "Edit Layout...");
+            openLayoutMenuItem.Text = Languages.Instance.GetText("openLayoutMenuItem", "Open Layout");
+            saveLayoutMenuItem.Text = Languages.Instance.GetText("saveLayoutMenuItem", "Save Layout");
+            saveLayoutAsMenuItem.Text = Languages.Instance.GetText("saveLayoutAsMenuItem", "Save Layout As...");
+            settingsMenuItem.Text = Languages.Instance.GetText("settingsMenuItem", "Settings");
+            aboutMenuItem.Text = Languages.Instance.GetText("aboutMenuItem", "About");
+            exitMenuItem.Text = Languages.Instance.GetText("exitMenuItem", "Exit");
+            splitMenuItem.Text = Languages.Instance.GetText("splitMenuItem_Start", "Start");
+            resetMenuItem.Text = Languages.Instance.GetText("resetMenuItem", "Reset");
+            undoSplitMenuItem.Text = Languages.Instance.GetText("undoSplitMenuItem", "Undo Split");
+            skipSplitMenuItem.Text = Languages.Instance.GetText("skipSplitMenuItem", "Skip Split");
+            pauseMenuItem.Text = Languages.Instance.GetText("pauseMenuItem", "Pause");
+            undoPausesMenuItem.Text = Languages.Instance.GetText("undoPausesMenuItem", "Undo All Pause");
+            hotkeysMenuItem.Text = Languages.Instance.GetText("hotkeysMenuItem", "Global Hotkeys");
+            comparisonMenuItem.Text = Languages.Instance.GetText("comparisonMenuItem", "Comparison");
+            foreach (ToolStripItem item in openLayoutMenuItem.DropDownItems)
+            {
+                if (item.Name == "fromFileToolStripMenuItem")
+                {
+                    item.Text = Languages.Instance.GetText("fromFileToolStripMenuItem", "From File...");
+                };
+                if (item.Name == "openFromURLMenuItem_1")
+                {
+                    item.Text = Languages.Instance.GetText("openFromURLMenuItem_1", "From URL...");
+                };
+                if (item.Name == "defaultLayoutMenuItem")
+                {
+                    item.Text = Languages.Instance.GetText("defaultLayoutMenuItem", "Default");
+                };
+                if (item.Name == "editSplitHistoryMenuItem")
+                {
+                    item.Text = Languages.Instance.GetText("editSplitHistoryMenuItem", "Edit History");
+                }
+            }
+            foreach (ToolStripItem item in openSplitsMenuItem.DropDownItems)
+            {
+                if (item.Name == "fromFileToolStripMenuItem")
+                {
+                    item.Text = Languages.Instance.GetText("fromFileToolStripMenuItem", "From File...");
+                };
+                if (item.Name == "openFromURLMenuItem_1")
+                {
+                    item.Text = Languages.Instance.GetText("openFromURLMenuItem_1", "From URL...");
+                };
+                if (item.Name == "fromSpeedruncomToolStripMenuItem")
+                {
+                    item.Text = Languages.Instance.GetText("fromSpeedruncomToolStripMenuItem", "Default");
+                };
+                if (item.Name == "editSplitHistoryMenuItem")
+                {
+                    item.Text = Languages.Instance.GetText("editSplitHistoryMenuItem", "Edit History");
+                };
+            }
+            foreach (ToolStripItem item in comparisonMenuItem.DropDownItems)
+            {
+                if (item.Name == "RealTime")
+                {
+                    item.Text = Languages.Instance.GetText("RealTime", "Real Time");
+                };
+                if (item.Name == "GameTime")
+                {
+                    item.Text = Languages.Instance.GetText("GameTime", "Game Time");
+                };
+                if (item.Name.ToString() == "PersonalBest")
+                {
+                    item.Text = Languages.Instance.GetText("PersonalBest", "Personal Best");
+                };
+                if (item.Name.ToString() == "BestSegments")
+                {
+                    item.Text = Languages.Instance.GetText("BestSegments", "Best Segments");
+                };
+                if (item.Name.ToString() == "AverageSegments")
+                {
+                    item.Text = Languages.Instance.GetText("AverageSegments", "Average Segments");
+                };
             }
         }
     }


### PR DESCRIPTION
# Multiple Language Support

Copy the entire **`Languages` folder** to the directory where **LiveSplit.exe** is located.

Run LiveSplit.exe, right click on the window and set the language in `Settings` -> `Languages`.

## Add Other Languages

If LiveSplit does not support your language, you can add your language to it.

1. Create a new file ending in .cfg in the Languages folder with a name that is an abbreviation for your language. For example, `zh-CN.cfg`.
2. Copy all the contents of the `en.cfg` file into the newly created file.
3. Change the contents of the DisplayName tag to the name of your language, which will be displayed in the "Settings" -> "Language" option. For example, `<DisplayName>English</DisplayName>`.
4. Translate all content in xml tags to your language based on English text.

After completing the above, you can switch to your language in the "Settings" -> "Language" of the software.