### PR TITLE
Enforce TLS 1.2 support

### DIFF
--- a/src/LiveSplit.Core/Model/AutoSplitterFactory.cs
+++ b/src/LiveSplit.Core/Model/AutoSplitterFactory.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Xml;
 
 namespace LiveSplit.Model
@@ -37,6 +38,7 @@ namespace LiveSplit.Model
             if (AutoSplitters != null)
                 return;
 
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             var document = DownloadAutoSplitters();
 
             if (document != null)


### PR DESCRIPTION
Related issue: #2409 

- Enforces support for the highest available TLS protocol on .NET Framework 4.6.1 to resolve edge cases where there's a missconfiguration on user's OS