### PR TITLE
Update LiveSplit.AutoSplitters.xml (Spyro Reignited Trilogy Autosplitter)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -10797,10 +10797,10 @@
             <Game>Spyro Reignited Trilogy (PC)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Dinopony/spyrort-asl/master/spyrort.asl</URL>
+            <URL>https://raw.githubusercontent.com/SirBorris/SpyroAutoSplit/main/SRT_AutoSplitter_v1.17.1.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto-splitting, Start, Reset and Load Removal are available (by Dinopony)</Description>
+        <Description>Auto-splitting, Start, Reset and Load Removal are available (by Dinopony, Updated by SirBorris & BoredBanana)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>


### PR DESCRIPTION
With the approval of the leaderboard moderators, I have created an update to the Spyro Reignited Trilogy autosplitter, resolving many issues that the original autosplitter had. Changelog can be found in the ASL file, however changes include: 

- SRT3, Sorceress Last Hit fixed and enabled
- SRT3, Buzz, Spike, Scorch autosplit logic added
- SRT3, Sgt Byrd's Base autosplit fixed, typo in the level name
- SRT1, Autosplit added to Balloonists, with or without an EBL (required differing logic)

There will likely be further changes, however at this stage these QOL fixes are ready to be shipped.