### PR TITLE
Changes to enable subclassing PercentileComparisonGenerator

### DIFF
--- a/src/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
+++ b/src/LiveSplit.Core/Model/Comparisons/PercentileComparisonGenerator.cs
@@ -13,7 +13,7 @@ public class PercentileComparisonGenerator : IComparisonGenerator
     public IRun Run { get; set; }
     public const string ComparisonName = "Balanced PB";
     public const string ShortComparisonName = "Balanced";
-    public string Name => ComparisonName;
+    public virtual string Name => ComparisonName;
     public const double Weight = 0.9375;
 
     public PercentileComparisonGenerator(IRun run)
@@ -36,6 +36,15 @@ public class PercentileComparisonGenerator : IComparisonGenerator
         double percDn = (Key1 - perc) * Value2.Ticks / (Key1 - Key2);
         double percUp = (perc - Key2) * Value1.Ticks / (Key1 - Key2);
         return TimeSpan.FromTicks(Convert.ToInt64(percUp + percDn));
+    }
+
+    protected virtual TimeSpan? GetGoalTime(TimingMethod method) {
+        TimeSpan? goalTime = null;
+        if (Run[Run.Count - 1].PersonalBestSplitTime[method].HasValue)
+        {
+            goalTime = Run[Run.Count - 1].PersonalBestSplitTime[method].Value;
+        }
+        return goalTime;
     }
 
     public void Generate(TimingMethod method)
@@ -127,12 +136,7 @@ public class PercentileComparisonGenerator : IComparisonGenerator
             }
         }
 
-        TimeSpan? goalTime = null;
-        if (Run[Run.Count - 1].PersonalBestSplitTime[method].HasValue)
-        {
-            goalTime = Run[Run.Count - 1].PersonalBestSplitTime[method].Value;
-        }
-
+        TimeSpan? goalTime = GetGoalTime(method);
         TimeSpan runSum = TimeSpan.Zero;
         var outputSplits = new List<TimeSpan>();
         double percentile = 0.5;


### PR DESCRIPTION
Pulls goal time retrieval out into a method, and allows goal time and comparison name to be overridden. This allows extensions to create balanced comparisons with a goal time other than PB.

### Some background

[LiveSplit.TheoryComparisonGenerator](https://github.com/fmichea/LiveSplit.TheoryComparisonGenerator) allows you to create comparisons with arbitrary goal times and distributes timesave evenly across your splits. I like this, but I want a more balanced distribution of the timesave akin to the built-in Balanced PB comparison.

Previously, I crudely copy-pasted PercentileComparisonGenerator into a fork of their repo and made some alterations to fit it into their framework. This works for me, but I don't want to merge it back into the main repo in that state. Opening up a couple methods on PercentileComparisonGenerator for overrides allows me to do this more cleanly and hopefully obsolete the fork.