### PR TITLE
Update copyright years in README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2024 Christopher Serr and Sergey Papushin
+Copyright (c) 2013 Christopher Serr and Sergey Papushin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2020 Christopher Serr and Sergey Papushin
+Copyright (c) 2013-2024 Christopher Serr and Sergey Papushin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The documentation for how to develop, test, and submit an Auto Splitter can be f
 
 The MIT License (MIT)
 
-Copyright (c) 2013-2023 Christopher Serr and Sergey Papushin
+Copyright (c) 2013-2024 Christopher Serr and Sergey Papushin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The documentation for how to develop, test, and submit an Auto Splitter can be f
 
 The MIT License (MIT)
 
-Copyright (c) 2013-2024 Christopher Serr and Sergey Papushin
+Copyright (c) 2013 Christopher Serr and Sergey Papushin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
README's end date still had 2023 (not a huge deal), LICENSE contained an end date of 2020 (not really a huge deal either).

Purely a cosmetic change!