### PR TITLE
[Breaking] [Server] Use a StreamWriter

### DIFF
--- a/LiveSplit/LiveSplit.Core/Server/Connection.cs
+++ b/LiveSplit/LiveSplit.Core/Server/Connection.cs
@@ -75,8 +75,8 @@ namespace LiveSplit.Server
 
         public virtual void Dispose()
         {
-            Stream.Dispose();
             ReaderThread.Abort();
+            Stream.Dispose();
         }
     }
 

--- a/LiveSplit/LiveSplit.Core/Server/Connection.cs
+++ b/LiveSplit/LiveSplit.Core/Server/Connection.cs
@@ -36,7 +36,7 @@ namespace LiveSplit.Server
             Stream = stream;
             Reader = new StreamReader(Stream, Encoding.UTF8, false);
 
-            Writer = new StreamWriter(Stream, Encoding.UTF8)
+            Writer = new StreamWriter(Stream, new UTF8Encoding(false))
             {
                 NewLine = "\n"
             };

--- a/LiveSplit/LiveSplit.Core/Server/Connection.cs
+++ b/LiveSplit/LiveSplit.Core/Server/Connection.cs
@@ -77,6 +77,7 @@ namespace LiveSplit.Server
         {
             ReaderThread.Abort();
             Stream.Dispose();
+            Reader.Dispose();
         }
     }
 

--- a/LiveSplit/LiveSplit.Core/Server/Connection.cs
+++ b/LiveSplit/LiveSplit.Core/Server/Connection.cs
@@ -25,6 +25,7 @@ namespace LiveSplit.Server
     {
         protected Stream Stream { get; private set; }
         protected StreamReader Reader { get; private set; }
+        protected StreamWriter Writer { get; private set; }
         protected Thread ReaderThread { get; private set; }
 
         public event MessageEventHandler MessageReceived;
@@ -35,6 +36,7 @@ namespace LiveSplit.Server
             Stream = stream;
             Reader = new StreamReader(Stream, Encoding.UTF8, false);
 
+            Writer = new StreamWriter(Stream, Encoding.UTF8)
             ReaderThread = new Thread(new ThreadStart(ReadCommands));
             ReaderThread.Start();
         }
@@ -63,8 +65,8 @@ namespace LiveSplit.Server
         {
             try
             {
-                var buffer = Encoding.UTF8.GetBytes(message + Environment.NewLine);
-                Stream.Write(buffer, 0, buffer.Length);
+                Writer.WriteLine(message);
+                Writer.Flush();
             }
             catch (Exception e)
             {
@@ -78,6 +80,7 @@ namespace LiveSplit.Server
             ReaderThread.Abort();
             Stream.Dispose();
             Reader.Dispose();
+            Writer.Dispose();
         }
     }
 

--- a/LiveSplit/LiveSplit.Core/Server/Connection.cs
+++ b/LiveSplit/LiveSplit.Core/Server/Connection.cs
@@ -37,6 +37,10 @@ namespace LiveSplit.Server
             Reader = new StreamReader(Stream, Encoding.UTF8, false);
 
             Writer = new StreamWriter(Stream, Encoding.UTF8)
+            {
+                NewLine = "\n"
+            };
+
             ReaderThread = new Thread(new ThreadStart(ReadCommands));
             ReaderThread.Start();
         }

--- a/LiveSplit/LiveSplit.Core/Server/Connection.cs
+++ b/LiveSplit/LiveSplit.Core/Server/Connection.cs
@@ -33,7 +33,7 @@ namespace LiveSplit.Server
         public Connection(Stream stream)
         {
             Stream = stream;
-            Reader = new StreamReader(Stream);
+            Reader = new StreamReader(Stream, Encoding.UTF8, false);
 
             ReaderThread = new Thread(new ThreadStart(ReadCommands));
             ReaderThread.Start();


### PR DESCRIPTION
This PR makes a small tweak to the Connection object used by the server, making it use a StreamWriter instead of encoding the bytes manually and appending a newline. It also introduces a potentially breaking change in that it writes a line feed after each response instead of using carriage return + line feed. I feel this makes more sense for a protocol that is intended to work cross-app and cross-platform.