### PR TITLE
Add support for ScriptType element in AutoSplitters XML

### DIFF
--- a/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
+++ b/LiveSplit/LiveSplit.Tests/AutoSplitterTests/AutoSplitterXML.cs
@@ -30,15 +30,10 @@ namespace LiveSplit.Tests.AutoSplitterTests
             var urlElems = autoSplitterElems.SelectMany(x => x["URLs"].ChildNodes.OfType<XmlElement>());
             Assert.True(urlElems.All(x => x.Name == "URL"), "<URLs> must contain only <URL> elements");
 
-            IDictionary<string, AutoSplitter> autoSplitters = autoSplitterElems.Select(element =>
-                    new AutoSplitter()
-                    {
-                        Description = element["Description"].InnerText,
-                        URLs = element["URLs"].ChildNodes.OfType<XmlElement>().Select(x => x.InnerText).ToList(),
-                        Type = (AutoSplitterType)Enum.Parse(typeof(AutoSplitterType), element["Type"].InnerText),
-                        Games = element["Games"].ChildNodes.OfType<XmlElement>().Select(x => (x.InnerText ?? "").ToLower()).ToList(),
-                        ShowInLayoutEditor = element["ShowInLayoutEditor"] != null
-                    }).SelectMany(x => x.Games.Select(y => new KeyValuePair<string, AutoSplitter>(y, x))).ToDictionary(x => x.Key, x => x.Value);
+            IDictionary<string, AutoSplitter> autoSplitters = autoSplitterElems
+                .Select(element => AutoSplitterFactory.CreateFromXmlElement(element))
+                .SelectMany(x => x.Games.Select(y => new KeyValuePair<string, AutoSplitter>(y, x)))
+                .ToDictionary(x => x.Key, x => x.Value);
 
             Assert.True(!autoSplitters.Any(x => string.IsNullOrWhiteSpace(x.Key)), "Empty Game Names are not allowed");
             Assert.True(!autoSplitters.Values.Any(x => string.IsNullOrWhiteSpace(x.Description)), "Auto Splitters need a description");
@@ -46,8 +41,14 @@ namespace LiveSplit.Tests.AutoSplitterTests
             Assert.True(!autoSplitters.Values.Any(x => !x.URLs.Any()), "Auto Splitters need to have at least one URL");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".asl")) && x.Type == AutoSplitterType.Component),
                 "ASL Script is downloaded even though Type \"Component\" is specified");
-            Assert.True(!autoSplitters.Values.Any(x => x.URLs.First().EndsWith(".dll") && x.Type == AutoSplitterType.Script),
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".asl")) && x.Type == AutoSplitterType.AutoSplittingRuntimeScript),
+                "ASL Script is downloaded even though ScriptType \"AutoSplittingRuntime\" is specified");
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.First().EndsWith(".dll") && (x.Type == AutoSplitterType.Script || x.Type == AutoSplitterType.AutoSplittingRuntimeScript)),
                 "Component is downloaded even though Type \"Script\" is specified");
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".wasm")) && x.Type == AutoSplitterType.Component),
+                "WebAssembly Script is downloaded even though Type \"Component\" is specified");
+            Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => y.EndsWith(".wasm")) && x.Type == AutoSplitterType.Script),
+                "WebAssembly Script is downloaded even though ScriptType \"AutoSplittingRuntime\" is not specified");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => !Uri.IsWellFormedUriString(y, UriKind.Absolute))),
                 "Auto Splitters need to have valid URLs");
             Assert.True(!autoSplitters.Values.Any(x => x.URLs.Any(y => Regex.IsMatch(y, "https://github.com/[^/]*/[^/]*/blob/"))),


### PR DESCRIPTION
This PR updates the AutoSplitters XML format so support a new `ScriptType` element for AutoSplittingRuntime scripts. To define an Auto Splitter like this, you would specify:
```
<Type>Script</Type>
<ScriptType>AutoSplittingRuntime</ScriptType>
```
For all other Auto Splitters, the format isn't changed.

I also verified that LiveSplit 1.8.21 (before we added the new AutoSplittingRuntime component) loads even with an Auto Splitter defined in this new format.