### PR TITLE
Use MSBuild targets for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up .NET environment
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.x'
+          dotnet-version: '8.0.x'
 
       - name: Build LiveSplit
         run: >
@@ -36,7 +36,8 @@ jobs:
           -v m
           -c Release
           -p:DebugType=None
-          .\LiveSplit.sln
+          -o .\ci-build
+          .\src\LiveSplit
 
       - name: Build UpdateManager.exe
         run: >
@@ -44,7 +45,8 @@ jobs:
           -v m
           -c UpdateManagerExe
           -p:DebugType=None
-          .\src\UpdateManager\UpdateManager.csproj
+          -o .\ci-update-manager
+          .\src\UpdateManager
 
       - name: Run tests
         run: >
@@ -58,18 +60,18 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: LiveSplit_Build
-          path: .\bin\Release
+          path: .\ci-build
 
       - name: Upload UpdateManager.exe as an artifact
         uses: actions/upload-artifact@v4
         with:
           name: UpdateManagerExe
-          path: .\bin\UpdateManagerExe
+          path: .\ci-update-manager
 
       - name: Upload build to LiveSplit.github.io
         if: github.repository == 'LiveSplit/LiveSplit' && github.ref == 'refs/heads/master'
         run: |
-          7z a LiveSplitDevBuild.zip .\bin\Release\*
+          7z a LiveSplitDevBuild.zip .\ci-build\*
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git clone -q --branch master --single-branch "https://github.com/LiveSplit/LiveSplit.github.io.git"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,6 @@
   <PropertyGroup Label="Output Settings">
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(RootPath)\artifacts</ArtifactsPath>
-
-    <BuildPath>$(RootPath)\bin\$(Configuration.ToLowerInvariant())</BuildPath>
   </PropertyGroup>
 
 </Project>

--- a/components/Directory.Build.props
+++ b/components/Directory.Build.props
@@ -7,8 +7,4 @@
     <LsLibPath>$(RootPath)\lib</LsLibPath>
   </PropertyGroup>
 
-  <PropertyGroup Label="Output Settings">
-    <OutDir>$(BuildPath)\Components</OutDir>
-  </PropertyGroup>
-
 </Project>

--- a/lib/CustomFontDialog/CustomFontDialog/CustomFontDialog.csproj
+++ b/lib/CustomFontDialog/CustomFontDialog/CustomFontDialog.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutDir>bin\$(Configuration)</OutDir>
     <TargetFramework>net4.6.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
 

--- a/lib/WinForms Color Picker/WinFormsColor/WinFormsColor.csproj
+++ b/lib/WinForms Color Picker/WinFormsColor/WinFormsColor.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutDir>bin\$(Configuration)</OutDir>
     <TargetFramework>net4.6.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="..\Directory.Build.props" />
-
-  <PropertyGroup Label="Output Settings">
-    <OutDir>$(BuildPath)</OutDir>
-  </PropertyGroup>
-
-</Project>

--- a/src/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/src/LiveSplit.Core/LiveSplit.Core.csproj
@@ -37,21 +37,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <PreBuildEvent>
-      mkdir "$(MSBuildProjectDirectory)\Updates\GitInfo\."
-      where git
-      if %25ERRORLEVEL%25 == 0 (
-        git describe --dirty --always --long --tags &gt; "$(MSBuildProjectDirectory)\Updates\GitInfo\version.txt"
-        git rev-parse --abbrev-ref HEAD &gt; "$(MSBuildProjectDirectory)\Updates\GitInfo\branch.txt"
-        git rev-parse HEAD &gt; "$(MSBuildProjectDirectory)\Updates\GitInfo\revision.txt"
-      ) else (
-        touch "$(MSBuildProjectDirectory)\Updates\GitInfo\version.txt"
-        touch "$(MSBuildProjectDirectory)\Updates\GitInfo\branch.txt"
-        touch "$(MSBuildProjectDirectory)\Updates\GitInfo\revision.txt"
-      )
-      EXIT 0
-    </PreBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\targets\_CreateGitInfo.targets" />
 
 </Project>

--- a/src/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/src/LiveSplit.Core/LiveSplit.Core.csproj
@@ -37,6 +37,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)\targets\_CreateGitInfo.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)\targets\*.targets" />
 
 </Project>

--- a/src/LiveSplit.Core/targets/_CreateGitInfo.targets
+++ b/src/LiveSplit.Core/targets/_CreateGitInfo.targets
@@ -1,0 +1,42 @@
+<Project>
+
+  <PropertyGroup>
+    <GitInfoPath>$(MSBuildProjectDirectory)\Updates\GitInfo</GitInfoPath>
+  </PropertyGroup>
+
+  <Target Name="_CreateGitInfo" BeforeTargets="PreBuildEvent">
+    <Message Importance="high" Text="Creating Git Info..." />
+    <MakeDir Directories="$(GitInfoPath)" />
+
+    <Exec Command="where git" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="WhereGitExitCode" />
+    </Exec>
+  </Target>
+
+  <Target Name="_CreateGitInfoWithGit" AfterTargets="_CreateGitInfo"
+          Condition="'$(WhereGitExitCode)' == '0'">
+    <Exec Command="git describe --dirty --always --long --tags" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitVersion" />
+    </Exec>
+
+    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitBranch" />
+    </Exec>
+
+    <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitRevision" />
+    </Exec>
+
+    <WriteLinesToFile File="$(GitInfoPath)\version.txt" Lines="$(GitVersion)" Overwrite="true" />
+    <WriteLinesToFile File="$(GitInfoPath)\branch.txt" Lines="$(GitBranch)" Overwrite="true" />
+    <WriteLinesToFile File="$(GitInfoPath)\revision.txt" Lines="$(GitRevision)" Overwrite="true" />
+  </Target>
+
+  <Target Name="_CreateGitInfoWithoutGit" AfterTargets="_CreateGitInfo"
+          Condition="'$(WhereGitExitCode)' != '0'">
+    <Touch Files="$(GitInfoPath)\version.txt" AlwaysCreate="true" />
+    <Touch Files="$(GitInfoPath)\branch.txt" AlwaysCreate="true" />
+    <Touch Files="$(GitInfoPath)\revision.txt" AlwaysCreate="true" />
+  </Target>
+
+</Project>

