### PR TITLE
Invoke update prompt dialog if required

### DIFF
--- a/LiveSplit/LiveSplit.Core/Updates/UpdateHelper.cs
+++ b/LiveSplit/LiveSplit.Core/Updates/UpdateHelper.cs
@@ -29,19 +29,28 @@ namespace LiveSplit.Updates
                                 x.GetChangeLog().Select(y => " - " + y + "\r\n")
                                         .Aggregate("", (y, z) => y + z) + "\r\n")
                                         .Aggregate((x, y) => x + y) + "Do you want to update?";
-                        DialogResult result = (new ScrollableMessageBox()).Show(dialogText, "New updates are available", MessageBoxButtons.YesNo);
-                        if (result == DialogResult.Yes)
+
+                        Action promptForUpdates = () =>
                         {
-                            try
+                            DialogResult result = (new ScrollableMessageBox()).Show(dialogText, "New updates are available", MessageBoxButtons.YesNo);
+                            if (result == DialogResult.Yes)
                             {
-                                Updater.UpdateAll(actualUpdateables, "http://livesplit.org/update/UpdateManager.exe");
-                                closeAction();
+                                try
+                                {
+                                    Updater.UpdateAll(actualUpdateables, "http://livesplit.org/update/UpdateManager.exe");
+                                    closeAction();
+                                }
+                                catch (Exception e)
+                                {
+                                    Log.Error(e);
+                                }
                             }
-                            catch (Exception e)
-                            {
-                                Log.Error(e);
-                            }
-                        }
+                        };
+
+                        if (form.InvokeRequired)
+                            form.Invoke(promptForUpdates);
+                        else
+                            promptForUpdates();
                     }
                     AlreadyChecked.AddRange(actualUpdateables.Select(x => x.GetType()));
                 }


### PR DESCRIPTION
I was trying [this script](https://stackoverflow.com/a/52721562) to see which controls are created off of the main thread, and I noticed that the update prompt has this problem. I'm not sure if this could be related to #2385.

This PR moves the update prompt so that it's invoked onto the main thread if required. One potential downside is that users who don't update will now be unable to use LiveSplit until after they close this prompt.