### PR TITLE
Skip incompatible image formats

### DIFF
--- a/src/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
+++ b/src/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
@@ -1,4 +1,5 @@
 ﻿using LiveSplit.Model.Comparisons;
+using LiveSplit.Options;
 using LiveSplit.UI;
 using System;
 using System.Drawing;
@@ -78,7 +79,20 @@ namespace LiveSplit.Model.RunFactories
             // See https://github.com/LiveSplit/LiveSplit/issues/894
             var stream = new MemoryStream(buffer);
 
-            return Image.FromStream(stream);
+            try
+            {
+                return Image.FromStream(stream);
+            }
+            catch (Exception ex)
+            {
+                // .NET Framework's Image doesn't support newer image formats
+                // such as AVIF, WEBP, and JPEG XL. These may be used in
+                // LiveSplit One. So we need to fall back to an empty image
+                // instead of erroring out.
+                Log.Error(ex);
+                stream.Dispose();
+                return null;
+            }
         }
 
         public IRun Create(IComparisonGeneratorsFactory factory)


### PR DESCRIPTION
When parsing the splits we may encounter splits from LiveSplit One where images may be using newer image formats such as WEBP, AVIF, and JPEG XL. Instead of rejecting the splits files entirely, we simply skip those images instead. A long term solution could be to try converting those images into PNG.

cc https://github.com/LiveSplit/LiveSplit/issues/2454 (probably doesn't fix the main issue but the one in the comment).