### PR TITLE
Revert to `IntPtr` and `UIntPtr`

### DIFF
--- a/lib/CustomFontDialog/CustomFontDialog/FontList.cs
+++ b/lib/CustomFontDialog/CustomFontDialog/FontList.cs
@@ -127,7 +127,7 @@ public partial class FontList : UserControl
     }
 
     [DllImport("user32.dll")]
-    private static extern nint SendMessage(nint hWnd, uint Msg, uint wParam, uint lParam);
+    private static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, uint wParam, uint lParam);
 
     /// <summary>
     ///

--- a/lib/WinForms Color Picker/WinFormsColor/ColorPickerDialog.cs
+++ b/lib/WinForms Color Picker/WinFormsColor/ColorPickerDialog.cs
@@ -659,19 +659,19 @@ public partial class ColorPickerDialog : Form
     }
 
     [DllImport("user32.dll")]
-    private static extern nint GetDC(nint hwnd);
+    private static extern IntPtr GetDC(IntPtr hwnd);
 
     [DllImport("user32.dll")]
-    private static extern int ReleaseDC(nint hwnd, nint hdc);
+    private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
 
     [DllImport("gdi32.dll")]
-    private static extern uint GetPixel(nint hdc, int nXPos, int nYPos);
+    private static extern uint GetPixel(IntPtr hdc, int nXPos, int nYPos);
 
     private Color GetPixelColor(int x, int y)
     {
-        nint hdc = GetDC(0);
+        IntPtr hdc = GetDC(IntPtr.Zero);
         uint pixel = GetPixel(hdc, x, y);
-        ReleaseDC(0, hdc);
+        ReleaseDC(IntPtr.Zero, hdc);
         var color = Color.FromArgb((int)(pixel & 0x000000FF),
                      (int)(pixel & 0x0000FF00) >> 8,
                      (int)(pixel & 0x00FF0000) >> 16);

--- a/lib/WinForms Color Picker/WinFormsColor/MouseHook.cs
+++ b/lib/WinForms Color Picker/WinFormsColor/MouseHook.cs
@@ -19,9 +19,9 @@ public static class MouseHook
     }
 
     private static readonly LowLevelMouseProc _proc = HookCallback;
-    private static nint _hookID = 0;
+    private static IntPtr _hookID = IntPtr.Zero;
 
-    private static nint SetHook(LowLevelMouseProc proc)
+    private static IntPtr SetHook(LowLevelMouseProc proc)
     {
         using var curProcess = Process.GetCurrentProcess();
         using ProcessModule curModule = curProcess.MainModule;
@@ -29,10 +29,10 @@ public static class MouseHook
           GetModuleHandle(curModule.ModuleName), 0);
     }
 
-    private delegate nint LowLevelMouseProc(int nCode, nint wParam, nint lParam);
+    private delegate IntPtr LowLevelMouseProc(int nCode, IntPtr wParam, IntPtr lParam);
 
-    private static nint HookCallback(
-      int nCode, nint wParam, nint lParam)
+    private static IntPtr HookCallback(
+      int nCode, IntPtr wParam, IntPtr lParam)
     {
         if (nCode >= 0 && MouseMessages.WM_LBUTTONUP == (MouseMessages)wParam)
         {
@@ -69,22 +69,22 @@ public static class MouseHook
         public uint mouseData;
         public uint flags;
         public uint time;
-        public nint dwExtraInfo;
+        public IntPtr dwExtraInfo;
     }
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern nint SetWindowsHookEx(int idHook,
-      LowLevelMouseProc lpfn, nint hMod, uint dwThreadId);
+    private static extern IntPtr SetWindowsHookEx(int idHook,
+      LowLevelMouseProc lpfn, IntPtr hMod, uint dwThreadId);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool UnhookWindowsHookEx(nint hhk);
+    private static extern bool UnhookWindowsHookEx(IntPtr hhk);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern nint CallNextHookEx(nint hhk, int nCode,
-      nint wParam, nint lParam);
+    private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode,
+      IntPtr wParam, IntPtr lParam);
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern nint GetModuleHandle(string lpModuleName);
+    private static extern IntPtr GetModuleHandle(string lpModuleName);
 
 }

