### PR TITLE
Update SRC API key link to not include their name

### DIFF
--- a/LiveSplit/LiveSplit.Core/Web/Share/SpeedrunComAPIKeyPrompt.cs
+++ b/LiveSplit/LiveSplit.Core/Web/Share/SpeedrunComAPIKeyPrompt.cs
@@ -15,7 +15,7 @@ namespace LiveSplit.Web.Share
             Process.Start("https://www.speedrun.com");
 
             string accessToken = null;
-            InputBox.Show("Speedrun.com Authentication", "Enter your Speedrun.com API Key (Go to speedrun.com/users/<username>/settings/api):", ref accessToken);
+            InputBox.Show("Speedrun.com Authentication", "Enter your Speedrun.com API Key (Go to speedrun.com/settings/api):", ref accessToken);
             return accessToken;
         }
     }

--- a/LiveSplit/LiveSplit.Core/Web/Share/SpeedrunComAPIKeyPrompt.cs
+++ b/LiveSplit/LiveSplit.Core/Web/Share/SpeedrunComAPIKeyPrompt.cs
@@ -12,10 +12,10 @@ namespace LiveSplit.Web.Share
     {
         public string GetAccessToken()
         {
-            Process.Start("https://www.speedrun.com");
+            Process.Start("https://www.speedrun.com/settings/api");
 
             string accessToken = null;
-            InputBox.Show("Speedrun.com Authentication", "Enter your Speedrun.com API Key (Go to speedrun.com/settings/api):", ref accessToken);
+            InputBox.Show("Speedrun.com Authentication", "Enter your Speedrun.com API Key:", ref accessToken);
             return accessToken;
         }
     }


### PR DESCRIPTION
I've updated the SRC API key link to not include the username. Since this link redirects directly to the user's page without them having to type in their name.