### PR TITLE
Delete extra ASR DLLs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           Get-ChildItem * -Include cef.pak,cef_100_percent.pak,cef_200_percent.pak,cef_extensions.pak,CefSharp.BrowserSubprocess.Core.dll,CefSharp.BrowserSubprocess.exe,CefSharp.Core.Runtime.dll,chrome_elf.dll,d3dcompiler_47.dll,devtools_resources.pak,icudtl.dat,libcef.dll,libEGL.dll,libGLESv2.dll,snapshot_blob.bin,v8_context_snapshot.bin | Remove-Item -Recurse
           Remove-Item locales -Recurse
           Remove-Item swiftshader -Recurse
+          Remove-Item x64/asr_capi.dll
+          Remove-Item x86/asr_capi.dll
 
       - name: Upload build as an artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
In the build process, there are currently duplicate copies of `asr_capi.dll` that get copied to the `x64` and `x86` folders.