### PR TITLE
Ignore invalid timing methods

### DIFF
--- a/LiveSplit/LiveSplit.Core/Server/CommandServer.cs
+++ b/LiveSplit/LiveSplit.Core/Server/CommandServer.cs
@@ -380,7 +380,15 @@ namespace LiveSplit.Server
                         }
                     case "switchto":
                         {
-                            State.CurrentTimingMethod = args[1] == "gametime" ? TimingMethod.GameTime : TimingMethod.RealTime;
+                            switch (args[1])
+                            {
+                                case "gametime":
+                                    State.CurrentTimingMethod = TimingMethod.GameTime;
+                                    break;
+                                case "realtime":
+                                    State.CurrentTimingMethod = TimingMethod.RealTime;
+                                    break;
+                            }
                             break;
                         }
                     case "setsplitname":


### PR DESCRIPTION
This PR changes the server behavior such that the "switchto" command does nothing if not given either "gametime" or "realtime" as an argument instead of switching to realtime.