### PR TITLE
Always track gametime - remove GT if needed on reset

### DIFF
--- a/src/LiveSplit.Core/Model/LiveSplitState.cs
+++ b/src/LiveSplit.Core/Model/LiveSplitState.cs
@@ -123,8 +123,7 @@ public class LiveSplitState : ICloneable
             else
             {
                 curTime.GameTime = IsGameTimePaused
-                    ? GameTimePauseTime
-                    : curTime.RealTime - (IsGameTimeInitialized ? LoadingTimes : null);
+                    ? GameTimePauseTime : curTime.RealTime - LoadingTimes;
             }
 
             return curTime;

--- a/src/LiveSplit.Core/Model/TimerModel.cs
+++ b/src/LiveSplit.Core/Model/TimerModel.cs
@@ -121,6 +121,17 @@ public class TimerModel : ITimerModel
 
     private void ResetState(bool updateTimes)
     {
+        if (!CurrentState.IsGameTimeInitialized)
+        {
+            // Remove Game Times because they haven't been used
+            foreach (Segment split in CurrentState.Run)
+            {
+                Time time = split.SplitTime;
+                time.GameTime = null;
+                split.SplitTime = time;
+            }
+        }
+
         if (CurrentState.CurrentPhase != TimerPhase.Ended)
         {
             CurrentState.AttemptEnded = TimeStamp.CurrentDateTime;


### PR DESCRIPTION
When the loading time edges are given via Named Pipe, TCP or Websocket server (via "pausegametime" and "unpausegametime"), GameTime would show "-" for any splits that don't have loads yet.

The gametime in these splits are `null`, so they cannot be used as expected for comparison.

This PR always saves the current GT, even if the loads are not initialized. If they are still not initialized when resetting, the GTs are removed, so the behavior for RT runs doesn't change, the GT tab will remain empty in the splits editor.

Behavior tested via Websocket pause and unpause