### PR TITLE
CommandServer: add getcustomvariablevalue

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Commands that return a string:
 - getcurrentsplitname  
 - getprevioussplitname
 - getcurrenttimerphase
+- getcustomvariablevalue NAME
 - ping  
 (always returns `pong`)
 

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -5,6 +5,7 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 using LiveSplit.Model;
@@ -491,6 +492,13 @@ public class CommandServer
                     Log.Warning($"[Sever] Split index {index} out of bounds for command {command}");
                 }
 
+                break;
+            }
+            case "getcustomvariablevalue":
+            {
+                string value = State.Run.Metadata.CustomVariableValue(args[1]);
+                // make sure response isn't null or empty, and doesn't contain line endings
+                response = string.IsNullOrEmpty(value) ? "-" : Regex.Replace(value, @"\r\n?|\n", " ");
                 break;
             }
             case "ping":


### PR DESCRIPTION
Resolves #2564 by adding `getcustomvariablevalue` to let a client retrieve a custom variable value.

I have not tested this yet, as I don't have a client to test it with. @Luukie13, do you have such a client?