### PR TITLE
Revert PlatformTarget change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           dotnet build
           -v m
           -c Release
-          -p:PlatformTarget=x64
           -p:GenerateDocumentationFile=false
           -p:DebugType=None
           .\LiveSplit.sln
@@ -45,7 +44,6 @@ jobs:
           dotnet build
           -v m
           -c UpdateManagerExe
-          -p:PlatformTarget=x64
           -p:GenerateDocumentationFile=false
           -p:DebugType=None
           .\src\UpdateManager\UpdateManager.csproj

--- a/src/LiveSplit/LiveSplit.csproj
+++ b/src/LiveSplit/LiveSplit.csproj
@@ -10,6 +10,7 @@
 
     <Nullable>disable</Nullable>
     <NoWarn>1587;1591;1701;1702</NoWarn>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UpdateManager/UpdateManager.csproj
+++ b/src/UpdateManager/UpdateManager.csproj
@@ -17,6 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)' == 'UpdateManagerExe'">
     <OutputType>WinExe</OutputType>
     <Optimize>True</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In https://github.com/LiveSplit/LiveSplit/commit/4b0ccc3085b559b7172d28eaede31dc0ef064c56, we started building LiveSplit.exe to support 64 bit only. I believe the previous behavior was "Any CPU" based on https://stackoverflow.com/a/30352426