### PR TITLE
Remove SpeedrunComSharp.dll from Components folder in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           rm .\LiveSplit\bin\Release\Microsoft.WindowsAPICodePack.ExtendedLinguisticServices.dll
           rm .\LiveSplit\bin\Release\Microsoft.WindowsAPICodePack.Sensors.dll
           rm .\LiveSplit\bin\Release\Microsoft.WindowsAPICodePack.ShellExtensions.dll
+          rm .\LiveSplit\bin\Release\Components\SpeedrunComSharp.dll
 
       - name: Upload build as an artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Resolves #2436

A better fix would be some way to get it to avoid copying the DLL to the `Components` folder, but I wasn't able to figure out.