--- a/src/LiveSplit.Core/ComponentUtil/DeepPointer.cs
+++ b/src/LiveSplit.Core/ComponentUtil/DeepPointer.cs
@@ -14,7 +14,7 @@ public class DeepPointer
 {
     public enum DerefType { Auto, Bit32, Bit64 }
 
-    private readonly nint _absoluteBase;
+    private readonly IntPtr _absoluteBase;
     private readonly bool _usingAbsoluteBase;
     private readonly DerefType _derefType;
 
@@ -22,10 +22,10 @@ public class DeepPointer
     private List<OffsetT> _offsets;
     private readonly string _module;
 
-    public DeepPointer(nint absoluteBase, params OffsetT[] offsets)
+    public DeepPointer(IntPtr absoluteBase, params OffsetT[] offsets)
         : this(absoluteBase, DerefType.Auto, offsets) { }
 
-    public DeepPointer(nint absoluteBase, DerefType derefType, params OffsetT[] offsets)
+    public DeepPointer(IntPtr absoluteBase, DerefType derefType, params OffsetT[] offsets)
     {
         _absoluteBase = absoluteBase;
         _usingAbsoluteBase = true;
@@ -65,7 +65,7 @@ public class DeepPointer
 
     public bool Deref<T>(Process process, out T value) where T : struct
     {
-        if (!DerefOffsets(process, out nint ptr)
+        if (!DerefOffsets(process, out IntPtr ptr)
             || !process.ReadValue(ptr, out value))
         {
             value = default;
@@ -87,7 +87,7 @@ public class DeepPointer
 
     public bool DerefBytes(Process process, int count, out byte[] value)
     {
-        if (!DerefOffsets(process, out nint ptr)
+        if (!DerefOffsets(process, out IntPtr ptr)
             || !process.ReadBytes(ptr, count, out value))
         {
             value = null;
@@ -142,7 +142,7 @@ public class DeepPointer
 
     public bool DerefString(Process process, ReadStringType type, StringBuilder sb)
     {
-        if (!DerefOffsets(process, out nint ptr)
+        if (!DerefOffsets(process, out IntPtr ptr)
             || !process.ReadString(ptr, type, sb))
         {
             return false;
@@ -151,7 +151,7 @@ public class DeepPointer
         return true;
     }
 
-    public bool DerefOffsets(Process process, out nint ptr)
+    public bool DerefOffsets(Process process, out IntPtr ptr)
     {
         bool is64Bit;
         if (_derefType == DerefType.Auto)
@@ -169,7 +169,7 @@ public class DeepPointer
                 .FirstOrDefault(m => m.ModuleName.ToLower() == _module);
             if (module == null)
             {
-                ptr = 0;
+                ptr = IntPtr.Zero;
                 return false;
             }
 
@@ -187,7 +187,7 @@ public class DeepPointer
         for (int i = 0; i < _offsets.Count - 1; i++)
         {
             if (!process.ReadPointer(ptr + _offsets[i], is64Bit, out ptr)
-                || ptr == 0)
+                || ptr == IntPtr.Zero)
             {
                 return false;
             }

--- a/src/LiveSplit.Core/ComponentUtil/MemoryWatcher.cs
+++ b/src/LiveSplit.Core/ComponentUtil/MemoryWatcher.cs
@@ -72,7 +72,7 @@ public abstract class MemoryWatcher
     protected bool InitialUpdate { get; set; }
     protected DateTime? LastUpdateTime { get; set; }
     protected DeepPointer DeepPtr { get; set; }
-    protected nint Address { get; set; }
+    protected IntPtr Address { get; set; }
 
     protected AddressType AddrType { get; }
     protected enum AddressType { DeepPointer, Absolute }
@@ -85,7 +85,7 @@ public abstract class MemoryWatcher
         FailAction = ReadFailAction.DontUpdate;
     }
 
-    protected MemoryWatcher(nint address)
+    protected MemoryWatcher(IntPtr address)
     {
         Address = address;
         AddrType = AddressType.Absolute;
@@ -148,14 +148,14 @@ public class StringWatcher : MemoryWatcher
     public StringWatcher(DeepPointer pointer, int numBytes)
         : this(pointer, ReadStringType.AutoDetect, numBytes) { }
 
-    public StringWatcher(nint address, ReadStringType type, int numBytes)
+    public StringWatcher(IntPtr address, ReadStringType type, int numBytes)
         : base(address)
     {
         _stringType = type;
         _numBytes = numBytes;
     }
 
-    public StringWatcher(nint address, int numBytes)
+    public StringWatcher(IntPtr address, int numBytes)
         : this(address, ReadStringType.AutoDetect, numBytes) { }
 
     public override bool Update(Process process)
@@ -241,7 +241,7 @@ public class MemoryWatcher<T> : MemoryWatcher where T : struct
 
     public MemoryWatcher(DeepPointer pointer)
         : base(pointer) { }
-    public MemoryWatcher(nint address)
+    public MemoryWatcher(IntPtr address)
         : base(address) { }
 
     public override bool Update(Process process)

--- a/src/LiveSplit.Core/ComponentUtil/SignatureScanner.cs
+++ b/src/LiveSplit.Core/ComponentUtil/SignatureScanner.cs
@@ -14,10 +14,10 @@ public class SignatureScanner
 {
     private byte[] _memory;
     private Process _process;
-    private nint _address;
+    private IntPtr _address;
     private int _size;
 
-    public nint Address
+    public IntPtr Address
     {
         get => _address;
         set
@@ -57,14 +57,14 @@ public class SignatureScanner
         }
     }
 
-    public SignatureScanner(Process proc, nint addr, int size)
+    public SignatureScanner(Process proc, IntPtr addr, int size)
     {
         if (proc == null)
         {
             throw new ArgumentNullException(nameof(proc));
         }
 
-        if (addr == 0)
+        if (addr == IntPtr.Zero)
         {
             throw new ArgumentException("addr cannot be 0.", nameof(addr));
         }
@@ -92,12 +92,12 @@ public class SignatureScanner
     }
 
     // backwards compat method signature
-    public nint Scan(SigScanTarget target)
+    public IntPtr Scan(SigScanTarget target)
     {
         return Scan(target, 1);
     }
 
-    public nint Scan(SigScanTarget target, int align)
+    public IntPtr Scan(SigScanTarget target, int align)
     {
         if ((long)_address % align != 0)
         {
@@ -107,17 +107,17 @@ public class SignatureScanner
         return ScanAll(target, align).FirstOrDefault();
     }
 
-    public IEnumerable<nint> ScanAll(SigScanTarget target, int align = 1)
+    public IEnumerable<IntPtr> ScanAll(SigScanTarget target, int align = 1)
     {
         if ((long)_address % align != 0)
         {
             throw new ArgumentOutOfRangeException(nameof(align), "start address must be aligned");
         }
 
-        return ScanInternal(target, align);
+        return ScaIntPtrernal(target, align);
     }
 
-    private IEnumerable<nint> ScanInternal(SigScanTarget target, int align)
+    private IEnumerable<IntPtr> ScaIntPtrernal(SigScanTarget target, int align)
     {
         if (_memory == null || _memory.Length != _size)
         {
@@ -136,7 +136,7 @@ public class SignatureScanner
             // have to implement IEnumerator manually because you can't yield in an unsafe block...
             foreach (int off in new ScanEnumerator(_memory, align, sig))
             {
-                nint ptr = _address + off + sig.Offset;
+                IntPtr ptr = _address + off + sig.Offset;
                 if (target.OnFound != null)
                 {
                     ptr = target.OnFound(_process, this, ptr);
@@ -283,7 +283,7 @@ public class SigScanTarget
         public int Offset;
     }
 
-    public delegate nint OnFoundCallback(Process proc, SignatureScanner scanner, nint ptr);
+    public delegate IntPtr OnFoundCallback(Process proc, SignatureScanner scanner, IntPtr ptr);
     public OnFoundCallback OnFound { get; set; }
 
     private readonly List<Signature> _sigs;

--- a/src/LiveSplit.Core/ComponentUtil/WinAPI.cs
+++ b/src/LiveSplit.Core/ComponentUtil/WinAPI.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-using SizeT = nuint;
+using SizeT = System.UIntPtr;
 
 namespace LiveSplit.ComponentUtil;
 public enum MemPageState : uint
@@ -38,8 +38,8 @@ public enum MemPageProtect : uint
 [StructLayout(LayoutKind.Sequential)]
 public struct MemoryBasicInformation // MEMORY_BASIC_INFORMATION
 {
-    public nint BaseAddress;
-    public nint AllocationBase;
+    public IntPtr BaseAddress;
+    public IntPtr AllocationBase;
     public MemPageProtect AllocationProtect;
     public SizeT RegionSize;
     public MemPageState State;
@@ -51,69 +51,69 @@ public static class WinAPI
 {
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool ReadProcessMemory(nint hProcess, nint lpBaseAddress, [Out] byte[] lpBuffer,
+    public static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, [Out] byte[] lpBuffer,
         SizeT nSize, out SizeT lpNumberOfBytesRead);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool WriteProcessMemory(nint hProcess, nint lpBaseAddress, byte[] lpBuffer,
+    public static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] lpBuffer,
         SizeT nSize, out SizeT lpNumberOfBytesWritten);
 
     [DllImport("psapi.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool EnumProcessModulesEx(nint hProcess, [Out] nint[] lphModule, uint cb,
+    public static extern bool EnumProcessModulesEx(IntPtr hProcess, [Out] IntPtr[] lphModule, uint cb,
         out uint lpcbNeeded, uint dwFilterFlag);
 
     [DllImport("psapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    public static extern uint GetModuleFileNameExW(nint hProcess, nint hModule, [Out] StringBuilder lpBaseName,
+    public static extern uint GetModuleFileNameExW(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName,
         uint nSize);
 
     [DllImport("psapi.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool GetModuleInformation(nint hProcess, nint hModule, [Out] out MODULEINFO lpmodinfo,
+    public static extern bool GetModuleInformation(IntPtr hProcess, IntPtr hModule, [Out] out MODULEINFO lpmodinfo,
         uint cb);
 
     [DllImport("psapi.dll", CharSet = CharSet.Unicode)]
-    public static extern uint GetModuleBaseNameW(nint hProcess, nint hModule, [Out] StringBuilder lpBaseName,
+    public static extern uint GetModuleBaseNameW(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName,
         uint nSize);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool IsWow64Process(nint hProcess,
+    public static extern bool IsWow64Process(IntPtr hProcess,
         [Out, MarshalAs(UnmanagedType.Bool)] out bool wow64Process);
 
     [DllImport("kernel32.dll", SetLastError = true)]
-    public static extern SizeT VirtualQueryEx(nint hProcess, nint lpAddress,
+    public static extern SizeT VirtualQueryEx(IntPtr hProcess, IntPtr lpAddress,
         [Out] out MemoryBasicInformation lpBuffer, SizeT dwLength);
 
     [DllImport("kernel32.dll", SetLastError = true)]
-    public static extern nint VirtualAllocEx(nint hProcess, nint lpAddress, SizeT dwSize, uint flAllocationType,
+    public static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress, SizeT dwSize, uint flAllocationType,
         MemPageProtect flProtect);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool VirtualFreeEx(nint hProcess, nint lpAddress, SizeT dwSize, uint dwFreeType);
+    public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress, SizeT dwSize, uint dwFreeType);
 
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool VirtualProtectEx(nint hProcess, nint lpAddress, SizeT dwSize,
+    public static extern bool VirtualProtectEx(IntPtr hProcess, IntPtr lpAddress, SizeT dwSize,
         MemPageProtect flNewProtect, [Out] out MemPageProtect lpflOldProtect);
 
     [DllImport("ntdll.dll", SetLastError = true)]
-    public static extern nint NtSuspendProcess(nint hProcess);
+    public static extern IntPtr NtSuspendProcess(IntPtr hProcess);
 
     [DllImport("ntdll.dll", SetLastError = true)]
-    public static extern nint NtResumeProcess(nint hProcess);
+    public static extern IntPtr NtResumeProcess(IntPtr hProcess);
 
     [DllImport("kernel32.dll", SetLastError = true)]
-    public static extern nint CreateRemoteThread(nint hProcess, nint lpThreadAttributes, SizeT dwStackSize,
-        nint lpStartAddress, nint lpParameter, uint dwCreationFlags, out nint lpThreadId);
+    public static extern IntPtr CreateRemoteThread(IntPtr hProcess, IntPtr lpThreadAttributes, SizeT dwStackSize,
+        IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, out IntPtr lpThreadId);
 
     [StructLayout(LayoutKind.Sequential)]
     public struct MODULEINFO
     {
-        public nint lpBaseOfDll;
+        public IntPtr lpBaseOfDll;
         public uint SizeOfImage;
-        public nint EntryPoint;
+        public IntPtr EntryPoint;
     }
 }

--- a/src/LiveSplit.Core/LiveSplitCoreFactory.cs
+++ b/src/LiveSplit.Core/LiveSplitCoreFactory.cs
@@ -34,7 +34,7 @@ public class LiveSplitCoreFactory
     {
         string path;
 
-        if (Unsafe.SizeOf<nint>() == 4)
+        if (Unsafe.SizeOf<IntPtr>() == 4)
         {
             path = "x86\\livesplit_core.dll";
         }

--- a/src/LiveSplit.Core/Model/Input/HotkeyHook.cs
+++ b/src/LiveSplit.Core/Model/Input/HotkeyHook.cs
@@ -62,10 +62,10 @@ public sealed class HotkeyHook : IDisposable
     public event EventHandler<KeyPressedEventArgs> KeyPressed;
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool RegisterHotKey(nint hWnd, int id, uint fsModifiers, uint vk);
+    private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool UnregisterHotKey(nint hWnd, int id);
+    private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
     public void RegisterHotKey(ModifierKeys modifier, Keys key)
     {
         _currentId++;

--- a/src/LiveSplit.Core/Model/Input/LowLevelKeyboardHook.cs
+++ b/src/LiveSplit.Core/Model/Input/LowLevelKeyboardHook.cs
@@ -109,7 +109,7 @@ public class KeyboardInput : IDisposable
         public uint scanCode;
         public KBDLLHOOKSTRUCTFlags flags;
         public uint time;
-        public nuint dwExtraInfo;
+        public UIntPtr dwExtraInfo;
     }
 
     [Flags]
@@ -124,14 +124,14 @@ public class KeyboardInput : IDisposable
     public event KeyEventHandler KeyBoardKeyPressed;
 
     private readonly WindowsHookHelper.HookDelegate keyBoardDelegate;
-    private nint keyBoardHandle;
+    private IntPtr keyBoardHandle;
     private const int WH_KEYBOARD_LL = 13;
     private bool disposed;
 
     [DllImport("kernel32.dll")]
     private static extern uint GetLastError();
     [DllImport("kernel32.dll")]
-    private static extern nint GetModuleHandle(string module);
+    private static extern IntPtr GetModuleHandle(string module);
 
     private Keys modifiers;
     private Control messageLoopControl;
@@ -164,12 +164,12 @@ public class KeyboardInput : IDisposable
     {
         using var process = Process.GetCurrentProcess();
         using ProcessModule module = process.MainModule;
-        nint hModule = GetModuleHandle(module.ModuleName);
+        IntPtr hModule = GetModuleHandle(module.ModuleName);
         messageLoopControl.BeginInvoke(new Action(() =>
         {
             try
             {
-                if (keyBoardHandle != 0)
+                if (keyBoardHandle != IntPtr.Zero)
                 {
                     WindowsHookHelper.UnhookWindowsHookEx(keyBoardHandle);
                 }
@@ -181,8 +181,8 @@ public class KeyboardInput : IDisposable
         }));
     }
 
-    private nint KeyboardHookDelegate(
-        int Code, nint wParam, nint lParam)
+    private IntPtr KeyboardHookDelegate(
+        int Code, IntPtr wParam, IntPtr lParam)
     {
         if (Code < 0)
         {
@@ -192,7 +192,7 @@ public class KeyboardInput : IDisposable
 
         var hookStruct = (KBDLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(KBDLLHOOKSTRUCT));
 
-        if (wParam is 0x0100 or 0x0104) //KeyDown
+        if (wParam == (IntPtr)0x0100 || wParam == (IntPtr)0x0104) //KeyDown
         {
             var key = (Keys)hookStruct.vkCode;
 
@@ -244,7 +244,7 @@ public class KeyboardInput : IDisposable
                 modifiers &= ~Keys.Alt;
             }
         }
-        else if (wParam is 0x0101 or 0x0105) //KeyUp
+        else if (wParam == (IntPtr)0x0101 || wParam == (IntPtr)0x0105) //KeyUp
         {
             var key = (Keys)hookStruct.vkCode;
 
@@ -276,7 +276,7 @@ public class KeyboardInput : IDisposable
     {
         if (!disposed)
         {
-            if (keyBoardHandle != 0)
+            if (keyBoardHandle != IntPtr.Zero)
             {
                 WindowsHookHelper.UnhookWindowsHookEx(
                     keyBoardHandle);
@@ -294,18 +294,18 @@ public class KeyboardInput : IDisposable
 
 public class WindowsHookHelper
 {
-    public delegate nint HookDelegate(
-        int Code, nint wParam, nint lParam);
+    public delegate IntPtr HookDelegate(
+        int Code, IntPtr wParam, IntPtr lParam);
 
     [DllImport("User32.dll")]
-    public static extern nint CallNextHookEx(
-        nint hHook, int nCode, nint wParam, nint lParam);
+    public static extern IntPtr CallNextHookEx(
+        IntPtr hHook, int nCode, IntPtr wParam, IntPtr lParam);
 
     [DllImport("User32.dll")]
-    public static extern nint UnhookWindowsHookEx(nint hHook);
+    public static extern IntPtr UnhookWindowsHookEx(IntPtr hHook);
 
     [DllImport("User32.dll")]
-    public static extern nint SetWindowsHookEx(
-        int idHook, HookDelegate lpfn, nint hmod,
+    public static extern IntPtr SetWindowsHookEx(
+        int idHook, HookDelegate lpfn, IntPtr hmod,
         int dwThreadId);
 }

--- a/src/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
+++ b/src/LiveSplit.Core/Model/RunFactories/StandardFormatsRunFactory.cs
@@ -64,7 +64,7 @@ public class StandardFormatsRunFactory : IRunFactory
         };
     }
 
-    private static Image ParseImage(nint imagePtr, ulong length)
+    private static Image ParseImage(IntPtr imagePtr, ulong length)
     {
         if (length == 0)
         {

--- a/src/LiveSplit.Core/Options/FiletypeRegistryHelper.cs
+++ b/src/LiveSplit.Core/Options/FiletypeRegistryHelper.cs
@@ -269,8 +269,8 @@ public static class FiletypeRegistryHelper
     [DllImport("shell32.dll")]
     private static extern void SHChangeNotify(HChangeNotifyEventID wEventId,
                                        HChangeNotifyFlags uFlags,
-                                       nint dwItem1,
-                                       nint dwItem2);
+                                       IntPtr dwItem1,
+                                       IntPtr dwItem2);
 
     public static void RegisterFileFormats()
     {
@@ -367,7 +367,7 @@ public static class FiletypeRegistryHelper
         command.SetValue("", $"\"{Application.ExecutablePath.Replace("LiveSplit.Register.exe", "LiveSplit.exe")}\" -s \"{"%1"}\"");
         RegistryKey iconKey = lssApplicationKey.CreateSubKey("DefaultIcon");
         iconKey.SetValue("", $"{Path.GetDirectoryName(Application.ExecutablePath)}\\Resources\\{"SplitsFile.ico"}");
-        SHChangeNotify(HChangeNotifyEventID.SHCNE_ASSOCCHANGED, HChangeNotifyFlags.SHCNF_IDLIST, 0, 0);
+        SHChangeNotify(HChangeNotifyEventID.SHCNE_ASSOCCHANGED, HChangeNotifyFlags.SHCNF_IDLIST, IntPtr.Zero, IntPtr.Zero);
 
     }
 
@@ -416,7 +416,7 @@ public static class FiletypeRegistryHelper
         command.SetValue("", $"\"{Application.ExecutablePath.Replace("LiveSplit.Register.exe", "LiveSplit.exe")}\" -l \"{"%1"}\"");
         RegistryKey iconKey = lslApplicationKey.CreateSubKey("DefaultIcon");
         iconKey.SetValue("", $"{Path.GetDirectoryName(Application.ExecutablePath)}\\Resources\\{"LayoutFile.ico"}");
-        SHChangeNotify(HChangeNotifyEventID.SHCNE_ASSOCCHANGED, HChangeNotifyFlags.SHCNF_IDLIST, 0, 0);
+        SHChangeNotify(HChangeNotifyEventID.SHCNE_ASSOCCHANGED, HChangeNotifyFlags.SHCNF_IDLIST, IntPtr.Zero, IntPtr.Zero);
     }
 
     private static bool CheckLSLApplicationKey()

--- a/src/LiveSplit.Core/Web/CredentialManager.cs
+++ b/src/LiveSplit.Core/Web/CredentialManager.cs
@@ -37,7 +37,7 @@ public static class CredentialManager
 {
     public static Credential ReadCredential(string applicationName)
     {
-        bool read = CredRead(applicationName, CredentialType.Generic, 0, out nint nCredPtr);
+        bool read = CredRead(applicationName, CredentialType.Generic, 0, out IntPtr nCredPtr);
         if (read)
         {
             using var critCred = new CriticalCredentialHandle(nCredPtr);
@@ -53,7 +53,7 @@ public static class CredentialManager
         string applicationName = Marshal.PtrToStringUni(credential.TargetName);
         string userName = Marshal.PtrToStringUni(credential.UserName);
         string secret = null;
-        if (credential.CredentialBlob != 0)
+        if (credential.CredentialBlob != IntPtr.Zero)
         {
             secret = Marshal.PtrToStringUni(credential.CredentialBlob, (int)credential.CredentialBlobSize / 2);
         }
@@ -84,9 +84,9 @@ public static class CredentialManager
         var credential = new CREDENTIAL
         {
             AttributeCount = 0,
-            Attributes = 0,
-            Comment = 0,
-            TargetAlias = 0,
+            Attributes = IntPtr.Zero,
+            Comment = IntPtr.Zero,
+            TargetAlias = IntPtr.Zero,
             Type = CredentialType.Generic,
             Persist = (uint)CredentialPersistence.LocalMachine,
             CredentialBlobSize = (uint)(byteArray == null ? 0 : byteArray.Length),
@@ -133,7 +133,7 @@ public static class CredentialManager
     }
 
     [DllImport("Advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern bool CredRead(string target, CredentialType type, int reservedFlag, out nint credentialPtr);
+    private static extern bool CredRead(string target, CredentialType type, int reservedFlag, out IntPtr credentialPtr);
 
     [DllImport("Advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern bool CredDelete(string target, CredentialType type, int reservedFlag);
@@ -142,7 +142,7 @@ public static class CredentialManager
     private static extern bool CredWrite([In] ref CREDENTIAL userCredential, [In] uint flags);
 
     [DllImport("Advapi32.dll", EntryPoint = "CredFree", SetLastError = true)]
-    private static extern bool CredFree([In] nint cred);
+    private static extern bool CredFree([In] IntPtr cred);
 
     private enum CredentialPersistence : uint
     {
@@ -156,21 +156,21 @@ public static class CredentialManager
     {
         public uint Flags;
         public CredentialType Type;
-        public nint TargetName;
-        public nint Comment;
+        public IntPtr TargetName;
+        public IntPtr Comment;
         public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
         public uint CredentialBlobSize;
-        public nint CredentialBlob;
+        public IntPtr CredentialBlob;
         public uint Persist;
         public uint AttributeCount;
-        public nint Attributes;
-        public nint TargetAlias;
-        public nint UserName;
+        public IntPtr Attributes;
+        public IntPtr TargetAlias;
+        public IntPtr UserName;
     }
 
     private sealed class CriticalCredentialHandle : CriticalHandleZeroOrMinusOneIsInvalid
     {
-        public CriticalCredentialHandle(nint preexistingHandle)
+        public CriticalCredentialHandle(IntPtr preexistingHandle)
         {
             SetHandle(preexistingHandle);
         }

--- a/src/LiveSplit.View/Model/Win32.cs
+++ b/src/LiveSplit.View/Model/Win32.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace LiveSplit.Model;
 
@@ -69,27 +70,27 @@ internal class Win32
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool UpdateLayeredWindow(nint hwnd, nint hdcDst,
-        ref Point pptDst, ref Size psize, nint hdcSrc, ref Point pprSrc,
+    public static extern bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst,
+        ref Point pptDst, ref Size psize, IntPtr hdcSrc, ref Point pprSrc,
         int crKey, ref BLENDFUNCTION pblend, int dwFlags);
 
     [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    public static extern nint CreateCompatibleDC(nint hDC);
+    public static extern IntPtr CreateCompatibleDC(IntPtr hDC);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    public static extern nint GetDC(nint hWnd);
+    public static extern IntPtr GetDC(IntPtr hWnd);
 
     [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    public static extern int ReleaseDC(nint hWnd, nint hDC);
+    public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
     [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool DeleteDC(nint hdc);
+    public static extern bool DeleteDC(IntPtr hdc);
 
     [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    public static extern nint SelectObject(nint hDC, nint hObject);
+    public static extern IntPtr SelectObject(IntPtr hDC, IntPtr hObject);
 
     [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool DeleteObject(nint hObject);
+    public static extern bool DeleteObject(IntPtr hObject);
 }

--- a/src/LiveSplit.View/View/TimerForm.cs
+++ b/src/LiveSplit.View/View/TimerForm.cs
@@ -157,19 +157,19 @@ public partial class TimerForm : Form
     private float? ResizingInitialAspectRatio { get; set; } = null;
 
     [DllImport("user32.dll")]
-    private static extern int GetUpdateRgn(nint hWnd, nint hRgn, [MarshalAs(UnmanagedType.Bool)] bool bErase);
+    private static extern int GetUpdateRgn(IntPtr hWnd, IntPtr hRgn, [MarshalAs(UnmanagedType.Bool)] bool bErase);
 
     [DllImport("gdi32.dll")]
-    private static extern nint CreateRectRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
+    private static extern IntPtr CreateRectRgn(int nLeftRect, int nTopRect, int nRightRect, int nBottomRect);
 
     [DllImport("user32")]
-    private static extern uint SetWindowLong(nint hwnd, int nIndex, uint dwNewLong);
+    private static extern uint SetWindowLong(IntPtr hwnd, int nIndex, uint dwNewLong);
 
     [DllImport("user32")]
-    private static extern uint GetWindowLong(nint hwnd, int nIndex);
+    private static extern uint GetWindowLong(IntPtr hwnd, int nIndex);
 
     [DllImport("user32.dll")]
-    private static extern nint GetForegroundWindow();
+    private static extern IntPtr GetForegroundWindow();
 
     public TimerForm(string splitsPath = null, string layoutPath = null, string basePath = "")
     {
@@ -1691,7 +1691,7 @@ public partial class TimerForm : Form
             {
                 if (hitBox.Value.Contains(clientPoint))
                 {
-                    m.Result = (nint)hitBox.Key;
+                    m.Result = (IntPtr)hitBox.Key;
                     handled = true;
                     break;
                 }
@@ -1705,7 +1705,7 @@ public partial class TimerForm : Form
 
         if (m.Msg == WM_PAINT)
         {
-            if (hRgn != 0)
+            if (hRgn != IntPtr.Zero)
             {
                 DeleteObject(hRgn);
             }
@@ -1811,10 +1811,10 @@ public partial class TimerForm : Form
         return true;
     }
 
-    private nint hRgn = 0;
+    private IntPtr hRgn = IntPtr.Zero;
     [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool DeleteObject([In] nint hObject);
+    private static extern bool DeleteObject([In] IntPtr hObject);
 
     private void exitToolStripMenuItem_Click(object sender, EventArgs e)
     {

--- a/test/LiveSplit.Tests/ComponentUtil/DeepPointerTests.cs
+++ b/test/LiveSplit.Tests/ComponentUtil/DeepPointerTests.cs
@@ -48,12 +48,12 @@ public class DeepPointerTests
     [Fact]
     public void ThrowException_WhenInitializedWithValidPointerAndNullOffsets()
     {
-        Assert.Throws<NullReferenceException>(() => new DeepPointer((nint)0, null));
+        Assert.Throws<NullReferenceException>(() => new DeepPointer((IntPtr)0, null));
     }
 
     [Fact]
     public void ThrowException_WhenInitializedWithValidPointerDerefTypeButNullOffset()
     {
-        Assert.Throws<NullReferenceException>(() => new DeepPointer((nint)0, DerefType.Auto, null));
+        Assert.Throws<NullReferenceException>(() => new DeepPointer((IntPtr)0, DerefType.Auto, null));
     }
 }


### PR DESCRIPTION
Closes #2536.
Reverts https://github.com/LiveSplit/LiveSplit/pull/2533/commits/e2413da6b2bc69f7a9cfb4125b0f6a3915d601c0.

### Description

ASL has an issue with finding method signatures using the new `nint` and `nuint` types, due to its outdated compiler. This PR reverts that change and should allow ASL scripts to function once more.
