### PR TITLE
Adding games to Splits Editor combobox: Make task incremental and cancelable

### DIFF
--- a/src/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/src/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -717,6 +717,7 @@
             this.MinimumSize = new System.Drawing.Size(700, 510);
             this.Name = "RunEditorDialog";
             this.Text = "Splits Editor";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.RunEditorDialog_FormClosing);
             this.Load += new System.EventHandler(this.RunEditorDialog_Load);
             ((System.ComponentModel.ISupportInitialize)(this.runGrid)).EndInit();
             this.tableLayoutPanel1.ResumeLayout(false);


### PR DESCRIPTION
Adding all games at once seems to block the Split Editor Form, so it is unusable for around 5 seconds while the ~44k games are added to the combobox.

To fix the inability to edit the splits immediately after loading, the `AddRange` calls are split into segments of 1000 elements each. I didn't run a optimization on that value, but setting 10000 still visibly lags the Split Editor.

While this makes the splits editable directly after the Form opens, on pressing `Ok` we would still need to wait until all games have been added. Therefore the task is made cancelable and it is getting cancelled when the Form is getting closed.

Fixes #2580 