### PR TITLE
Don't parse TimeSpans as floats

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/TimeSpanParser.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimeSpanParser.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Globalization;
 using LiveSplit.TimeFormatters;
+using System.Collections.Generic;
 
 namespace LiveSplit.Model
 {
@@ -25,12 +26,48 @@ namespace LiveSplit.Model
                 timeString = timeString.Substring(1);
             }
 
-            var seconds = timeString
+            var splitTimeString = timeString.Split(new char[] {'.'}, 2);
+            var secondsText = splitTimeString[0];
+            var secondsTicks = ParseSecondsAsTicks(secondsText);
+
+            var fractionTicks = 0L;
+            if (splitTimeString.Length > 1)
+            {
+                var fractionText = splitTimeString[1];
+                fractionTicks = ParseFractionAsTicks(fractionText);
+            }
+
+            return TimeSpan.FromTicks((long)(factor * (secondsTicks + fractionTicks)));
+        }
+
+        private static long ParseFractionAsTicks(string fractionText)
+        {
+            if (fractionText.Length > 7)
+                fractionText = fractionText.Substring(0, 7);
+
+            return long.Parse(fractionText) * powersOfTen[7 - fractionText.Length];
+        }
+
+        private static long ParseSecondsAsTicks(string secondsText)
+        {
+            var totalSeconds = secondsText
                 .Split(':')
-                .Select(x => double.Parse(x, NumberStyles.Float, CultureInfo.InvariantCulture))
+                .Select(x => long.Parse(x, NumberStyles.Float, CultureInfo.InvariantCulture))
                 .Aggregate((a, b) => 60 * a + b);
 
-            return TimeSpan.FromTicks((long)(factor * seconds * TimeSpan.TicksPerSecond));
+            return totalSeconds * TimeSpan.TicksPerSecond;
         }
+
+        private static readonly Dictionary<int, long> powersOfTen = new Dictionary<int, long>()
+        {
+            { 0, 1L },
+            { 1, 10L },
+            { 2, 100L },
+            { 3, 1000L },
+            { 4, 10000L },
+            { 5, 100000L },
+            { 6, 1000000L },
+            { 7, 10000000L },
+        };
     }
 }

--- a/LiveSplit/LiveSplit.Core/Model/TimeSpanParser.cs
+++ b/LiveSplit/LiveSplit.Core/Model/TimeSpanParser.cs
@@ -30,44 +30,44 @@ namespace LiveSplit.Model
             var secondsText = splitTimeString[0];
             var secondsTicks = ParseSecondsAsTicks(secondsText);
 
-            var fractionTicks = 0L;
+            var fractionTicks = 0UL;
             if (splitTimeString.Length > 1)
             {
                 var fractionText = splitTimeString[1];
                 fractionTicks = ParseFractionAsTicks(fractionText);
             }
 
-            return TimeSpan.FromTicks((long)(factor * (secondsTicks + fractionTicks)));
+            return TimeSpan.FromTicks(factor * (long)(secondsTicks + fractionTicks));
         }
 
-        private static long ParseFractionAsTicks(string fractionText)
+        private static ulong ParseFractionAsTicks(string fractionText)
         {
             if (fractionText.Length > 7)
                 fractionText = fractionText.Substring(0, 7);
 
-            return long.Parse(fractionText) * powersOfTen[7 - fractionText.Length];
+            return ulong.Parse(fractionText, NumberStyles.Integer, CultureInfo.InvariantCulture) * powersOfTen[7 - fractionText.Length];
         }
 
-        private static long ParseSecondsAsTicks(string secondsText)
+        private static ulong ParseSecondsAsTicks(string secondsText)
         {
             var totalSeconds = secondsText
                 .Split(':')
-                .Select(x => long.Parse(x, NumberStyles.Float, CultureInfo.InvariantCulture))
+                .Select(x => ulong.Parse(x, NumberStyles.Integer, CultureInfo.InvariantCulture))
                 .Aggregate((a, b) => 60 * a + b);
 
             return totalSeconds * TimeSpan.TicksPerSecond;
         }
 
-        private static readonly Dictionary<int, long> powersOfTen = new Dictionary<int, long>()
+        private static readonly ulong[] powersOfTen =
         {
-            { 0, 1L },
-            { 1, 10L },
-            { 2, 100L },
-            { 3, 1000L },
-            { 4, 10000L },
-            { 5, 100000L },
-            { 6, 1000000L },
-            { 7, 10000000L },
+            1UL,
+            10UL,
+            100UL,
+            1000UL,
+            10000UL,
+            100000UL,
+            1000000UL,
+            10000000UL,
         };
     }
 }

--- a/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/LiveSplit/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="TimeFormatTests\RegularTimeFormattersTests.cs" />
     <Compile Include="TimeFormatTests\DeltaTimeFormattersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TimeParseTests\TimeSpanParserTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/LiveSplit/LiveSplit.Tests/TimeParseTests/TimeSpanParserTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeParseTests/TimeSpanParserTests.cs
@@ -1,0 +1,35 @@
+﻿using LiveSplit.Model;
+using System;
+using Xunit;
+
+namespace LiveSplit.Tests.TimeParseTests
+{
+    public class TimeSpanParserTests
+    {
+        [Theory]
+        [InlineData("5:40.41", "00:05:40.4100000")]
+        [InlineData("4:20.69", "00:04:20.6900000")]
+        [InlineData("04:20.69", "00:04:20.6900000")]
+        [InlineData("-12:37:30.12", "-12:37:30.1200000")]
+        [InlineData("-37:30.12", "-00:37:30.1200000")]
+        [InlineData("-30.12", "-00:00:30.1200000")]
+        [InlineData("-10:30", "-00:10:30")]
+        [InlineData("-30", "-00:00:30")]
+        [InlineData("-100", "-00:01:40")]
+        [InlineData("37:03.12", "00:37:03.1200000")]
+        [InlineData("10.12345", "00:00:10.1234500")]
+        [InlineData("10.1234567", "00:00:10.1234567")]
+        [InlineData("10.123456789", "00:00:10.1234567")]
+        [InlineData("10.0987654321987654321", "00:00:10.0987654")]
+        [InlineData("07:05:1.03", "07:05:01.0300000")]
+        [InlineData("00:0:01.00900", "00:00:01.0090000")]
+        [InlineData("1:05:01.9999999", "01:05:01.9999999")]
+
+        public void ParsesTimeSpanCorrectly(string timeSpanToParse, string expectedTimeSpan)
+        {
+            var time = TimeSpanParser.Parse(timeSpanToParse);
+            var formattedTime = time.ToString();
+            Assert.Equal(expectedTimeSpan, formattedTime);
+        }
+    }
+}


### PR DESCRIPTION
Fix #2286 

There was previously an issue where the number of seconds would be parsed as a floating point number, rather than as an exact number of ticks.

Equivalent PR in livesplit-core: https://github.com/LiveSplit/livesplit-core/pull/578