### PR TITLE
Add CustomVariables

### DIFF
--- a/src/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
+++ b/src/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
@@ -134,6 +134,15 @@ public class StandardFormatsRunFactory : IRunFactory
             }
         }
 
+        using (LiveSplitCore.RunMetadataCustomVariablesIter iter = metadata.CustomVariables())
+        {
+            LiveSplitCore.RunMetadataCustomVariableRef variable;
+            while ((variable = iter.Next()) != null)
+            {
+                run.Metadata.GetOrAddCustomVariable(variable.Name()).AsPermanent().Value = variable.Value();
+            }
+        }
+
         run.GameIcon = ParseImage(lscRun.GameIconPtr(), lscRun.GameIconLen());
         run.GameName = lscRun.GameName();
         run.CategoryName = lscRun.CategoryName();

--- a/src/LiveSplit.Core/Model/RunMetadata.cs
+++ b/src/LiveSplit.Core/Model/RunMetadata.cs
@@ -119,6 +119,64 @@ public class RunMetadata
         }
     }
 
+    /// <summary>
+    ///     A dictionary mapping custom variable names to <see cref="CustomVariable"/> objects.
+    /// </summary>
+    public Dictionary<string, CustomVariable> CustomVariables { get; private set; } = new Dictionary<string, CustomVariable>();
+
+    /// <summary>
+    ///     Gets the custom variable with the specified <paramref name="name"/> if it exists;
+    ///     otherwise, adds a new one.
+    /// </summary>
+    /// <param name="name">
+    ///     The key of the custom variable to get or add.
+    /// </param>
+    /// <returns>
+    ///     The custom variable corresponding to the specified <paramref name="name"/>.
+    /// </returns>
+    public CustomVariable GetOrAddCustomVariable(string name)
+    {
+        if (!CustomVariables.TryGetValue(name, out CustomVariable variable))
+        {
+            CustomVariables.Add(name, variable = new());
+        }
+
+        return variable;
+    }
+
+    /// <summary>
+    ///     Gets the value of the custom variable corresponding to <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">
+    ///     The key of the custom variable whose value to get.
+    /// </param>
+    /// <returns>
+    ///     The value of the custom variable corresponding to <paramref name="name"/>.
+    /// </returns>
+    public string CustomVariableValue(string name)
+    {
+        return GetOrAddCustomVariable(name).Value;
+    }
+
+    /// <summary>
+    ///     Sets a custom variable, mapping <paramref name="name"/> to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="name">
+    ///     The key of the custom variable.
+    /// </param>
+    /// <param name="value">
+    ///     The value which the custom variable should have.
+    /// </param>
+    public void SetCustomVariable(string name, string value)
+    {
+        CustomVariable v = GetOrAddCustomVariable(name);
+        v.Value = value;
+        if (v.IsPermanent)
+        {
+            LiveSplitRun.HasChanged = true;
+        }
+    }
+
     public bool UsesEmulator
     {
         get => usesEmulator;
@@ -157,6 +215,7 @@ public class RunMetadata
     {
         LiveSplitRun = run;
         VariableValueNames = new Dictionary<string, string>();
+        CustomVariables = new Dictionary<string, CustomVariable>();
         game = new Lazy<Game>(() => null);
         category = new Lazy<Category>(() => null);
         this.run = new Lazy<SpeedrunComSharp.Run>(() => null);
@@ -324,6 +383,7 @@ public class RunMetadata
             regionName = regionName,
             usesEmulator = usesEmulator,
             VariableValueNames = VariableValueNames.ToDictionary(x => x.Key, x => x.Value),
+            CustomVariables = CustomVariables.ToDictionary(x => x.Key, x => x.Value.Clone()),
             CategoryAvailable = CategoryAvailable,
             GameAvailable = GameAvailable
             //TODO: set members instead later
@@ -334,5 +394,70 @@ public class RunMetadata
     private void TriggerPropertyChanged(bool clearRunID)
     {
         PropertyChanged?.Invoke(this, new MetadataChangedEventArgs(clearRunID));
+    }
+}
+
+/// <summary>
+///     A custom variable that has a value and can be marked permanent.
+/// </summary>
+public sealed class CustomVariable
+{
+    /// <summary>
+    ///     The current value of the custom variable.
+    /// </summary>
+    public string Value { get; set; }
+
+    /// <summary>
+    ///     Gets a value indicating whether the custom variable should be saved in the run permanently.
+    /// </summary>
+    /// <value>
+    ///     <see langword="false"/> initially. Once set to <see langword="true"/>, will remain as such.
+    /// </value>
+    public bool IsPermanent { get; private set; }
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="CustomVariable"/> class
+    ///     with a default value, not permanent.
+    /// </summary>
+    public CustomVariable()
+        : this(null, false) { }
+
+    /// <summary>
+    ///     Creates a new instance of the <see cref="CustomVariable"/> class
+    ///     with the specified <paramref name="value"/> and permanence.
+    /// </summary>
+    /// <param name="value">
+    ///     The value of the custom variable.
+    /// </param>
+    /// <param name="isPermanent">
+    ///     Indicates whether it should be saved in the run permanently.
+    /// </param>
+    public CustomVariable(string value, bool isPermanent)
+    {
+        Value = value;
+        IsPermanent = isPermanent;
+    }
+
+    /// <summary>
+    ///     Makes the custom variable permanent.
+    /// </summary>
+    /// <returns>
+    ///     The same custom variable object marked permanent.
+    /// </returns>
+    public CustomVariable AsPermanent()
+    {
+        IsPermanent = true;
+        return this;
+    }
+
+    /// <summary>
+    ///     Constructs a new custom variable with the same value and permanence.
+    /// </summary>
+    /// <returns>
+    ///     A copy of the custom variable.
+    /// </returns>
+    public CustomVariable Clone()
+    {
+        return new CustomVariable(Value, IsPermanent);
     }
 }

--- a/src/LiveSplit.Core/Model/RunSavers/XMLRunSaver.cs
+++ b/src/LiveSplit.Core/Model/RunSavers/XMLRunSaver.cs
@@ -45,6 +45,20 @@ public class XMLRunSaver : IRunSaver
         }
 
         metadata.AppendChild(variables);
