### PR TITLE
Clean up ShortTimeFormatter

### DIFF
--- a/src/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
+++ b/src/LiveSplit.Core/TimeFormatters/ShortTimeFormatter.cs
@@ -3,13 +3,9 @@ using System.Globalization;
 
 namespace LiveSplit.TimeFormatters
 {
-    public class ShortTimeFormatter : GeneralTimeFormatter
+    public class ShortTimeFormatter : ITimeFormatter
     {
-        public ShortTimeFormatter()
-        {
-            Accuracy = TimeAccuracy.Hundredths;
-            NullFormat = NullFormat.ZeroWithAccuracy;
-        }
+        public ShortTimeFormatter() { }
 
         [Obsolete("Switch over to DigitsFormat")]
         public string Format(TimeSpan? time, TimeFormat format)
@@ -33,6 +29,11 @@ namespace LiveSplit.TimeFormatters
             };
 
             return formatRequest.Format(time);
+        }
+
+        public string Format(TimeSpan? timeSpan)
+        {
+            return Format(timeSpan, DigitsFormat.SingleDigitSeconds);
         }
     }
 }


### PR DESCRIPTION
`ShortTimeFormatter` was simultaneously inheriting from `GeneralTimeFormatter` and initializing a new instance in the `Format` call.