### PR TITLE
Use unicode versions of WinAPI functions.

### DIFF
--- a/LiveSplit/LiveSplit.Core/ComponentUtil/ProcessExtensions.cs
+++ b/LiveSplit/LiveSplit.Core/ComponentUtil/ProcessExtensions.cs
@@ -76,12 +76,12 @@ namespace LiveSplit.ComponentUtil
             for (int i = 0; i < numMods; i++)
             {
                 sb.Clear();
-                if (WinAPI.GetModuleFileNameEx(p.Handle, hModules[i], sb, (uint)sb.Capacity) == 0)
+                if (WinAPI.GetModuleFileNameExW(p.Handle, hModules[i], sb, (uint)sb.Capacity) == 0)
                     throw new Win32Exception();
                 string fileName = sb.ToString();
 
                 sb.Clear();
-                if (WinAPI.GetModuleBaseName(p.Handle, hModules[i], sb, (uint)sb.Capacity) == 0)
+                if (WinAPI.GetModuleBaseNameW(p.Handle, hModules[i], sb, (uint)sb.Capacity) == 0)
                     throw new Win32Exception();
                 string baseName = sb.ToString();
 

--- a/LiveSplit/LiveSplit.Core/ComponentUtil/WinAPI.cs
+++ b/LiveSplit/LiveSplit.Core/ComponentUtil/WinAPI.cs
@@ -67,8 +67,8 @@ namespace LiveSplit.ComponentUtil
         public static extern bool EnumProcessModulesEx(IntPtr hProcess, [Out] IntPtr[] lphModule, uint cb,
             out uint lpcbNeeded, uint dwFilterFlag);
 
-        [DllImport("psapi.dll", SetLastError = true)]
-        public static extern uint GetModuleFileNameEx(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName,
+        [DllImport("psapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern uint GetModuleFileNameExW(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName,
             uint nSize);
 
         [DllImport("psapi.dll", SetLastError = true)]
@@ -76,8 +76,8 @@ namespace LiveSplit.ComponentUtil
         public static extern bool GetModuleInformation(IntPtr hProcess, IntPtr hModule, [Out] out MODULEINFO lpmodinfo,
             uint cb);
 
-        [DllImport("psapi.dll")]
-        public static extern uint GetModuleBaseName(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName,
+        [DllImport("psapi.dll", CharSet = CharSet.Unicode)]
+        public static extern uint GetModuleBaseNameW(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName,
             uint nSize);
 
         [DllImport("kernel32.dll", SetLastError = true)]


### PR DESCRIPTION
This PR changes the two WinAPI functions `GetModuleFileNameEx` and `GetModuleBaseName` to use their respective UTF16 versions `GetModuleFileNameExW` and `GetModuleBaseNameW`.

This fixes some issues with non-UTF8 characters (for example Chinese characters) not being read correctly.