### PR TITLE
Add Completed and Attempted Run Count information to LiveSplit Server command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Commands that return an int:
 
 - getsplitindex  
 (returns -1 if the timer is not running)
+- getattemptcount
+- getcompletedcount
 
 Commands that return a string:
 

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -506,6 +506,11 @@ public class CommandServer
                 response = "pong";
                 break;
             }
+            case "getattemptcount":
+            {
+                response = Model.CurrentState.Run.AttemptCount.ToString();
+                break;
+            }
             default:
             {
                 Log.Error($"[Server] Invalid command: {message}");

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -544,7 +544,7 @@ public class CommandServer
 
                 else
                 {
-                    response = Math.Round(State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount, 3).ToString();
+                    response = Math.Round(State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount, 3).ToString().TrimStart('0');
                 }
                 break;
             }

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -523,12 +523,29 @@ public class CommandServer
             }
             case "getwinratepct":
             {
-                response = Math.Round((State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount) * 100, 1).ToString();
+                if (Model.CurrentState.Run.AttemptCount == 0)
+                {
+                    response = "0.0";
+                }
+
+                else
+                {
+                    response = Math.Round((State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount) * 100, 1).ToString();
+                }
+                
                 break;
             }
             case "getwinratedec":
             {
-                response = Math.Round(State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount, 3).ToString();
+                if (Model.CurrentState.Run.AttemptCount == 0)
+                {
+                    response = ".000";
+                }
+
+                else
+                {
+                    response = Math.Round(State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount, 3).ToString();
+                }
                 break;
             }
             default:

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -537,7 +537,7 @@ public class CommandServer
             }
             case "getwinratedec":
             {
-                if (Model.CurrentState.Run.AttemptCount == 0)
+                if (Model.CurrentState.Run.AttemptCount == 0 || State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) == 0 )
                 {
                     response = ".000";
                 }

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -511,6 +511,26 @@ public class CommandServer
                 response = Model.CurrentState.Run.AttemptCount.ToString();
                 break;
             }
+			case "getcompletedcount":
+            {
+                response = State.Run.AttemptHistory.Count(x => x.Time.RealTime != null).ToString();
+                break;
+            }
+            case "getcompletionsoverattempts":
+            {
+                response = State.Run.AttemptHistory.Count(x => x.Time.RealTime != null).ToString() + "/" + Model.CurrentState.Run.AttemptCount.ToString();
+                break;
+            }
+            case "getwinratepct":
+            {
+                response = Math.Round((State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount) * 100, 1).ToString();
+                break;
+            }
+            case "getwinratedec":
+            {
+                response = Math.Round(State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount, 3).ToString();
+                break;
+            }
             default:
             {
                 Log.Error($"[Server] Invalid command: {message}");

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -516,38 +516,6 @@ public class CommandServer
                 response = State.Run.AttemptHistory.Count(x => x.Time.RealTime != null).ToString();
                 break;
             }
-            case "getcompletionsoverattempts":
-            {
-                response = State.Run.AttemptHistory.Count(x => x.Time.RealTime != null).ToString() + "/" + Model.CurrentState.Run.AttemptCount.ToString();
-                break;
-            }
-            case "getwinratepct":
-            {
-                if (Model.CurrentState.Run.AttemptCount == 0)
-                {
-                    response = "0.0";
-                }
-
-                else
-                {
-                    response = Math.Round((State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount) * 100, 1).ToString();
-                }
-                
-                break;
-            }
-            case "getwinratedec":
-            {
-                if (Model.CurrentState.Run.AttemptCount == 0 || State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) == 0 )
-                {
-                    response = ".000";
-                }
-
-                else
-                {
-                    response = Math.Round(State.Run.AttemptHistory.Count(x => x.Time.RealTime != null) / (double)Model.CurrentState.Run.AttemptCount, 3).ToString().TrimStart('0');
-                }
-                break;
-            }
             default:
             {
                 Log.Error($"[Server] Invalid command: {message}");


### PR DESCRIPTION
For Issue #2588.

Adds the following commands available for the Server component:

- getattemptcount
    -  Gets the total number of attempted runs, including the current run (as it is updated at start)
- getcompletedcount
    -  Gets the total number of COMPLETED runs, using the same method that the "Title" layout component does (`State.Run.AttemptHistory.Count(x => x.Time.RealTime != null)`)

I've been able to test this using PHP to access the TCP server. But I'm not smart enough to program something to access -anything- in the LiveSplit server via sockets or pipes, so I'd appreciate some help in making sure it works as intended that way, as well.


The following was removed from the pull request as originally submitted:
- A command to output `{CompletedRuns}/{AttemtpedRuns}`
- Commands to output the winrate (e.g. 3 completed runs, 4 attempted runs, output either `75.0` or `.750`