+
+        XmlElement customVariables = document.CreateElement("CustomVariables");
+        foreach (System.Collections.Generic.KeyValuePair<string, CustomVariable> entry in run.Metadata.CustomVariables)
+        {
+            if (entry.Value.IsPermanent)
+            {
+                XmlElement customVariableElement = ToElement(document, "Variable", entry.Value.Value);
+                customVariableElement.Attributes.Append(ToAttribute(document, "name", entry.Key));
+                customVariables.AppendChild(customVariableElement);
+            }
+        }
+
+        metadata.AppendChild(customVariables);
+
         parent.AppendChild(metadata);
 
         CreateSetting(document, parent, "Offset", run.Offset);


### PR DESCRIPTION
The `LiveSplit.Core` part of changes to add Custom Variables to LiveSplit.

I also have a branch lined up with changes to `LiveSplit.AutoSplittingRuntime` to allow autosplitters to set these Custom Variables: https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/16

Tasks:
- [x] Test parsing `.lss` runs with permanent custom variables created in LiveSplit One, and saving it without modifying with an autosplitter.
  - It's fine that the LSO tag `SpeedrunComVariables` was translated to the LS tag `Variables`.
  - The important thing is that the LSO tag `CustomVariables` was both parsed and saved correctly, staying as `CustomVariables`.
- [x] Test saving `.lss` runs with permanent custom variables modified by an autosplitter.
- [x] Test parsing those modified `.lss` runs back in LiveSplit.
- [x] Test parsing those modified `.lss` runs back in LiveSplit One.
  - It's fine that the LS tag `Variables` was translated to the LSO tag `SpeedrunComVariables`.
  - The important thing is LS `CustomVariables` to LSO `CustomVariables` went smoothly.