### PR TITLE
Get speedrun.com game categories using their game ID, not their game name

### DIFF
--- a/LiveSplit/LiveSplit.Core/Model/RunMetadata.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunMetadata.cs
@@ -178,7 +178,8 @@ namespace LiveSplit.Model
                         {
                             try
                             {
-                                var game = SpeedrunCom.Client.Games.SearchGameExact(oldGameName, new GameEmbeds(embedRegions: true, embedPlatforms: true));
+                                var gameName = Web.CompositeGameList.Instance.GetGameID(oldGameName);
+                                var game = SpeedrunCom.Client.Games.GetGame(gameName, new GameEmbeds(embedRegions: true, embedPlatforms: true));
                                 gameLoaded = true;
                                 if (game != null)
                                     GameAvailable = true;

--- a/LiveSplit/LiveSplit.Core/Model/RunMetadata.cs
+++ b/LiveSplit/LiveSplit.Core/Model/RunMetadata.cs
@@ -178,8 +178,8 @@ namespace LiveSplit.Model
                         {
                             try
                             {
-                                var gameName = Web.CompositeGameList.Instance.GetGameID(oldGameName);
-                                var game = SpeedrunCom.Client.Games.GetGame(gameName, new GameEmbeds(embedRegions: true, embedPlatforms: true));
+                                var gameId = Web.CompositeGameList.Instance.GetGameID(oldGameName);
+                                var game = SpeedrunCom.Client.Games.GetGame(gameId, new GameEmbeds(embedRegions: true, embedPlatforms: true));
                                 gameLoaded = true;
                                 if (game != null)
                                     GameAvailable = true;

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -282,7 +282,7 @@ namespace LiveSplit.View
             {
                 try
                 {
-                    gameNames = CompositeGameList.Instance.GetGameNamesAndCacheIDs().ToArray();
+                    gameNames = CompositeGameList.Instance.GetGameNames().ToArray();
                     abbreviations = gameNames
                     .Select(x => x.GetAbbreviations()
                         .Select(y => new KeyValuePair<string, string>(x, y)))

--- a/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
+++ b/LiveSplit/LiveSplit.View/View/RunEditorDialog.cs
@@ -282,7 +282,7 @@ namespace LiveSplit.View
             {
                 try
                 {
-                    gameNames = CompositeGameList.Instance.GetGameNames().ToArray();
+                    gameNames = CompositeGameList.Instance.GetGameNamesAndCacheIDs().ToArray();
                     abbreviations = gameNames
                     .Select(x => x.GetAbbreviations()
                         .Select(y => new KeyValuePair<string, string>(x, y)))


### PR DESCRIPTION
This patch changes the way the categories for a game on speedrun.com are retrieved. Previously, it would try searching using the name which works in most cases but there are some edge cases that are mishandled by the speedrun.com API. Now, the categories will be retrieved using the game ID which will be previously cached by the CompositeGameList inside a dictionary. This change only adds a field and 2 methods to the CompositeGameList class which shouldn't break applications relying on the previous behavior.

This fixes #1829, #2368 and #2380