### PR TITLE
Fix Offset on GameTimePaused before start

### DIFF
--- a/src/LiveSplit.Core/Model/LiveSplitState.cs
+++ b/src/LiveSplit.Core/Model/LiveSplitState.cs
@@ -64,6 +64,11 @@ public class LiveSplitState : ICloneable
         get => isGameTimePaused;
         set
         {
+            if (CurrentPhase == TimerPhase.NotRunning)
+            {
+                return;
+            }
+
             if (!value && isGameTimePaused)
             {
                 LoadingTimes = CurrentTime.RealTime.Value - (CurrentTime.GameTime ?? CurrentTime.RealTime.Value);


### PR DESCRIPTION
Fixes #2628 by making an autosplitter's calls to `pause_game_time` do nothing when `CurrentPhase` is `TimerState.NotRunning`.

This makes `pause_game_time` and `resume_game_time` behavior more similar to `livesplit-core` behavior from: https://github.com/LiveSplit/livesplit-core/pull/818

(the workaround that autosplitters can use, simply not calling `pause_game_time` or `resume_game_time` while the timer state is `NotRunning`, works well enough that I'd consider this to be low priority, and should not block a release)