### PR TITLE
Add share to X (Twitter) with web intents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ LiveSplit is a timer program for speedrunners that is both easy to use and full 
 
 **Dynamic Resizing:** LiveSplit can be resized to any size so that it looks good on stream. As LiveSplit’s size is changed, all of its parts are automatically scaled up in order to preserve its appearance.
 
-**Sharing Runs:** Any run can be shared to [Speedrun.com](http://speedrun.com/). Splits can also be distributed using [splits i/o](https://splits.io/) and imported from a URL. You can also share a screenshot of your splits to [Imgur](http://imgur.com/) or save it as a file. Your [Twitch](http://www.twitch.tv/) title can be updated as well based on the game you are playing.
+**Sharing Runs:** Any run can be shared to [Speedrun.com](http://speedrun.com/) and [X (Twitter)](https://twitter.com/). Splits can also be distributed using [splits i/o](https://splits.io/) and imported from a URL. You can also share a screenshot of your splits to [Imgur](http://imgur.com/) or save it as a file. Your [Twitch](http://www.twitch.tv/) title can be updated as well based on the game you are playing.
 
 **Component Development:** Anyone can develop their own components that can easily be shared and used with LiveSplit. Additional downloadable components can be found in the [Components Section](https://livesplit.org/components/).
 

--- a/src/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/src/LiveSplit.Core/LiveSplit.Core.csproj
@@ -37,6 +37,21 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Web\Share\ShareSettings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ShareSettings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Web\Share\ShareSettings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>ShareSettings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
   <PropertyGroup>
     <PreBuildEvent>
       mkdir "$(MSBuildProjectDirectory)\Updates\GitInfo\."

--- a/src/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/src/LiveSplit.Core/LiveSplit.Core.csproj
@@ -37,21 +37,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Web\Share\ShareSettings.Designer.cs">
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ShareSettings.settings</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="Web\Share\ShareSettings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>ShareSettings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-
   <PropertyGroup>
     <PreBuildEvent>
       mkdir "$(MSBuildProjectDirectory)\Updates\GitInfo\."

--- a/src/LiveSplit.Core/Web/Share/ShareSettings.Designer.cs
+++ b/src/LiveSplit.Core/Web/Share/ShareSettings.Designer.cs
@@ -30,6 +30,21 @@ namespace LiveSplit.Web.Share
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string TwitterFormat
+        {
+            get
+            {
+                return ((string)(this["TwitterFormat"]));
+            }
+            set
+            {
+                this["TwitterFormat"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string TwitchFormat
         {
             get
@@ -39,6 +54,21 @@ namespace LiveSplit.Web.Share
             set
             {
                 this["TwitchFormat"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string TwitterFormatRunning
+        {
+            get
+            {
+                return ((string)(this["TwitterFormatRunning"]));
+            }
+            set
+            {
+                this["TwitterFormatRunning"] = value;
             }
         }
     }

--- a/src/LiveSplit.Core/Web/Share/ShareSettings.settings
+++ b/src/LiveSplit.Core/Web/Share/ShareSettings.settings
@@ -5,5 +5,11 @@
     <Setting Name="TwitchFormat" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="TwitterFormat" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="TwitterFormatRunning" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/LiveSplit.Core/Web/Share/Twitter.cs
+++ b/src/LiveSplit.Core/Web/Share/Twitter.cs
@@ -24,7 +24,7 @@ namespace LiveSplit.Web.Share
 
         public string Description =>
 @"X (Twitter) allows you to share your run with the world. 
-When sharing, a screenshot of LiveSplit is automatically copied the the clipboard.
+When sharing, a screenshot of LiveSplit is automatically copied to the clipboard.
 When you click share, LiveSplit opens a Tweet composition window in your default browser.";
 
         public bool VerifyLogin()

--- a/src/LiveSplit.Core/Web/Share/Twitter.cs
+++ b/src/LiveSplit.Core/Web/Share/Twitter.cs
@@ -1,0 +1,71 @@
+﻿using LiveSplit.Model;
+using LiveSplit.Options;
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Windows.Forms;
+
+namespace LiveSplit.Web.Share
+{
+    public class Twitter : IRunUploadPlatform
+    {
+        public ISettings Settings { get; set; }
+
+        protected static readonly Twitter _Instance = new Twitter();
+        public static Twitter Instance => _Instance;
+
+        public static readonly Uri BaseUri = new Uri("https://twitter.com/intent/tweet");
+
+        protected Twitter() { }
+
+        public string PlatformName => "X (Twitter)";
+
+        public string Description =>
+@"X (Twitter) allows you to share your run with the world. 
+When sharing, a screenshot of the split is automatically copied to the clipboard.
+When you click share, open the post edit window in your default browser.";
+
+        public bool VerifyLogin()
+        {
+            return true;
+        }
+
+        public bool SubmitRun(IRun run, Func<Image> screenShotFunction = null, bool attachSplits = false, TimingMethod method = TimingMethod.RealTime, string comment = "", params string[] additionalParams)
+        {
+            if (attachSplits)
+                comment += " " + SplitsIO.Instance.Share(run, screenShotFunction);
+
+            ImageToCripboard(screenShotFunction());
+            var uri = MakeUri(comment);
+            Process.Start(uri);
+
+            return true;
+        }
+
+        private void ImageToCripboard(Image image)
+        {
+            if (image is null)
+                return;
+
+            Image pngImage;
+            using (var stream = new MemoryStream())
+            {
+                image.Save(stream, ImageFormat.Png);
+                pngImage = Image.FromStream(stream);
+            }
+            Clipboard.SetDataObject(pngImage);
+        }
+        private string MakeUri(string text)
+        {
+            var intentText = "";
+            if (!String.IsNullOrEmpty(text))
+            {
+                intentText = "?text=" + Uri.EscapeDataString(text);
+            }
+
+            return BaseUri + intentText;
+        }
+    }
+}

--- a/src/LiveSplit.Core/Web/Share/Twitter.cs
+++ b/src/LiveSplit.Core/Web/Share/Twitter.cs
@@ -24,7 +24,7 @@ namespace LiveSplit.Web.Share
 
         public string Description =>
 @"X (Twitter) allows you to share your run with the world. 
-When sharing, a screenshot of the split is automatically copied to the clipboard.
+When sharing, a screenshot of LiveSplit is automatically copied the the clipboard.
 When you click share, LiveSplit opens a Tweet composition window in your default browser.";
 
         public bool VerifyLogin()

--- a/src/LiveSplit.Core/Web/Share/Twitter.cs
+++ b/src/LiveSplit.Core/Web/Share/Twitter.cs
@@ -37,14 +37,14 @@ When you click share, LiveSplit opens a Tweet composition window in your default
             if (attachSplits)
                 comment += " " + SplitsIO.Instance.Share(run, screenShotFunction);
 
-            ImageToCripboard(screenShotFunction());
+            ImageToClipboard(screenShotFunction());
             var uri = MakeUri(comment);
             Process.Start(uri);
 
             return true;
         }
 
-        private void ImageToCripboard(Image image)
+        private void ImageToClipboard(Image image)
         {
             if (image is null)
                 return;

--- a/src/LiveSplit.Core/Web/Share/Twitter.cs
+++ b/src/LiveSplit.Core/Web/Share/Twitter.cs
@@ -25,7 +25,7 @@ namespace LiveSplit.Web.Share
         public string Description =>
 @"X (Twitter) allows you to share your run with the world. 
 When sharing, a screenshot of the split is automatically copied to the clipboard.
-When you click share, open the post edit window in your default browser.";
+When you click share, LiveSplit opens a Tweet composition window in your default browser.";
 
         public bool VerifyLogin()
         {

--- a/src/LiveSplit.Core/app.config
+++ b/src/LiveSplit.Core/app.config
@@ -8,7 +8,13 @@
     <userSettings>
         <LiveSplit.Web.Share.ShareSettings>
             <setting name="TwitchFormat" serializeAs="String">
-                <value/>
+                <value />
+            </setting>
+            <setting name="TwitterFormat" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="TwitterFormatRunning" serializeAs="String">
+                <value />
             </setting>
         </LiveSplit.Web.Share.ShareSettings>
     </userSettings>

--- a/src/LiveSplit.View/View/ShareRunDialog.cs
+++ b/src/LiveSplit.View/View/ShareRunDialog.cs
@@ -44,6 +44,8 @@ namespace LiveSplit.View
 
         private void SubmitDialog_Load(object sender, EventArgs e)
         {
+            cbxPlatform.Items.Add("X (Twitter)");
+
             if (State.CurrentPhase == TimerPhase.NotRunning || State.CurrentPhase == TimerPhase.Ended)
             {
                 if (HasPersonalBest(Run))
@@ -72,6 +74,7 @@ namespace LiveSplit.View
             switch (cbxPlatform.SelectedItem.ToString())
             {
                 case "Splits.io": CurrentPlatform = SplitsIO.Instance; break;
+                case "X (Twitter)": CurrentPlatform = Twitter.Instance; break;
                 case "Twitch": CurrentPlatform = Twitch.Instance; break;
                 case "Screenshot": CurrentPlatform = Screenshot.Instance; break;
                 case "Imgur": CurrentPlatform = Imgur.Instance; break;
@@ -84,7 +87,7 @@ namespace LiveSplit.View
             txtNotes.Enabled = btnInsertCategory.Enabled = btnInsertDeltaTime.Enabled = btnInsertGame.Enabled
                 = btnInsertPB.Enabled = btnInsertSplitName.Enabled = btnInsertSplitTime.Enabled
                 = btnInsertStreamLink.Enabled = btnInsertTitle.Enabled = btnPreview.Enabled =
-                (CurrentPlatform == Twitch.Instance || CurrentPlatform == Imgur.Instance);
+                (CurrentPlatform == Twitter.Instance || CurrentPlatform == Twitch.Instance || CurrentPlatform == Imgur.Instance);
 
             if (State.CurrentPhase == TimerPhase.NotRunning || State.CurrentPhase == TimerPhase.Ended)
                 chkAttachSplits.Enabled = !(CurrentPlatform == Screenshot.Instance || CurrentPlatform == SplitsIO.Instance
@@ -164,7 +167,27 @@ namespace LiveSplit.View
 
         private void RefreshNotes()
         {
-            if (CurrentPlatform == Twitch.Instance)
+            if (CurrentPlatform == Twitter.Instance)
+            {
+                ShareSettings.Default.Reload();
+                if (State.CurrentPhase == TimerPhase.NotRunning || State.CurrentPhase == TimerPhase.Ended)
+                {
+                    txtNotes.Text = ShareSettings.Default.TwitterFormat;
+                    if (string.IsNullOrEmpty(txtNotes.Text))
+                    {
+                        txtNotes.Text = "I got a $pb in $title.";
+                    }
+                }
+                else
+                {
+                    txtNotes.Text = ShareSettings.Default.TwitterFormatRunning;
+                    if (string.IsNullOrEmpty(txtNotes.Text))
+                    {
+                        txtNotes.Text = "I'm $delta in $title.";
+                    }
+                }
+            }
+            else if (CurrentPlatform == Twitch.Instance)
             {
                 ShareSettings.Default.Reload();
                 txtNotes.Text = ShareSettings.Default.TwitchFormat;
@@ -179,7 +202,15 @@ namespace LiveSplit.View
 
         private void SaveNotesFormat()
         {
-            if (CurrentPlatform == Twitch.Instance)
+            if (CurrentPlatform == Twitter.Instance)
+            {
+                if (State.CurrentPhase == TimerPhase.NotRunning || State.CurrentPhase == TimerPhase.Ended)
+                    ShareSettings.Default.TwitterFormat = txtNotes.Text;
+                else
+                    ShareSettings.Default.TwitterFormatRunning = txtNotes.Text;
+                ShareSettings.Default.Save();
+            }
+            else if (CurrentPlatform == Twitch.Instance)
             {
                 ShareSettings.Default.TwitchFormat = txtNotes.Text;
                 ShareSettings.Default.Save();


### PR DESCRIPTION
Share to X (Twitter) using web intents instead of API.
When sharing, a screenshot is copied to the clipboard, so you can use ctrl+v on the post edit screen to paste the screenshot.