### PR TITLE
Use DigitsFormat instead of TimeFormat

### DIFF
--- a/LiveSplit/LiveSplit.Core/TimeFormatters/DigitsFormat.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/DigitsFormat.cs
@@ -2,15 +2,6 @@
 
 namespace LiveSplit.TimeFormatters
 {
-    [Obsolete("Switch over to DigitsFormat")]
-    public enum TimeFormat
-    {
-        TenHours,
-        Hours,
-        Minutes,
-        Seconds
-    }
-
     public enum DigitsFormat
     {
         /// `1`
@@ -27,8 +18,18 @@ namespace LiveSplit.TimeFormatters
         DoubleDigitHours,
     }
 
+    [Obsolete("Switch over to DigitsFormat")]
+    public enum TimeFormat
+    {
+        TenHours,
+        Hours,
+        Minutes,
+        Seconds
+    }
+
     static class FormatUtils
     {
+#pragma warning disable 618
         public static DigitsFormat ToDigitsFormat(this TimeFormat timeFormat)
         {
             if (timeFormat == TimeFormat.Seconds)
@@ -39,6 +40,7 @@ namespace LiveSplit.TimeFormatters
                 return DigitsFormat.SingleDigitHours;
             else if (timeFormat == TimeFormat.TenHours)
                 return DigitsFormat.DoubleDigitHours;
+#pragma warning restore 618
 
             return DigitsFormat.SingleDigitSeconds;
         }

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/GeneralTimeFormatter.cs
@@ -7,9 +7,6 @@ namespace LiveSplit.TimeFormatters {
 
         public TimeAccuracy Accuracy { get; set; }
 
-        [Obsolete("Use DigitsFormat instead")]
-        public TimeFormat TimeFormat { set => DigitsFormat = value.ToDigitsFormat(); }
-
         public DigitsFormat DigitsFormat { get; set; }
 
         /// <summary>

--- a/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
+++ b/LiveSplit/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
@@ -11,12 +11,25 @@ namespace LiveSplit.TimeFormatters
             NullFormat = NullFormat.ZeroWithAccuracy;
         }
 
+        [Obsolete("Switch over to DigitsFormat")]
         public string Format(TimeSpan? time, TimeFormat format)
         {
             var formatRequest = new GeneralTimeFormatter {
                 Accuracy = TimeAccuracy.Hundredths,
                 NullFormat = NullFormat.ZeroWithAccuracy,
-                TimeFormat = format
+                DigitsFormat = format.ToDigitsFormat(),
+            };
+
+            return formatRequest.Format(time);
+        }
+
+        public string Format(TimeSpan? time, DigitsFormat format)
+        {
+            var formatRequest = new GeneralTimeFormatter
+            {
+                Accuracy = TimeAccuracy.Hundredths,
+                NullFormat = NullFormat.ZeroWithAccuracy,
+                DigitsFormat = format,
             };
 
             return formatRequest.Format(time);

--- a/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
+++ b/LiveSplit/LiveSplit.Tests/TimeFormatTests/ShortTimeFormatterTests.cs
@@ -21,7 +21,7 @@ namespace LiveSplit.Tests.TimeFormatterTests
             var sut = new ShortTimeFormatter();
             var defaultFormat = sut.Format(null);
 
-            var formattedValueInSeconds = sut.Format(null, TimeFormat.Seconds);
+            var formattedValueInSeconds = sut.Format(null, DigitsFormat.SingleDigitSeconds);
             Assert.Equal(defaultFormat, formattedValueInSeconds);
         }
 
@@ -54,16 +54,16 @@ namespace LiveSplit.Tests.TimeFormatterTests
             var time = TimeSpan.Parse(timespanText);
 
             var defaultFormat = sut.Format(time);
-            var formattedTimeInSeconds = sut.Format(time, TimeFormat.Seconds);
+            var formattedTimeInSeconds = sut.Format(time, DigitsFormat.SingleDigitSeconds);
             Assert.Equal(defaultFormat, formattedTimeInSeconds);
         }
 
         [Theory]
-        [InlineData(TimeFormat.Seconds)]
-        [InlineData(TimeFormat.Minutes)]
-        [InlineData(TimeFormat.Hours)]
-        [InlineData(TimeFormat.TenHours)]
-        public void FormatsNullTimeInGivenFormatCorrectly(TimeFormat givenFormat)
+        [InlineData(DigitsFormat.SingleDigitSeconds)]
+        [InlineData(DigitsFormat.DoubleDigitMinutes)]
+        [InlineData(DigitsFormat.SingleDigitHours)]
+        [InlineData(DigitsFormat.DoubleDigitHours)]
+        public void FormatsNullTimeInGivenFormatCorrectly(DigitsFormat givenFormat)
         {
             var sut = new ShortTimeFormatter();
 
@@ -72,36 +72,36 @@ namespace LiveSplit.Tests.TimeFormatterTests
         }
 
         [Theory]
-        [InlineData("00:00:00", TimeFormat.Seconds, "0.00")]
-        [InlineData("00:00:00", TimeFormat.Minutes, "00:00.00")]
-        [InlineData("00:00:00", TimeFormat.Hours, "0:00:00.00")]
-        [InlineData("00:00:00", TimeFormat.TenHours, "00:00:00.00")]
+        [InlineData("00:00:00", DigitsFormat.SingleDigitSeconds, "0.00")]
+        [InlineData("00:00:00", DigitsFormat.DoubleDigitMinutes, "00:00.00")]
+        [InlineData("00:00:00", DigitsFormat.SingleDigitHours, "0:00:00.00")]
+        [InlineData("00:00:00", DigitsFormat.DoubleDigitHours, "00:00:00.00")]
 
-        [InlineData("00:00:01.03", TimeFormat.Seconds, "1.03")]
-        [InlineData("00:00:01.03", TimeFormat.Minutes, "00:01.03")]
-        [InlineData("00:00:01.03", TimeFormat.Hours, "0:00:01.03")]
-        [InlineData("00:00:01.03", TimeFormat.TenHours, "00:00:01.03")]
+        [InlineData("00:00:01.03", DigitsFormat.SingleDigitSeconds, "1.03")]
+        [InlineData("00:00:01.03", DigitsFormat.DoubleDigitMinutes, "00:01.03")]
+        [InlineData("00:00:01.03", DigitsFormat.SingleDigitHours, "0:00:01.03")]
+        [InlineData("00:00:01.03", DigitsFormat.DoubleDigitHours, "00:00:01.03")]
 
-        [InlineData("00:05:01.03", TimeFormat.Seconds, "5:01.03")]
-        [InlineData("00:05:01.03", TimeFormat.Minutes, "05:01.03")]
-        [InlineData("00:05:01.03", TimeFormat.Hours, "0:05:01.03")]
-        [InlineData("00:05:01.03", TimeFormat.TenHours, "00:05:01.03")]
+        [InlineData("00:05:01.03", DigitsFormat.SingleDigitSeconds, "5:01.03")]
+        [InlineData("00:05:01.03", DigitsFormat.DoubleDigitMinutes, "05:01.03")]
+        [InlineData("00:05:01.03", DigitsFormat.SingleDigitHours, "0:05:01.03")]
+        [InlineData("00:05:01.03", DigitsFormat.DoubleDigitHours, "00:05:01.03")]
 
-        [InlineData("-00:05:01.03", TimeFormat.Seconds, "−5:01.03")]
-        [InlineData("-00:05:01.03", TimeFormat.Minutes, "−05:01.03")]
-        [InlineData("-00:05:01.03", TimeFormat.Hours, "−0:05:01.03")]
-        [InlineData("-00:05:01.03", TimeFormat.TenHours, "−00:05:01.03")]
+        [InlineData("-00:05:01.03", DigitsFormat.SingleDigitSeconds, "−5:01.03")]
+        [InlineData("-00:05:01.03", DigitsFormat.DoubleDigitMinutes, "−05:01.03")]
+        [InlineData("-00:05:01.03", DigitsFormat.SingleDigitHours, "−0:05:01.03")]
+        [InlineData("-00:05:01.03", DigitsFormat.DoubleDigitHours, "−00:05:01.03")]
 
-        [InlineData("07:05:01.03", TimeFormat.Seconds, "7:05:01.03")]
-        [InlineData("07:05:01.03", TimeFormat.Minutes, "7:05:01.03")]
-        [InlineData("07:05:01.03", TimeFormat.Hours, "7:05:01.03")]
-        [InlineData("07:05:01.03", TimeFormat.TenHours, "07:05:01.03")]
+        [InlineData("07:05:01.03", DigitsFormat.SingleDigitSeconds, "7:05:01.03")]
+        [InlineData("07:05:01.03", DigitsFormat.DoubleDigitMinutes, "7:05:01.03")]
+        [InlineData("07:05:01.03", DigitsFormat.SingleDigitHours, "7:05:01.03")]
+        [InlineData("07:05:01.03", DigitsFormat.DoubleDigitHours, "07:05:01.03")]
 
-        [InlineData("1.07:05:01.03", TimeFormat.Seconds, "31:05:01.03")]
-        [InlineData("1.07:05:01.03", TimeFormat.Minutes, "31:05:01.03")]
-        [InlineData("1.07:05:01.03", TimeFormat.Hours, "31:05:01.03")]
-        [InlineData("1.07:05:01.03", TimeFormat.TenHours, "31:05:01.03")]
-        public void FormatsTimeCorrectly_WhenTimeIsValidAndTimeFormatIsSupplied(string timespanText, TimeFormat format,
+        [InlineData("1.07:05:01.03", DigitsFormat.SingleDigitSeconds, "31:05:01.03")]
+        [InlineData("1.07:05:01.03", DigitsFormat.DoubleDigitMinutes, "31:05:01.03")]
+        [InlineData("1.07:05:01.03", DigitsFormat.SingleDigitHours, "31:05:01.03")]
+        [InlineData("1.07:05:01.03", DigitsFormat.DoubleDigitHours, "31:05:01.03")]
+        public void FormatsTimeCorrectly_WhenTimeIsValidAndTimeFormatIsSupplied(string timespanText, DigitsFormat format,
             string expectedTime)
         {
             var sut = new ShortTimeFormatter();


### PR DESCRIPTION
`TimeFormat` has been deprecated for a while. This PR removes the last uses of it in the standard components.