### PR TITLE
Improve accuracy of how times are stored

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/Comparisons/AverageSegmentsComparisonGenerator.cs
+++ b/LiveSplit/LiveSplit.Core/Model/Comparisons/AverageSegmentsComparisonGenerator.cs
@@ -26,7 +26,7 @@ namespace LiveSplit.Model.Comparisons
             weightedList = weightedList.OrderBy(x => x.Value).ToList();
             var totalWeights = weightedList.Aggregate(0.0, (s, x) => (s + x.Key));
             var averageTime = weightedList.Aggregate(0.0, (s, x) => (s + x.Key * x.Value.TotalSeconds)) / totalWeights;
-            return TimeSpan.FromSeconds(averageTime);
+            return TimeSpan.FromTicks((long)(averageTime * TimeSpan.TicksPerSecond));
         }
 
         protected double GetWeight(int index, int count) => Pow(Weight, count - index - 1);

--- a/LiveSplit/LiveSplit.Core/Model/NTP.cs
+++ b/LiveSplit/LiveSplit.Core/Model/NTP.cs
@@ -38,11 +38,11 @@ namespace LiveSplit.Model
                 socket.Receive(ntpData);
 
                 var after = TimeStamp.Now;
-                var delta = TimeSpan.FromMilliseconds((after - before).TotalMilliseconds / 2);
+                var delta = TimeSpan.FromTicks((after - before).Ticks / 2);
 
                 socket.Close();
 
-                //Offset to get to the "Transmit Timestamp" field (time at which the reply 
+                //Offset to get to the "Transmit Timestamp" field (time at which the reply
                 //departed the server for the client, in 64-bit timestamp format."
                 const byte serverReplyTime = 40;
 

--- a/LiveSplit/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
@@ -24,7 +24,7 @@ namespace LiveSplit.Model.RunFactories
 
         static TimeSpan ParseTimeSpan(LiveSplitCore.TimeSpanRef timeSpan)
         {
-            return TimeSpan.FromSeconds(timeSpan.TotalSeconds());
+            return TimeSpan.FromTicks((long)(timeSpan.TotalSeconds() * TimeSpan.TicksPerSecond));
         }
 
         static TimeSpan? ParseOptionalTimeSpan(LiveSplitCore.TimeSpanRef timeSpan)
@@ -33,7 +33,7 @@ namespace LiveSplit.Model.RunFactories
             {
                 return null;
             }
-            return TimeSpan.FromSeconds(timeSpan.TotalSeconds());
+            return TimeSpan.FromTicks((long)(timeSpan.TotalSeconds() * TimeSpan.TicksPerSecond));
         }
 
         static AtomicDateTime? ParseOptionalAtomicDateTime(LiveSplitCore.AtomicDateTimeRef dateTime)

--- a/LiveSplit/LiveSplit.Core/Model/TimeSpanParser.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimeSpanParser.cs
@@ -30,7 +30,7 @@ namespace LiveSplit.Model
                 .Select(x => double.Parse(x, NumberStyles.Float, CultureInfo.InvariantCulture))
                 .Aggregate((a, b) => 60 * a + b);
 
-            return TimeSpan.FromSeconds(factor * seconds);
+            return TimeSpan.FromTicks((long)(factor * seconds * TimeSpan.TicksPerSecond));
         }
     }
 }

--- a/LiveSplit/LiveSplit.Core/Model/TimeStamp.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimeStamp.cs
@@ -41,8 +41,8 @@ namespace LiveSplit.Model
         }
 
         public static TimeStamp Now
-            => new TimeStamp(TimeSpan.FromMilliseconds(qpc.Elapsed.TotalMilliseconds / PersistentDrift));
-        
+            => new TimeStamp(TimeSpan.FromTicks((long)(qpc.Elapsed.Ticks / PersistentDrift)));
+
         public static bool IsSyncedWithAtomicClock
             => lastQPCTime != TimeSpan.Zero;
 


### PR DESCRIPTION
Turns out that `TimeSpan.FromSeconds` only retains 3 fractional digits, everything else is zeroed out. Internally however `TimeSpan` uses `Ticks` that are as accurate as `100ns`. They only fixed this method just recently for .NET 7. We can just manually construct the ticks.