### PR TITLE
Fix race condition in SetGameTime

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/LiveSplitState.cs
+++ b/LiveSplit/LiveSplit.Core/Model/LiveSplitState.cs
@@ -202,9 +202,14 @@ namespace LiveSplit.Model
 
         public void SetGameTime(TimeSpan? gameTime)
         {
-            if (CurrentTime.RealTime.HasValue && gameTime.HasValue)
+            var currentTime = CurrentTime;
+            if (currentTime.RealTime.HasValue && gameTime.HasValue)
             {
-                LoadingTimes = CurrentTime.RealTime.Value - gameTime.Value;
+                LoadingTimes = currentTime.RealTime.Value - gameTime.Value;
+                if (IsGameTimePaused)
+                {
+                    GameTimePauseTime = gameTime.Value;
+                }
             }
         }
 


### PR DESCRIPTION
Previously, the value of `GameTimePauseTime` would take into account two separate calls to `TimeStamp.Now`, which resulted in a race condition. Now, the value is always set directly to `gameTime`.