### PR TITLE
Fix Speedrun.com API key prompt

### DIFF
--- a/LiveSplit/LiveSplit.Core/Web/Share/SpeedrunComAPIKeyPrompt.cs
+++ b/LiveSplit/LiveSplit.Core/Web/Share/SpeedrunComAPIKeyPrompt.cs
@@ -12,10 +12,10 @@ namespace LiveSplit.Web.Share
     {
         public string GetAccessToken()
         {
-            Process.Start("https://www.speedrun.com/me/settings/api");
+            Process.Start("https://www.speedrun.com");
 
             string accessToken = null;
-            InputBox.Show("Speedrun.com Authentication", "Enter your Speedrun.com API Key:", ref accessToken);
+            InputBox.Show("Speedrun.com Authentication", "Enter your Speedrun.com API Key (Go to speedrun.com/users/<username>/settings/api):", ref accessToken);
             return accessToken;
         }
     }


### PR DESCRIPTION
`https://www.speedrun.com/me/settings/api` no longer works (it redirects to Mirror's Edge instead).