### PR TITLE
CommandServer: add setcustomvariable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Commands that generate no response:
 - switchto gametime
 - setsplitname INDEX NAME
 - setcurrentsplitname NAME
+- setcustomvariable NAME VALUE
 
 Commands that return a time:
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Commands that generate no response:
 - switchto gametime
 - setsplitname INDEX NAME
 - setcurrentsplitname NAME
-- setcustomvariable NAME VALUE
+- setcustomvariable JSON([NAME, VALUE])
 
 Commands that return a time:
 

--- a/src/LiveSplit.Core/LiveSplit.Core.csproj
+++ b/src/LiveSplit.Core/LiveSplit.Core.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="SharpDX.DirectInput" Version="4.2.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.4" />
     <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
   </ItemGroup>
 

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -5,6 +5,7 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -510,9 +510,19 @@ public class CommandServer
                     break;
                 }
 
-                string[] options = args[1].Split([' '], 2);
+                string[] options;
+                try
+                {
+                    options = JsonSerializer.Deserialize<string[]>(args[1]);
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e);
+                    Log.Error($"[Server] Failed to parse JSON: {args[1]}");
+                    break;
+                }
 
-                if (options.Length < 2)
+                if (options == null || options.Length < 2)
                 {
                     Log.Error($"[Server] Command {command} incorrect usage: missing one or more arguments.");
                     break;

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -501,6 +501,25 @@ public class CommandServer
                 response = string.IsNullOrEmpty(value) ? "-" : Regex.Replace(value, @"\r\n?|\n", " ");
                 break;
             }
+            case "setcustomvariable":
+            {
+                if (args.Length < 2)
+                {
+                    Log.Error($"[Server] Command {command} incorrect usage: missing one or more arguments.");
+                    break;
+                }
+
+                string[] options = args[1].Split([' '], 2);
+
+                if (options.Length < 2)
+                {
+                    Log.Error($"[Server] Command {command} incorrect usage: missing one or more arguments.");
+                    break;
+                }
+
+                State.Run.Metadata.SetCustomVariable(options[0], options[1]);
+                break;
+            }
             case "ping":
             {
                 response = "pong";


### PR DESCRIPTION
Resolves #2574 by adding `setcustomvariable` to let a client create or update a `CustomVariable`.

Expects an argument encoding using JSON to combine 2 strings into 1 string.