--- a/src/LiveSplit/LiveSplit.csproj
+++ b/src/LiveSplit/LiveSplit.csproj
@@ -20,27 +20,6 @@
     <ProjectReference Include="$(LibPath)\WinForms Color Picker\WinFormsColor\WinFormsColor.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <PostBuildEvent>
-      mkdir "$(OutDir)\Resources"
-      copy "$(ResourcesPath)\SplitsFile.ico" "$(OutDir)\Resources"
-      copy "$(ResourcesPath)\LayoutFile.ico" "$(OutDir)\Resources"
-      rd /s /q "$(OutDir)\runtimes"
-      del "$(OutDir)\Microsoft.WindowsAPICodePack.ExtendedLinguisticServices.dll"
-      del "$(OutDir)\Microsoft.WindowsAPICodePack.Sensors.dll"
-      del "$(OutDir)\Microsoft.WindowsAPICodePack.ShellExtensions.dll"
-      del "$(OutDir)\x64\asr_capi.dll"
-      del "$(OutDir)\x86\asr_capi.dll"
-      del "$(OutDir)\Components\SpeedrunComSharp.dll"
-      del "$(OutDir)\Components\CustomFontDialog.dll"
-      del "$(OutDir)\Components\CustomFontDialog.dll.config"
-      del "$(OutDir)\Components\WinFormsColor.dll"
-      del "$(OutDir)\Components\System.Buffers.dll"
-      del "$(OutDir)\Components\System.Memory.dll"
-      del "$(OutDir)\Components\System.Numerics.Vectors.dll"
-      del "$(OutDir)\Components\System.Resources.Extensions.dll"
-      del "$(OutDir)\Components\System.Runtime.CompilerServices.Unsafe.dll"
-    </PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\targets\*.targets" />
 
 </Project>

--- a/src/LiveSplit/targets/_BuildComponents.targets
+++ b/src/LiveSplit/targets/_BuildComponents.targets
@@ -1,0 +1,12 @@
+<Project>
+
+  <Target Name="_BuildComponents" AfterTargets="Build">
+    <ItemGroup>
+      <_Components Include="$(ComponentsPath)\*\src\*\*.csproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(_Components)" Targets="Restore" Properties="IsRestoring=true" />
+    <MSBuild Projects="@(_Components)" Targets="Build" Properties="OutputPath=$(OutputPath)\Components" />
+  </Target>
+
+</Project>

--- a/src/LiveSplit/targets/_BuildLiveSplitRegister.targets
+++ b/src/LiveSplit/targets/_BuildLiveSplitRegister.targets
@@ -1,0 +1,8 @@
+<Project>
+
+  <Target Name="_BuildLiveSplitRegister" AfterTargets="Build">
+    <MSBuild Projects="$(SrcPath)\LiveSplit.Register\LiveSplit.Register.csproj" Targets="Restore" Properties="IsRestoring=true" />
+    <MSBuild Projects="$(SrcPath)\LiveSplit.Register\LiveSplit.Register.csproj" Targets="Build" Properties="OutputPath=$(OutputPath)" />
+  </Target>
+
+</Project>

--- a/src/LiveSplit/targets/_Finalize.targets
+++ b/src/LiveSplit/targets/_Finalize.targets
@@ -1,0 +1,24 @@
+<Project>
+
+  <Target Name="_Finalize" AfterTargets="_BuildComponents">
+    <ItemGroup>
+      <_ResourceFiles Include="$(ResourcesPath)\LayoutFile.ico" />
+      <_ResourceFiles Include="$(ResourcesPath)\SplitsFile.ico" />
+
+      <_AssembliesToRemove Include="$(OutputPath)\Components\**\*.*" />
+
+      <_AssembliesToRemove Include="$(OutputPath)\x64\asr_capi.dll" />
+      <_AssembliesToRemove Include="$(OutputPath)\x86\asr_capi.dll" />
+      <_AssembliesToRemove Include="$(OutputPath)\Microsoft.WindowsAPICodePack.ExtendedLinguisticServices.dll" />
+      <_AssembliesToRemove Include="$(OutputPath)\Microsoft.WindowsAPICodePack.Sensors.dll" />
+      <_AssembliesToRemove Include="$(OutputPath)\Microsoft.WindowsAPICodePack.ShellExtensions.dll" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_ResourceFiles)" DestinationFolder="$(OutputPath)\Resources" />
+
+    <!-- Delete only those files which already exist in the parent directory. -->
+    <Delete Files="@(_AssembliesToRemove)"
+            Condition="Exists('$(OutputPath)\%(RecursiveDir)\%(Filename)%(Extension)')" />
+  </Target>
+
+</Project>

--- a/test/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/test/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutDir>bin\$(Configuration)</OutDir>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description

- Drops all of the hard-coded `OutDir` properties.
- Moves pre and post-build events to MSBuild targets.