### PR TITLE
Adds HCPComparisonGenerator

### DIFF
--- a/src/LiveSplit.Core/Model/Comparisons/HCPComparisonGenerator.cs
+++ b/src/LiveSplit.Core/Model/Comparisons/HCPComparisonGenerator.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using LiveSplit.Options;
+
+using static System.Math;
+
+namespace LiveSplit.Model.Comparisons;
+
+public class HCPComparisonGenerator : IComparisonGenerator
+{
+    public IRun Run { get; set; }
+    public const string ComparisonName = "Golf HCP";
+    public const string ShortComparisonName = "HCP";
+    public string Name => ComparisonName;
+    private const int NumRuns = 8;
+    private const int AverageSamplesCount = 20;
+
+    public HCPComparisonGenerator(IRun run)
+    {
+        Run = run;
+    }
+
+    protected TimeSpan CalculateAverage(IEnumerable<TimeSpan> curList)
+    {
+        double averageTime = curList.OrderBy(x => x.TotalSeconds).Take(AverageSamplesCount).ToList().Aggregate(0.0, (s, x) => s + x.TotalSeconds) / Min(AverageSamplesCount, curList.Count());
+        return TimeSpan.FromTicks((long)(averageTime * TimeSpan.TicksPerSecond));
+    }
+
+    public void Generate(TimingMethod method)
+    {
+        var allHistory = new List<List<TimeSpan>>();
+        foreach (ISegment segment in Run)
+        {
+            allHistory.Add([]);
+        }
+
+        // Get the last 20 complete runs 
+        var recentRuns = Run.AttemptHistory
+            .Where(attempt => Run.Last().SegmentHistory.TryGetValue(attempt.Index, out Time lastSegmentTime) && lastSegmentTime[method] != null)
+            .OrderByDescending(attempt => attempt.Index)
+            .Take(NumRuns);
+
+        foreach (Attempt attempt in recentRuns)
+        {
+            int ind = attempt.Index;
+            bool ignoreNextHistory = false;
+            foreach (ISegment segment in Run)
+            {
+                if (segment.SegmentHistory.TryGetValue(ind, out Time history))
+                {
+                    if (history[method] == null)
+                    {
+                        ignoreNextHistory = true;
+                    }
+                    else if (!ignoreNextHistory)
+                    {
+                        allHistory[Run.IndexOf(segment)].Add(history[method].Value);
+                    }
+                    else
+                    {
+                        ignoreNextHistory = false;
+                    }
+                }
+                else
+                {
+                    ignoreNextHistory = false;
+                }
+            }
+        }
+
+        TimeSpan? totalTime = TimeSpan.Zero;
+        for (int ind = 0; ind < Run.Count; ind++)
+        {
+            List<TimeSpan> curList = allHistory[ind];
+            if (curList.Count == 0)
+            {
+                totalTime = null;
+            }
+
+            if (totalTime != null)
+            {
+                totalTime += CalculateAverage(curList);
+            }
+
+            var time = new Time(Run[ind].Comparisons[Name]);
+            time[method] = totalTime;
+            Run[ind].Comparisons[Name] = time;
+        }
+    }
+
+    public void Generate(ISettings settings)
+    {
+        Generate(TimingMethod.RealTime);
+        Generate(TimingMethod.GameTime);
+    }
+}

--- a/src/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
+++ b/src/LiveSplit.Core/Model/Comparisons/StandardComparisonGeneratorsFactory.cs
@@ -15,6 +15,7 @@ public class StandardComparisonGeneratorsFactory : IComparisonGeneratorsFactory
         AddShortComparisonName(WorstSegmentsComparisonGenerator.ComparisonName, WorstSegmentsComparisonGenerator.ShortComparisonName);
         AddShortComparisonName(PercentileComparisonGenerator.ComparisonName, PercentileComparisonGenerator.ShortComparisonName);
         AddShortComparisonName(LatestRunComparisonGenerator.ComparisonName, LatestRunComparisonGenerator.ShortComparisonName);
+        AddShortComparisonName(HCPComparisonGenerator.ComparisonName, HCPComparisonGenerator.ShortComparisonName);
     }
     public IEnumerable<IComparisonGenerator> Create(IRun run)
     {
@@ -31,6 +32,7 @@ public class StandardComparisonGeneratorsFactory : IComparisonGeneratorsFactory
         yield return new WorstSegmentsComparisonGenerator(run);
         yield return new PercentileComparisonGenerator(run);
         yield return new LatestRunComparisonGenerator(run);
+        yield return new HCPComparisonGenerator(run);
         yield return new NoneComparisonGenerator(run);
     }
 }

--- a/src/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
+++ b/src/LiveSplit.Core/Options/SettingsFactories/StandardSettingsFactory.cs
@@ -54,6 +54,7 @@ public class StandardSettingsFactory : ISettingsFactory
                 { WorstSegmentsComparisonGenerator.ComparisonName, false},
                 { PercentileComparisonGenerator.ComparisonName, false },
                 { LatestRunComparisonGenerator.ComparisonName, false },
+                { HCPComparisonGenerator.ComparisonName, false },
                 { NoneComparisonGenerator.ComparisonName, false }
             }
         };

--- a/src/LiveSplit.View/View/ChooseComparisonsDialog.cs
+++ b/src/LiveSplit.View/View/ChooseComparisonsDialog.cs
@@ -24,6 +24,7 @@ public partial class ChooseComparisonsDialog : Form
             WorstSegmentsComparisonGenerator.ComparisonName,
             PercentileComparisonGenerator.ComparisonName,
             LatestRunComparisonGenerator.ComparisonName,
+            HCPComparisonGenerator.ComparisonName,
             NoneComparisonGenerator.ComparisonName
         });
     }


### PR DESCRIPTION
HCP is a way of calculating results in Golf. It's based of the last 20 rounds played and averaging the top 8 results in that set.

This is an application of this method to give runners a goal different from beating their PBs, which tends to be the case for a lot of runners. This new HCP goal aims for the runner to be able to improve their overall timings, or handicap as it's commonly referred to, without the common mental pressure of beating their best time ever, which can demotivate a lot of folks when they don't see their skills evolving.