### PR TITLE
Enable DPI-awareness

### DIFF
--- a/src/LiveSplit/LiveSplit.csproj
+++ b/src/LiveSplit/LiveSplit.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
 
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/LiveSplit/app.manifest
+++ b/src/LiveSplit/app.manifest
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10+ -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+</assembly>


### PR DESCRIPTION
### Description

This PR enables DPI-awareness for LiveSplit. The change allows LiveSplit to scale text elements correctly for users which set their display scale to anything but 100%. Below are screenshots of the context menu on my display without (left) and with (right) the change.

Some possible problems might arise due to this change: evidently, the scale affects the size of some UI elements. Especially the default layout is affected by appearing a lot smaller than before (since it now scales the height and width to the DPI). I haven't checked the extent of this and if it actually screws up any of the controls. We may want to do that. 

Resolves #1346 

![](https://github.com/user-attachments/assets/f1a84153-5d74-407c-bb7c-cafa5807d876) ![](https://github.com/user-attachments/assets/e3711295-8c2f-429e-b75e-32e332e16cba)
