### PR TITLE
Add UpdateManager.exe build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,16 @@ jobs:
           -p:DebugType=None
           .\LiveSplit.sln
 
+      - name: Build UpdateManager.exe
+        run: >
+          dotnet build
+          -v m
+          -c ReleaseExecutable
+          -p:PlatformTarget=x64
+          -p:GenerateDocumentationFile=false
+          -p:DebugType=None
+          .\src\UpdateManager\UpdateManager.csproj
+
       - name: Run tests
         run: >
           dotnet test
@@ -69,6 +79,12 @@ jobs:
         with:
           name: LiveSplit_Build
           path: .\bin\Release
+
+      - name: Upload UpdateManager.exe as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: UpdateManagerExe
+          path: .\bin\ReleaseExecutable\UpdateManager.exe
 
       - name: Upload build to LiveSplit.github.io
         if: github.repository == 'LiveSplit/LiveSplit' && github.ref == 'refs/heads/master'

--- a/README.md
+++ b/README.md
@@ -184,10 +184,11 @@ Node.js client implementation available here: https://github.com/satanch/node-li
 
 1. Update versions of any components that changed (create a Git tag and update the factory file for each component) to match the new LiveSplit version.
 2. Create a Git tag for the new version.
-3. Download `LiveSplit_Build` from the GitHub Actions build for the new Git tag.
+3. Download `LiveSplit_Build` and `UpdateManager.exe` from the GitHub Actions build for the new Git tag.
 4. Create a GitHub release for the new version, and upload the LiveSplit build ZIP file with the correct filename (e.g. `LiveSplit_1.8.21.zip`).
 5. Modify files in [the update folder of LiveSplit.github.io](https://github.com/LiveSplit/LiveSplit.github.io/tree/master/update) and commit the changes:
-    - Copy changed files from the downloaded LiveSplit build ZIP file to the update folder.
+    - Copy changed files from the downloaded LiveSplit build ZIP file to the [update folder](https://github.com/LiveSplit/LiveSplit.github.io/tree/master/update).
+    - Copy the downloaded `UpdateManager.exe` to replace the [file in the update folder](https://github.com/LiveSplit/LiveSplit.github.io/blob/master/update/UpdateManager.exe) if there were any changes.
     - Add new versions to the update XMLs for (`update.xml`, `update.updater.xml`, and the update XMLs for any components that changed).
     - Modify the [DLL](https://github.com/therungg/LiveSplit.TheRun/blob/main/Components/LiveSplit.TheRun.dll) and [update XML](https://github.com/therungg/LiveSplit.TheRun/blob/main/update.LiveSplit.TheRun.xml) for LiveSplit.TheRun in its repo.
     - Update the version on the [downloads page](https://github.com/LiveSplit/LiveSplit.github.io/blob/master/downloads.md).

--- a/src/UpdateManager/UpdateManager.csproj
+++ b/src/UpdateManager/UpdateManager.csproj
@@ -11,6 +11,11 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <Nullable>disable</Nullable>
     <NoWarn>1587;1591;1701;1702</NoWarn>
+    <Configurations>Debug;Release;ReleaseExecutable</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'ReleaseExecutable'">
+    <OutputType>WinExe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When performing updates, LiveSplit downloads [`UpdateManager.exe`](https://github.com/LiveSplit/LiveSplit.github.io/blob/master/update/UpdateManager.exe) from the website:
https://github.com/LiveSplit/LiveSplit/blob/dc0b4585e9ffc151904f73f26ef94c297a78f9f2/src/LiveSplit.Core/Updates/UpdateHelper.cs#L40

We need to update this file whenever the UpdateManager code changes, since the LiveSplit build only ships with `UpdateManager.dll`, while `UpdateManager.exe` is used for the actual updates.

This PR updates the build process and release instructions to include building `UpdateManager.exe`.