### PR TITLE
[Server] setsplitname Error Handling Fix

### DIFF
--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -3,6 +3,7 @@ using LiveSplit.Options;
 using LiveSplit.TimeFormatters;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
@@ -421,23 +422,19 @@ namespace LiveSplit.Server
                         {
                             var options = args[1].Split(new[] { ' ' }, 2);
 
-                            try
-                            {
-                                index = Convert.ToInt32(options[0]);
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex);
-                                Log.Error($"[Server] Could not parse {options[0]} as a split index.");
-                            }
-
-                            title = options[1];
-
                             if (options.Length < 2)
                             {
                                 Log.Error($"[Server] Command {command} incorrect usage: missing one or more arguments.");
                                 break;
                             }
+
+                            if (!int.TryParse(options[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out index))
+                            {
+                                Log.Error($"[Server] Could not parse {options[0]} as a split index while setting split name.");
+                                break;
+                            }
+
+                            title = options[1];
                         }
 
                         if (index >= 0 && index < State.Run.Count)

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -3,7 +3,6 @@ using LiveSplit.Options;
 using LiveSplit.TimeFormatters;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;


### PR DESCRIPTION
This PR fixes a small logic error that could allow an exception to propagate from the `setsplitname` command. With this fix, the command should never throw an exception and instead write an error to the log and do nothing if the input is invalid.