### PR TITLE
Add per-component font override support

### DIFF
--- a/src/LiveSplit.Core/Options/FontOverrides.cs
+++ b/src/LiveSplit.Core/Options/FontOverrides.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Drawing;
+
+namespace LiveSplit.Options;
+
+public class FontOverrides : ICloneable, IDisposable
+{
+    public bool OverrideTimerFont { get; set; }
+
+    public Font TimerFont { get; set; }
+
+    public bool OverrideTimesFont { get; set; }
+
+    public Font TimesFont { get; set; }
+
+    public bool OverrideTextFont { get; set; }
+
+    public Font TextFont { get; set; }
+
+    public bool HasOverrides => OverrideTimerFont || OverrideTimesFont || OverrideTextFont;
+
+    public void ApplyTo(LayoutSettings settings, out Font origTimer, out Font origTimes, out Font origText)
+    {
+        if (settings == null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        origTimer = settings.TimerFont;
+        origTimes = settings.TimesFont;
+        origText = settings.TextFont;
+
+        if (OverrideTimerFont && TimerFont != null)
+        {
+            settings.TimerFont = TimerFont;
+        }
+
+        if (OverrideTimesFont && TimesFont != null)
+        {
+            settings.TimesFont = TimesFont;
+        }
+
+        if (OverrideTextFont && TextFont != null)
+        {
+            settings.TextFont = TextFont;
+        }
+    }
+
+    public static void Restore(LayoutSettings settings, Font origTimer, Font origTimes, Font origText)
+    {
+        if (settings == null)
+        {
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        settings.TimerFont = origTimer;
+        settings.TimesFont = origTimes;
+        settings.TextFont = origText;
+    }
+
+    public object Clone()
+    {
+        return new FontOverrides()
+        {
+            OverrideTimerFont = OverrideTimerFont,
+            TimerFont = TimerFont?.Clone() as Font,
+            OverrideTimesFont = OverrideTimesFont,
+            TimesFont = TimesFont?.Clone() as Font,
+            OverrideTextFont = OverrideTextFont,
+            TextFont = TextFont?.Clone() as Font
+        };
+    }
+
+    public void Dispose()
+    {
+        TimerFont?.Dispose();
+        TimesFont?.Dispose();
+        TextFont?.Dispose();
+    }
+}

--- a/src/LiveSplit.Core/UI/Components/ComponentRenderer.cs
+++ b/src/LiveSplit.Core/UI/Components/ComponentRenderer.cs
@@ -22,6 +22,8 @@ public class ComponentRenderer
 
     protected bool errorInComponent;
 
+    private readonly Dictionary<IComponent, FontOverrides> _overrideLookup = [];
+
     private void DrawVerticalComponent(int index, Graphics g, LiveSplitState state, float width, float height, Region clipRegion)
     {
         IComponent component = VisibleComponents.ElementAt(index);
@@ -170,19 +172,28 @@ public class ComponentRenderer
                 Region clip = g.Clip;
                 System.Drawing.Drawing2D.Matrix transform = g.Transform;
                 var crashedComponents = new List<IComponent>();
+                Dictionary<IComponent, FontOverrides> overrideLookup = BuildOverrideLookup(state);
                 int index = 0;
                 foreach (IComponent component in VisibleComponents)
                 {
                     try
                     {
                         g.Clip = clip;
-                        if (mode == LayoutMode.Vertical)
+                        ApplyFontOverrides(overrideLookup, component, state.LayoutSettings, out Font origTimer, out Font origTimes, out Font origText);
+                        try
                         {
-                            DrawVerticalComponent(index, g, state, width, height, clipRegion);
+                            if (mode == LayoutMode.Vertical)
+                            {
+                                DrawVerticalComponent(index, g, state, width, height, clipRegion);
+                            }
+                            else
+                            {
+                                DrawHorizontalComponent(index, g, state, width, height, clipRegion);
+                            }
                         }
-                        else
+                        finally
                         {
-                            DrawHorizontalComponent(index, g, state, width, height, clipRegion);
+                            FontOverrides.Restore(state.LayoutSettings, origTimer, origTimes, origText);
                         }
                     }
                     catch (Exception e)
@@ -242,20 +253,58 @@ public class ComponentRenderer
         float scaleFactor = mode == LayoutMode.Vertical
                 ? height / OverallSize
                 : width / OverallSize;
+        Dictionary<IComponent, FontOverrides> overrideLookup = BuildOverrideLookup(state);
 
         for (int ind = 0; ind < VisibleComponents.Count(); ind++)
         {
             IComponent component = VisibleComponents.ElementAt(ind);
-            if (mode == LayoutMode.Vertical)
+            ApplyFontOverrides(overrideLookup, component, state.LayoutSettings, out Font origTimer, out Font origTimes, out Font origText);
+            try
             {
-                InvalidateVerticalComponent(ind, state, invalidator, width, height, scaleFactor);
+                if (mode == LayoutMode.Vertical)
+                {
+                    InvalidateVerticalComponent(ind, state, invalidator, width, height, scaleFactor);
+                }
+                else
+                {
+                    InvalidateHorizontalComponent(ind, state, invalidator, width, height, scaleFactor);
+                }
             }
-            else
+            finally
             {
-                InvalidateHorizontalComponent(ind, state, invalidator, width, height, scaleFactor);
+                FontOverrides.Restore(state.LayoutSettings, origTimer, origTimes, origText);
             }
         }
 
         invalidator.Transform = oldTransform;
+    }
+
+    private Dictionary<IComponent, FontOverrides> BuildOverrideLookup(LiveSplitState state)
+    {
+        _overrideLookup.Clear();
+        foreach (ILayoutComponent layoutComponent in state.Layout.LayoutComponents)
+        {
+            if (layoutComponent is LayoutComponent componentWithOverrides
+                && componentWithOverrides.FontOverrides.HasOverrides)
+            {
+                _overrideLookup[componentWithOverrides.Component] = componentWithOverrides.FontOverrides;
+            }
+        }
+
+        return _overrideLookup;
+    }
+
+    private static void ApplyFontOverrides(Dictionary<IComponent, FontOverrides> lookup, IComponent component, LayoutSettings settings, out Font origTimer, out Font origTimes, out Font origText)
+    {
+        if (lookup.TryGetValue(component, out FontOverrides overrides))
+        {
+            overrides.ApplyTo(settings, out origTimer, out origTimes, out origText);
+        }
+        else
+        {
+            origTimer = settings.TimerFont;
+            origTimes = settings.TimesFont;
+            origText = settings.TextFont;
+        }
     }
 }

--- a/src/LiveSplit.Core/UI/Components/GlobalFont.cs
+++ b/src/LiveSplit.Core/UI/Components/GlobalFont.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace LiveSplit.UI.Components;
+
+/// <summary>
+/// Flags enum identifying which global layout fonts a component consumes.
+/// </summary>
+[Flags]
+public enum GlobalFont
+{
+    None = 0,
+    TimerFont = 1,
+    TimesFont = 2,
+    TextFont = 4,
+    All = TimerFont | TimesFont | TextFont
+}

--- a/src/LiveSplit.Core/UI/Components/GlobalFontConsumerAttribute.cs
+++ b/src/LiveSplit.Core/UI/Components/GlobalFontConsumerAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace LiveSplit.UI.Components;
+
+/// <summary>
+/// Declares which global layout fonts a component consumes.
+/// This controls which font override rows appear in the Layout Editor.
+/// Components without this attribute default to <see cref="GlobalFont.None"/>
+/// (no font override panel shown).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class GlobalFontConsumerAttribute : Attribute
+{
+    public GlobalFont UsedGlobalFonts { get; }
+
+    public GlobalFontConsumerAttribute(GlobalFont usedGlobalFonts)
+    {
+        UsedGlobalFonts = usedGlobalFonts;
+    }
+}

--- a/src/LiveSplit.Core/UI/Components/LayoutComponent.cs
+++ b/src/LiveSplit.Core/UI/Components/LayoutComponent.cs
@@ -1,18 +1,30 @@
-﻿namespace LiveSplit.UI.Components;
+﻿using LiveSplit.Options;
+
+namespace LiveSplit.UI.Components;
 
 public class LayoutComponent : ILayoutComponent
 {
     public IComponent Component { get; set; }
     public string Path { get; set; }
+    public FontOverrides FontOverrides { get; set; }
 
     public LayoutComponent(string path, IComponent component)
     {
         Component = component;
         Path = path;
+        FontOverrides = new FontOverrides();
     }
 
     public override string ToString()
     {
         return Component.ComponentName;
+    }
+
+    public LayoutComponent Clone()
+    {
+        return new LayoutComponent(Path, Component)
+        {
+            FontOverrides = (FontOverrides)FontOverrides.Clone()
+        };
     }
 }

--- a/src/LiveSplit.Core/UI/Layout.cs
+++ b/src/LiveSplit.Core/UI/Layout.cs
@@ -37,7 +37,7 @@ public class Layout : ILayout
     {
         return new Layout()
         {
-            LayoutComponents = new List<ILayoutComponent>(LayoutComponents),
+            LayoutComponents = LayoutComponents.Select(lc => lc is LayoutComponent concrete ? concrete.Clone() : lc).ToList(),
             VerticalWidth = VerticalWidth,
             VerticalHeight = VerticalHeight,
             HorizontalWidth = HorizontalWidth,

--- a/src/LiveSplit.Core/UI/LayoutFactories/XMLLayoutFactory.cs
+++ b/src/LiveSplit.Core/UI/LayoutFactories/XMLLayoutFactory.cs
@@ -126,6 +126,38 @@ public class XMLLayoutFactory : ILayoutFactory
                 try
                 {
                     layoutComponent.Component.SetSettings(settings);
+
+                    XmlElement fontOverridesElement = componentElement["FontOverrides"];
+                    if (fontOverridesElement != null && layoutComponent is LayoutComponent lc)
+                    {
+                        lc.FontOverrides.OverrideTimerFont = SettingsHelper.ParseBool(fontOverridesElement["OverrideTimerFont"]);
+                        if (lc.FontOverrides.OverrideTimerFont)
+                        {
+                            lc.FontOverrides.TimerFont = SettingsHelper.GetFontFromElement(fontOverridesElement["TimerFont"]);
+                        }
+
+                        lc.FontOverrides.OverrideTimesFont = SettingsHelper.ParseBool(fontOverridesElement["OverrideTimesFont"]);
+                        if (lc.FontOverrides.OverrideTimesFont)
+                        {
+                            lc.FontOverrides.TimesFont = SettingsHelper.GetFontFromElement(fontOverridesElement["TimesFont"]);
+                        }
+
+                        lc.FontOverrides.OverrideTextFont = SettingsHelper.ParseBool(fontOverridesElement["OverrideTextFont"]);
+                        if (lc.FontOverrides.OverrideTextFont)
+                        {
+                            lc.FontOverrides.TextFont = SettingsHelper.GetFontFromElement(fontOverridesElement["TextFont"]);
+                        }
+                    }
+                    else if (layoutComponent is LayoutComponent lcLegacy)
+                    {
+                        // Migrate legacy per-component font overrides via reflection.
+                        // Components that had their own font override settings can provide
+                        // a MigrateFontOverrides(FontOverrides) method to populate the new
+                        // unified FontOverrides on the LayoutComponent wrapper.
+                        layoutComponent.Component.GetType()
+                            .GetMethod("MigrateFontOverrides", [typeof(FontOverrides)])
+                            ?.Invoke(layoutComponent.Component, [lcLegacy.FontOverrides]);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/LiveSplit.Core/UI/LayoutSavers/XMLLayoutSaver.cs
+++ b/src/LiveSplit.Core/UI/LayoutSavers/XMLLayoutSaver.cs
@@ -86,6 +86,31 @@ public class XMLLayoutSaver : ILayoutSaver
                     settings.InnerXml = component.Component.GetSettings(document).InnerXml;
 
                     componentElement.AppendChild(settings);
+
+                    if (component is LayoutComponent layoutComponent
+                        && layoutComponent.FontOverrides.HasOverrides)
+                    {
+                        XmlElement fontOverridesElement = document.CreateElement("FontOverrides");
+                        SettingsHelper.CreateSetting(document, fontOverridesElement, "OverrideTimerFont", layoutComponent.FontOverrides.OverrideTimerFont);
+                        if (layoutComponent.FontOverrides.OverrideTimerFont && layoutComponent.FontOverrides.TimerFont != null)
+                        {
+                            SettingsHelper.CreateSetting(document, fontOverridesElement, "TimerFont", layoutComponent.FontOverrides.TimerFont);
+                        }
+
+                        SettingsHelper.CreateSetting(document, fontOverridesElement, "OverrideTimesFont", layoutComponent.FontOverrides.OverrideTimesFont);
+                        if (layoutComponent.FontOverrides.OverrideTimesFont && layoutComponent.FontOverrides.TimesFont != null)
+                        {
+                            SettingsHelper.CreateSetting(document, fontOverridesElement, "TimesFont", layoutComponent.FontOverrides.TimesFont);
+                        }
+
+                        SettingsHelper.CreateSetting(document, fontOverridesElement, "OverrideTextFont", layoutComponent.FontOverrides.OverrideTextFont);
+                        if (layoutComponent.FontOverrides.OverrideTextFont && layoutComponent.FontOverrides.TextFont != null)
+                        {
+                            SettingsHelper.CreateSetting(document, fontOverridesElement, "TextFont", layoutComponent.FontOverrides.TextFont);
+                        }
+
+                        componentElement.AppendChild(fontOverridesElement);
+                    }
                 }
                 else
                 {
@@ -97,6 +122,29 @@ public class XMLLayoutSaver : ILayoutSaver
                     else
                     {
                         hashCode ^= component.Component.GetSettings(new XmlDocument()).InnerXml.GetHashCode() ^ (component.GetHashCode() * count);
+                    }
+
+                    if (component is LayoutComponent layoutComponentForHash)
+                    {
+                        int fontHash = (layoutComponentForHash.FontOverrides.OverrideTimerFont ? 1 : 0)
+                            ^ (layoutComponentForHash.FontOverrides.OverrideTimesFont ? 2 : 0)
+                            ^ (layoutComponentForHash.FontOverrides.OverrideTextFont ? 4 : 0);
+                        if (layoutComponentForHash.FontOverrides.TimerFont != null)
+                        {
+                            fontHash ^= SettingsHelper.CreateSetting(null, null, "TimerFont", layoutComponentForHash.FontOverrides.TimerFont);
+                        }
+
+                        if (layoutComponentForHash.FontOverrides.TimesFont != null)
+                        {
+                            fontHash ^= SettingsHelper.CreateSetting(null, null, "TimesFont", layoutComponentForHash.FontOverrides.TimesFont);
+                        }
+
+                        if (layoutComponentForHash.FontOverrides.TextFont != null)
+                        {
+                            fontHash ^= SettingsHelper.CreateSetting(null, null, "TextFont", layoutComponentForHash.FontOverrides.TextFont);
+                        }
+
+                        hashCode ^= fontHash ^ (count * 31337);
                     }
                 }
             }

--- a/src/LiveSplit.View/View/FontOverridePanel.Designer.cs
+++ b/src/LiveSplit.View/View/FontOverridePanel.Designer.cs
@@ -1,0 +1,213 @@
+﻿namespace LiveSplit.View
+{
+    partial class FontOverridePanel
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this._groupBox = new System.Windows.Forms.GroupBox();
+            this._tableLayout = new System.Windows.Forms.TableLayoutPanel();
+            this._chkOverrideTimerFont = new System.Windows.Forms.CheckBox();
+            this._btnTimerFont = new System.Windows.Forms.Button();
+            this._lblTimerFont = new System.Windows.Forms.Label();
+            this._chkOverrideTimesFont = new System.Windows.Forms.CheckBox();
+            this._btnTimesFont = new System.Windows.Forms.Button();
+            this._lblTimesFont = new System.Windows.Forms.Label();
+            this._chkOverrideTextFont = new System.Windows.Forms.CheckBox();
+            this._btnTextFont = new System.Windows.Forms.Button();
+            this._lblTextFont = new System.Windows.Forms.Label();
+            this._groupBox.SuspendLayout();
+            this._tableLayout.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // _groupBox
+            // 
+            this._groupBox.Controls.Add(this._tableLayout);
+            this._groupBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._groupBox.Location = new System.Drawing.Point(0, 0);
+            this._groupBox.Name = "_groupBox";
+            this._groupBox.Padding = new System.Windows.Forms.Padding(10, 6, 10, 6);
+            this._groupBox.Size = new System.Drawing.Size(476, 120);
+            this._groupBox.TabIndex = 0;
+            this._groupBox.TabStop = false;
+            this._groupBox.Text = "Font Overrides";
+            // 
+            // _tableLayout
+            // 
+            this._tableLayout.ColumnCount = 3;
+            this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 160F));
+            this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 80F));
+            this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this._tableLayout.Controls.Add(this._chkOverrideTimerFont, 0, 0);
+            this._tableLayout.Controls.Add(this._btnTimerFont, 1, 0);
+            this._tableLayout.Controls.Add(this._lblTimerFont, 2, 0);
+            this._tableLayout.Controls.Add(this._chkOverrideTimesFont, 0, 1);
+            this._tableLayout.Controls.Add(this._btnTimesFont, 1, 1);
+            this._tableLayout.Controls.Add(this._lblTimesFont, 2, 1);
+            this._tableLayout.Controls.Add(this._chkOverrideTextFont, 0, 2);
+            this._tableLayout.Controls.Add(this._btnTextFont, 1, 2);
+            this._tableLayout.Controls.Add(this._lblTextFont, 2, 2);
+            this._tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._tableLayout.Location = new System.Drawing.Point(6, 16);
+            this._tableLayout.Name = "_tableLayout";
+            this._tableLayout.RowCount = 3;
+            this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33F));
+            this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.34F));
+            this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33F));
+            this._tableLayout.Size = new System.Drawing.Size(464, 101);
+            this._tableLayout.TabIndex = 0;
+            // 
+            // _chkOverrideTimerFont
+            // 
+            this._chkOverrideTimerFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._chkOverrideTimerFont.AutoSize = true;
+            this._chkOverrideTimerFont.Location = new System.Drawing.Point(3, 8);
+            this._chkOverrideTimerFont.Name = "_chkOverrideTimerFont";
+            this._chkOverrideTimerFont.Size = new System.Drawing.Size(128, 17);
+            this._chkOverrideTimerFont.TabIndex = 0;
+            this._chkOverrideTimerFont.Text = "Override Timer Font";
+            this._chkOverrideTimerFont.UseVisualStyleBackColor = true;
+            this._chkOverrideTimerFont.CheckedChanged += new System.EventHandler(this.chkOverrideTimerFont_CheckedChanged);
+            // 
+            // _btnTimerFont
+            // 
+            this._btnTimerFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._btnTimerFont.Enabled = false;
+            this._btnTimerFont.Location = new System.Drawing.Point(163, 5);
+            this._btnTimerFont.Name = "_btnTimerFont";
+            this._btnTimerFont.Size = new System.Drawing.Size(74, 23);
+            this._btnTimerFont.TabIndex = 1;
+            this._btnTimerFont.Text = "Choose...";
+            this._btnTimerFont.UseVisualStyleBackColor = true;
+            this._btnTimerFont.Click += new System.EventHandler(this.btnTimerFont_Click);
+            // 
+            // _lblTimerFont
+            // 
+            this._lblTimerFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._lblTimerFont.AutoSize = true;
+            this._lblTimerFont.Location = new System.Drawing.Point(243, 10);
+            this._lblTimerFont.Name = "_lblTimerFont";
+            this._lblTimerFont.Size = new System.Drawing.Size(63, 13);
+            this._lblTimerFont.TabIndex = 2;
+            this._lblTimerFont.Text = "Using global";
+            // 
+            // _chkOverrideTimesFont
+            // 
+            this._chkOverrideTimesFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._chkOverrideTimesFont.AutoSize = true;
+            this._chkOverrideTimesFont.Location = new System.Drawing.Point(3, 41);
+            this._chkOverrideTimesFont.Name = "_chkOverrideTimesFont";
+            this._chkOverrideTimesFont.Size = new System.Drawing.Size(130, 17);
+            this._chkOverrideTimesFont.TabIndex = 3;
+            this._chkOverrideTimesFont.Text = "Override Times Font";
+            this._chkOverrideTimesFont.UseVisualStyleBackColor = true;
+            this._chkOverrideTimesFont.CheckedChanged += new System.EventHandler(this.chkOverrideTimesFont_CheckedChanged);
+            // 
+            // _btnTimesFont
+            // 
+            this._btnTimesFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._btnTimesFont.Enabled = false;
+            this._btnTimesFont.Location = new System.Drawing.Point(163, 38);
+            this._btnTimesFont.Name = "_btnTimesFont";
+            this._btnTimesFont.Size = new System.Drawing.Size(74, 23);
+            this._btnTimesFont.TabIndex = 4;
+            this._btnTimesFont.Text = "Choose...";
+            this._btnTimesFont.UseVisualStyleBackColor = true;
+            this._btnTimesFont.Click += new System.EventHandler(this.btnTimesFont_Click);
+            // 
+            // _lblTimesFont
+            // 
+            this._lblTimesFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._lblTimesFont.AutoSize = true;
+            this._lblTimesFont.Location = new System.Drawing.Point(243, 43);
+            this._lblTimesFont.Name = "_lblTimesFont";
+            this._lblTimesFont.Size = new System.Drawing.Size(63, 13);
+            this._lblTimesFont.TabIndex = 5;
+            this._lblTimesFont.Text = "Using global";
+            // 
+            // _chkOverrideTextFont
+            // 
+            this._chkOverrideTextFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._chkOverrideTextFont.AutoSize = true;
+            this._chkOverrideTextFont.Location = new System.Drawing.Point(3, 75);
+            this._chkOverrideTextFont.Name = "_chkOverrideTextFont";
+            this._chkOverrideTextFont.Size = new System.Drawing.Size(122, 17);
+            this._chkOverrideTextFont.TabIndex = 6;
+            this._chkOverrideTextFont.Text = "Override Text Font";
+            this._chkOverrideTextFont.UseVisualStyleBackColor = true;
+            this._chkOverrideTextFont.CheckedChanged += new System.EventHandler(this.chkOverrideTextFont_CheckedChanged);
+            // 
+            // _btnTextFont
+            // 
+            this._btnTextFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._btnTextFont.Enabled = false;
+            this._btnTextFont.Location = new System.Drawing.Point(163, 72);
+            this._btnTextFont.Name = "_btnTextFont";
+            this._btnTextFont.Size = new System.Drawing.Size(74, 23);
+            this._btnTextFont.TabIndex = 7;
+            this._btnTextFont.Text = "Choose...";
+            this._btnTextFont.UseVisualStyleBackColor = true;
+            this._btnTextFont.Click += new System.EventHandler(this.btnTextFont_Click);
+            // 
+            // _lblTextFont
+            // 
+            this._lblTextFont.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._lblTextFont.AutoSize = true;
+            this._lblTextFont.Location = new System.Drawing.Point(243, 77);
+            this._lblTextFont.Name = "_lblTextFont";
+            this._lblTextFont.Size = new System.Drawing.Size(63, 13);
+            this._lblTextFont.TabIndex = 8;
+            this._lblTextFont.Text = "Using global";
+            // 
+            // FontOverridePanel
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this._groupBox);
+            this.Name = "FontOverridePanel";
+            this.Padding = new System.Windows.Forms.Padding(10);
+            this.Size = new System.Drawing.Size(476, 134);
+            this._groupBox.ResumeLayout(false);
+            this._tableLayout.ResumeLayout(false);
+            this._tableLayout.PerformLayout();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox _groupBox;
+        private System.Windows.Forms.TableLayoutPanel _tableLayout;
+        private System.Windows.Forms.CheckBox _chkOverrideTimerFont;
+        private System.Windows.Forms.Button _btnTimerFont;
+        private System.Windows.Forms.Label _lblTimerFont;
+        private System.Windows.Forms.CheckBox _chkOverrideTimesFont;
+        private System.Windows.Forms.Button _btnTimesFont;
+        private System.Windows.Forms.Label _lblTimesFont;
+        private System.Windows.Forms.CheckBox _chkOverrideTextFont;
+        private System.Windows.Forms.Button _btnTextFont;
+        private System.Windows.Forms.Label _lblTextFont;
+    }
+}

--- a/src/LiveSplit.View/View/FontOverridePanel.cs
+++ b/src/LiveSplit.View/View/FontOverridePanel.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+using LiveSplit.Options;
+using LiveSplit.UI;
+using LiveSplit.UI.Components;
+
+namespace LiveSplit.View;
+
+public partial class FontOverridePanel : UserControl
+{
+    private FontOverrides _fontOverrides;
+    private Options.LayoutSettings _globalSettings;
+
+    public FontOverridePanel()
+    {
+        InitializeComponent();
+    }
+
+    public void Bind(FontOverrides fontOverrides, Options.LayoutSettings globalSettings, GlobalFont usedFonts = GlobalFont.All)
+    {
+        _fontOverrides = fontOverrides;
+        _globalSettings = globalSettings;
+        UpdateUI();
+        ApplyFontFilter(usedFonts);
+    }
+
+    private void ApplyFontFilter(GlobalFont usedFonts)
+    {
+        bool showTimer = usedFonts.HasFlag(GlobalFont.TimerFont);
+        bool showTimes = usedFonts.HasFlag(GlobalFont.TimesFont);
+        bool showText = usedFonts.HasFlag(GlobalFont.TextFont);
+
+        SetRowVisible(0, showTimer);
+        SetRowVisible(1, showTimes);
+        SetRowVisible(2, showText);
+
+        int visibleRows = (showTimer ? 1 : 0) + (showTimes ? 1 : 0) + (showText ? 1 : 0);
+        AdjustHeight(visibleRows);
+    }
+
+    private void AdjustHeight(int visibleRows)
+    {
+        if (visibleRows >= _tableLayout.RowCount)
+        {
+            return;
+        }
+
+        // Subtract the proportional height of hidden rows from the table area.
+        // This preserves DPI-scaled values since we derive from the current Height.
+        int hiddenRows = _tableLayout.RowCount - visibleRows;
+        Height -= _tableLayout.Height * hiddenRows / _tableLayout.RowCount;
+    }
+
+    private void SetRowVisible(int row, bool visible)
+    {
+        foreach (Control control in _tableLayout.Controls)
+        {
+            if (_tableLayout.GetRow(control) == row)
+            {
+                control.Visible = visible;
+            }
+        }
+
+        _tableLayout.RowStyles[row] = visible
+            ? new RowStyle(SizeType.Percent, 33.33f)
+            : new RowStyle(SizeType.Absolute, 0f);
+    }
+
+    private void UpdateUI()
+    {
+        // Timer
+        _chkOverrideTimerFont.Checked = _fontOverrides.OverrideTimerFont;
+        _btnTimerFont.Enabled = _fontOverrides.OverrideTimerFont;
+        UpdateFontLabel(_lblTimerFont, _fontOverrides.OverrideTimerFont ? _fontOverrides.TimerFont : null, _globalSettings.TimerFont);
+
+        // Times
+        _chkOverrideTimesFont.Checked = _fontOverrides.OverrideTimesFont;
+        _btnTimesFont.Enabled = _fontOverrides.OverrideTimesFont;
+        UpdateFontLabel(_lblTimesFont, _fontOverrides.OverrideTimesFont ? _fontOverrides.TimesFont : null, _globalSettings.TimesFont);
+
+        // Text
+        _chkOverrideTextFont.Checked = _fontOverrides.OverrideTextFont;
+        _btnTextFont.Enabled = _fontOverrides.OverrideTextFont;
+        UpdateFontLabel(_lblTextFont, _fontOverrides.OverrideTextFont ? _fontOverrides.TextFont : null, _globalSettings.TextFont);
+    }
+
+    private static void UpdateFontLabel(Label label, Font overrideFont, Font globalFont)
+    {
+        if (overrideFont != null)
+        {
+            label.Text = SettingsHelper.FormatFont(overrideFont);
+            label.ForeColor = SystemColors.ControlText;
+        }
+        else
+        {
+            label.Text = globalFont != null
+                ? $"Using global: {SettingsHelper.FormatFont(globalFont)}"
+                : "Using global";
+            label.ForeColor = SystemColors.GrayText;
+        }
+    }
+
+    private void chkOverrideTimerFont_CheckedChanged(object sender, EventArgs e)
+    {
+        _fontOverrides.OverrideTimerFont = _chkOverrideTimerFont.Checked;
+        _btnTimerFont.Enabled = _chkOverrideTimerFont.Checked;
+        UpdateFontLabel(_lblTimerFont, _chkOverrideTimerFont.Checked ? _fontOverrides.TimerFont : null, _globalSettings.TimerFont);
+    }
+
+    private void chkOverrideTimesFont_CheckedChanged(object sender, EventArgs e)
+    {
+        _fontOverrides.OverrideTimesFont = _chkOverrideTimesFont.Checked;
+        _btnTimesFont.Enabled = _chkOverrideTimesFont.Checked;
+        UpdateFontLabel(_lblTimesFont, _chkOverrideTimesFont.Checked ? _fontOverrides.TimesFont : null, _globalSettings.TimesFont);
+    }
+
+    private void chkOverrideTextFont_CheckedChanged(object sender, EventArgs e)
+    {
+        _fontOverrides.OverrideTextFont = _chkOverrideTextFont.Checked;
+        _btnTextFont.Enabled = _chkOverrideTextFont.Checked;
+        UpdateFontLabel(_lblTextFont, _chkOverrideTextFont.Checked ? _fontOverrides.TextFont : null, _globalSettings.TextFont);
+    }
+
+    private void btnTimerFont_Click(object sender, EventArgs e)
+    {
+        Font current = _fontOverrides.TimerFont ?? _globalSettings.TimerFont;
+        // Scale down for dialog display, matching LayoutSettingsControl pattern
+        var dialogFont = new Font(current.FontFamily.Name, current.Size / 50f * 18f, current.Style, GraphicsUnit.Pixel);
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(dialogFont, 7, 20);
+        dialog.FontChanged += (s, ev) =>
+        {
+            Font newFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+            // Scale back up to the size the Timer component expects
+            _fontOverrides.TimerFont = new Font(newFont.FontFamily.Name, newFont.Size / 18f * 50f, newFont.Style, GraphicsUnit.Pixel);
+            UpdateFontLabel(_lblTimerFont, _fontOverrides.TimerFont, _globalSettings.TimerFont);
+        };
+        dialog.ShowDialog(FindForm());
+    }
+
+    private void btnTimesFont_Click(object sender, EventArgs e)
+    {
+        Font current = _fontOverrides.TimesFont ?? _globalSettings.TimesFont;
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(current, 11, 26);
+        dialog.FontChanged += (s, ev) =>
+        {
+            _fontOverrides.TimesFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+            UpdateFontLabel(_lblTimesFont, _fontOverrides.TimesFont, _globalSettings.TimesFont);
+        };
+        dialog.ShowDialog(FindForm());
+    }
+
+    private void btnTextFont_Click(object sender, EventArgs e)
+    {
+        Font current = _fontOverrides.TextFont ?? _globalSettings.TextFont;
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(current, 11, 26);
+        dialog.FontChanged += (s, ev) =>
+        {
+            _fontOverrides.TextFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+            UpdateFontLabel(_lblTextFont, _fontOverrides.TextFont, _globalSettings.TextFont);
+        };
+        dialog.ShowDialog(FindForm());
+    }
+}

--- a/src/LiveSplit.View/View/LayoutEditorDialog.cs
+++ b/src/LiveSplit.View/View/LayoutEditorDialog.cs
@@ -297,9 +297,12 @@ public partial class LayoutEditorDialog : Form
             try
             {
                 UI.Components.IComponent control = ((ILayoutComponent)selectedItem).Component;
-                if (control.GetSettingsControl(Layout.Mode) != null)
+                bool hasSettings = control.GetSettingsControl(Layout.Mode) != null;
+                bool hasFontOverrides = control.GetType()
+                    .GetCustomAttributes(typeof(GlobalFontConsumerAttribute), true).Length > 0;
+                if (hasSettings || hasFontOverrides)
                 {
-                    ShowLayoutSettings(((ILayoutComponent)selectedItem).Component);
+                    ShowLayoutSettings(control);
                 }
             }
             catch (Exception ex)

--- a/src/LiveSplit.View/View/LayoutSettingsDialog.Designer.cs
+++ b/src/LiveSplit.View/View/LayoutSettingsDialog.Designer.cs
@@ -7,18 +7,7 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
+        // Dispose is defined in LayoutSettingsDialog.cs to include snapshot cleanup.
 
         #region Windows Form Designer generated code
 

--- a/src/LiveSplit.View/View/LayoutSettingsDialog.cs
+++ b/src/LiveSplit.View/View/LayoutSettingsDialog.cs
@@ -5,6 +5,8 @@ using System.Windows.Forms;
 using System.Xml;
 
 using LiveSplit.Localization;
+using LiveSplit.Options;
+using LiveSplit.UI;
 using LiveSplit.UI.Components;
 
 namespace LiveSplit.View;
@@ -16,6 +18,24 @@ public partial class LayoutSettingsDialog : Form
     public List<XmlNode> ComponentSettings { get; set; }
     public List<IComponent> Components { get; set; }
 
+    private List<FontOverrides> _fontOverrideSnapshots;
+    private List<LayoutComponent> _layoutComponents;
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            foreach (FontOverrides snapshot in _fontOverrideSnapshots)
+            {
+                snapshot?.Dispose();
+            }
+
+            components?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
     public LayoutSettingsDialog(Options.LayoutSettings settings, UI.ILayout layout, IComponent tabComponent = null)
     {
         InitializeComponent();
@@ -23,6 +43,8 @@ public partial class LayoutSettingsDialog : Form
         Layout = layout;
         ComponentSettings = [];
         Components = [];
+        _fontOverrideSnapshots = [];
+        _layoutComponents = [];
         AddNewTab("Layout", new LayoutSettingsControl(settings, layout));
         AddComponents(tabComponent);
         UiLocalizer.Apply(this, LanguageResolver.ResolveCurrentCultureLanguage());
@@ -41,20 +63,93 @@ public partial class LayoutSettingsDialog : Form
             Components[i].SetSettings(ComponentSettings[i]);
         }
 
+        // Restore font overrides from snapshots, disposing fonts set during the dialog session
+        for (int i = 0; i < _layoutComponents.Count; i++)
+        {
+            FontOverrides snapshot = _fontOverrideSnapshots[i];
+            FontOverrides current = _layoutComponents[i].FontOverrides;
+
+            if (current.TimerFont != snapshot.TimerFont)
+            {
+                current.TimerFont?.Dispose();
+            }
+
+            if (current.TimesFont != snapshot.TimesFont)
+            {
+                current.TimesFont?.Dispose();
+            }
+
+            if (current.TextFont != snapshot.TextFont)
+            {
+                current.TextFont?.Dispose();
+            }
+
+            current.OverrideTimerFont = snapshot.OverrideTimerFont;
+            current.TimerFont = snapshot.TimerFont?.Clone() as Font;
+            current.OverrideTimesFont = snapshot.OverrideTimesFont;
+            current.TimesFont = snapshot.TimesFont?.Clone() as Font;
+            current.OverrideTextFont = snapshot.OverrideTextFont;
+            current.TextFont = snapshot.TextFont?.Clone() as Font;
+        }
+
         DialogResult = DialogResult.Cancel;
         Close();
     }
 
     protected void AddComponents(IComponent tabComponent = null)
     {
-        foreach (IComponent component in Layout.Components)
+        foreach (ILayoutComponent layoutComponent in Layout.LayoutComponents)
         {
+            IComponent component = layoutComponent.Component;
             Control settingsControl = component.GetSettingsControl(Layout.Mode);
-            if (settingsControl != null)
+            var lc = layoutComponent as LayoutComponent;
+
+            var fontAttr = component.GetType().GetCustomAttributes(typeof(GlobalFontConsumerAttribute), true);
+            GlobalFont usedFonts = fontAttr.Length > 0
+                ? ((GlobalFontConsumerAttribute)fontAttr[0]).UsedGlobalFonts
+                : GlobalFont.None;
+
+            // Snapshot font overrides for cancel
+            if (lc != null)
             {
-                AddNewTab(component.ComponentName, settingsControl);
+                _fontOverrideSnapshots.Add((FontOverrides)lc.FontOverrides.Clone());
+                _layoutComponents.Add(lc);
+            }
+
+            bool showFontPanel = lc != null && usedFonts != GlobalFont.None;
+
+            // Create a tab if component has settings OR if it should show font overrides
+            if (settingsControl != null || showFontPanel)
+            {
+                Control tabContent;
+                if (settingsControl != null && showFontPanel)
+                {
+                    // Both: stack font panel above settings
+                    var container = new Panel { Dock = DockStyle.Fill };
+                    var fontPanel = new FontOverridePanel();
+                    fontPanel.Bind(lc.FontOverrides, Layout.Settings, usedFonts);
+                    fontPanel.Dock = DockStyle.Top;
+                    container.Controls.Add(settingsControl);
+                    settingsControl.Dock = DockStyle.Fill;
+                    container.Controls.Add(fontPanel);
+                    tabContent = container;
+                }
+                else if (showFontPanel)
+                {
+                    // No settings control: show only font panel
+                    var fontPanel = new FontOverridePanel();
+                    fontPanel.Bind(lc.FontOverrides, Layout.Settings, usedFonts);
+                    tabContent = fontPanel;
+                }
+                else
+                {
+                    tabContent = settingsControl;
+                }
+
+                AddNewTab(component.ComponentName, tabContent);
                 ComponentSettings.Add(component.GetSettings(new XmlDocument()));
                 Components.Add(component);
+
                 if (component == tabComponent)
                 {
                     tabControl.SelectTab(tabControl.TabPages.Count - 1);

--- a/test/LiveSplit.Tests/LiveSplit.Tests.csproj
+++ b/test/LiveSplit.Tests/LiveSplit.Tests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
 </Project>

--- a/test/LiveSplit.Tests/Options/FontOverridesMust.cs
+++ b/test/LiveSplit.Tests/Options/FontOverridesMust.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Drawing;
+
+using LiveSplit.Options;
+
+using Xunit;
+
+namespace LiveSplit.Tests.Options;
+
+public class FontOverridesMust
+{
+    [Fact]
+    public void ApplyOverride_WhenTimerFontOverrideSet()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTimerFont = true,
+            TimerFont = new Font("Arial", 12f)
+        };
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Arial", settings.TimerFont.Name);
+        Assert.Equal(12f, settings.TimerFont.Size);
+        Assert.Equal("Segoe UI", settings.TimesFont.Name);
+        Assert.Equal("Segoe UI", settings.TextFont.Name);
+        Assert.Equal("Segoe UI", origTimer.Name);
+    }
+
+    [Fact]
+    public void ApplyOverride_WhenTimesFontOverrideSet()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTimesFont = true,
+            TimesFont = new Font("Consolas", 10f)
+        };
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Segoe UI", settings.TimerFont.Name);
+        Assert.Equal("Consolas", settings.TimesFont.Name);
+        Assert.Equal(10f, settings.TimesFont.Size);
+        Assert.Equal("Segoe UI", settings.TextFont.Name);
+        Assert.Equal("Segoe UI", origTimes.Name);
+    }
+
+    [Fact]
+    public void ApplyOverride_WhenTextFontOverrideSet()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTextFont = true,
+            TextFont = new Font("Courier New", 14f)
+        };
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Segoe UI", settings.TimerFont.Name);
+        Assert.Equal("Segoe UI", settings.TimesFont.Name);
+        Assert.Equal("Courier New", settings.TextFont.Name);
+        Assert.Equal(14f, settings.TextFont.Size);
+        Assert.Equal("Segoe UI", origText.Name);
+    }
+
+    [Fact]
+    public void ApplyOverride_WhenAllOverridesSet()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTimerFont = true,
+            TimerFont = new Font("Arial", 12f),
+            OverrideTimesFont = true,
+            TimesFont = new Font("Consolas", 10f),
+            OverrideTextFont = true,
+            TextFont = new Font("Courier New", 14f)
+        };
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Arial", settings.TimerFont.Name);
+        Assert.Equal("Consolas", settings.TimesFont.Name);
+        Assert.Equal("Courier New", settings.TextFont.Name);
+        Assert.Equal("Segoe UI", origTimer.Name);
+        Assert.Equal("Segoe UI", origTimes.Name);
+        Assert.Equal("Segoe UI", origText.Name);
+    }
+
+    [Fact]
+    public void PreserveOriginalFonts_WhenNoOverridesSet()
+    {
+        var sut = new FontOverrides();
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Segoe UI", settings.TimerFont.Name);
+        Assert.Equal(16f, settings.TimerFont.Size);
+        Assert.Equal("Segoe UI", settings.TimesFont.Name);
+        Assert.Equal("Segoe UI", settings.TextFont.Name);
+    }
+
+    [Fact]
+    public void RestoreOriginalFonts_AfterApply()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTimerFont = true,
+            TimerFont = new Font("Arial", 12f),
+            OverrideTimesFont = true,
+            TimesFont = new Font("Consolas", 10f),
+            OverrideTextFont = true,
+            TextFont = new Font("Courier New", 14f)
+        };
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Arial", settings.TimerFont.Name);
+
+        FontOverrides.Restore(settings, origTimer, origTimes, origText);
+
+        Assert.Equal("Segoe UI", settings.TimerFont.Name);
+        Assert.Equal(16f, settings.TimerFont.Size);
+        Assert.Equal("Segoe UI", settings.TimesFont.Name);
+        Assert.Equal("Segoe UI", settings.TextFont.Name);
+    }
+
+    [Fact]
+    public void HandleNullFont_WhenOverrideFlagTrueButFontNull()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTimerFont = true,
+            TimerFont = null,
+            OverrideTimesFont = true,
+            TimesFont = null,
+            OverrideTextFont = true,
+            TextFont = null
+        };
+        var settings = new LayoutSettings
+        {
+            TimerFont = new Font("Segoe UI", 16f),
+            TimesFont = new Font("Segoe UI", 16f),
+            TextFont = new Font("Segoe UI", 16f)
+        };
+
+        sut.ApplyTo(settings, out Font origTimer, out Font origTimes, out Font origText);
+
+        Assert.Equal("Segoe UI", settings.TimerFont.Name);
+        Assert.Equal("Segoe UI", settings.TimesFont.Name);
+        Assert.Equal("Segoe UI", settings.TextFont.Name);
+    }
+
+    [Fact]
+    public void CloneProducesIndependentCopy()
+    {
+        var sut = new FontOverrides
+        {
+            OverrideTimerFont = true,
+            TimerFont = new Font("Arial", 12f),
+            OverrideTimesFont = false,
+            OverrideTextFont = true,
+            TextFont = new Font("Courier New", 14f)
+        };
+
+        var clone = (FontOverrides)sut.Clone();
+
+        Assert.True(clone.OverrideTimerFont);
+        Assert.Equal("Arial", clone.TimerFont.Name);
+        Assert.Equal(12f, clone.TimerFont.Size);
+        Assert.False(clone.OverrideTimesFont);
+        Assert.Null(clone.TimesFont);
+        Assert.True(clone.OverrideTextFont);
+        Assert.Equal("Courier New", clone.TextFont.Name);
+
+        clone.OverrideTimerFont = false;
+        clone.TimerFont.Dispose();
+        clone.TimerFont = new Font("Verdana", 20f);
+
+        Assert.True(sut.OverrideTimerFont);
+        Assert.Equal("Arial", sut.TimerFont.Name);
+    }
+
+    [Fact]
+    public void HasOverridesReturnsFalse_WhenNoFlagsSet()
+    {
+        var sut = new FontOverrides();
+
+        Assert.False(sut.HasOverrides);
+    }
+
+    [Fact]
+    public void HasOverridesReturnsTrue_WhenAnyFlagSet()
+    {
+        var timerOnly = new FontOverrides { OverrideTimerFont = true };
+        var timesOnly = new FontOverrides { OverrideTimesFont = true };
+        var textOnly = new FontOverrides { OverrideTextFont = true };
+
+        Assert.True(timerOnly.HasOverrides);
+        Assert.True(timesOnly.HasOverrides);
+        Assert.True(textOnly.HasOverrides);
+    }
+}

--- a/test/LiveSplit.Tests/UI/LayoutSerializationFontOverridesMust.cs
+++ b/test/LiveSplit.Tests/UI/LayoutSerializationFontOverridesMust.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using System.Xml;
+
+using LiveSplit.Model;
+using LiveSplit.Options;
+using LiveSplit.Options.SettingsFactories;
+using LiveSplit.UI;
+using LiveSplit.UI.Components;
+using LiveSplit.UI.LayoutSavers;
+
+using Xunit;
+
+namespace LiveSplit.Tests.UI;
+
+public class LayoutSerializationFontOverridesMust
+{
+    [Fact]
+    public void RoundtripFontOverrides_WhenSavedAndLoaded()
+    {
+        var layout = new Layout { Settings = new StandardLayoutSettingsFactory().Create() };
+        var layoutComponent = new LayoutComponent("test.dll", new StubComponent())
+        {
+            FontOverrides = new FontOverrides
+            {
+                OverrideTextFont = true,
+                TextFont = new Font("Arial", 14f)
+            }
+        };
+        layout.LayoutComponents.Add(layoutComponent);
+
+        var saver = new XMLLayoutSaver();
+        using var stream = new MemoryStream();
+        saver.Save(layout, stream);
+        stream.Position = 0;
+
+        var doc = new XmlDocument();
+        doc.Load(stream);
+
+        XmlNode fontOverridesNode = doc.SelectSingleNode("//FontOverrides");
+        Assert.NotNull(fontOverridesNode);
+
+        XmlNode overrideTextFontNode = doc.SelectSingleNode("//FontOverrides/OverrideTextFont");
+        Assert.NotNull(overrideTextFontNode);
+        Assert.Equal("True", overrideTextFontNode.InnerText);
+
+        XmlNode textFontNode = doc.SelectSingleNode("//FontOverrides/TextFont");
+        Assert.NotNull(textFontNode);
+        Assert.False(string.IsNullOrEmpty(textFontNode.InnerText));
+    }
+
+    [Fact]
+    public void LoadOldLayoutWithoutFontOverrides_DefaultsToNoOverride()
+    {
+        var layoutComponent = new LayoutComponent("test.dll", new StubComponent());
+
+        Assert.NotNull(layoutComponent.FontOverrides);
+        Assert.False(layoutComponent.FontOverrides.HasOverrides);
+        Assert.False(layoutComponent.FontOverrides.OverrideTimerFont);
+        Assert.False(layoutComponent.FontOverrides.OverrideTimesFont);
+        Assert.False(layoutComponent.FontOverrides.OverrideTextFont);
+        Assert.Null(layoutComponent.FontOverrides.TimerFont);
+        Assert.Null(layoutComponent.FontOverrides.TimesFont);
+        Assert.Null(layoutComponent.FontOverrides.TextFont);
+    }
+
+    [Fact]
+    public void IncludeFontOverridesInHash_WhenOverridePresent()
+    {
+        var layout1 = new Layout { Settings = new StandardLayoutSettingsFactory().Create() };
+        layout1.LayoutComponents.Add(new LayoutComponent("test.dll", new StubComponent()));
+
+        var layout2 = new Layout { Settings = new StandardLayoutSettingsFactory().Create() };
+        var lcWithOverride = new LayoutComponent("test.dll", new StubComponent())
+        {
+            FontOverrides = new FontOverrides
+            {
+                OverrideTextFont = true,
+                TextFont = new Font("Arial", 14f)
+            }
+        };
+        layout2.LayoutComponents.Add(lcWithOverride);
+
+        var saver = new XMLLayoutSaver();
+        int hash1 = saver.CreateLayoutNode(null, null, layout1);
+        int hash2 = saver.CreateLayoutNode(null, null, layout2);
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void OmitFontOverridesFromXml_WhenNoOverridesSet()
+    {
+        var layout = new Layout { Settings = new StandardLayoutSettingsFactory().Create() };
+        layout.LayoutComponents.Add(new LayoutComponent("test.dll", new StubComponent()));
+
+        var saver = new XMLLayoutSaver();
+        using var stream = new MemoryStream();
+        saver.Save(layout, stream);
+        stream.Position = 0;
+
+        var doc = new XmlDocument();
+        doc.Load(stream);
+
+        XmlNode fontOverridesNode = doc.SelectSingleNode("//FontOverrides");
+        Assert.Null(fontOverridesNode);
+    }
+
+    /// <summary>
+    /// Minimal IComponent stub for serialization tests.
+    /// Only GetSettings is needed by XMLLayoutSaver.
+    /// </summary>
+    private sealed class StubComponent : IComponent
+    {
+        public string ComponentName => "Stub";
+
+        public float HorizontalWidth => 0;
+        public float MinimumHeight => 0;
+        public float VerticalHeight => 0;
+        public float MinimumWidth => 0;
+        public float PaddingTop => 0;
+        public float PaddingBottom => 0;
+        public float PaddingLeft => 0;
+        public float PaddingRight => 0;
+
+        public IDictionary<string, Action> ContextMenuControls => null;
+
+        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion) { }
+        public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion) { }
+        public Control GetSettingsControl(LayoutMode mode) { return null; }
+
+        public XmlNode GetSettings(XmlDocument document)
+        {
+            return document.CreateElement("Settings");
+        }
+
+        public void SetSettings(XmlNode settings) { }
+        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a unified per-component font override system that allows individual layout components to override the global Timer, Times, and Text fonts through the Layout Editor, without affecting other components.
- Add [GlobalFontConsumer] attribute to core base classes (InfoTextComponent, InfoTimeComponent) so the Layout Editor shows the correct font override rows.

## Changes

### New files
- **FontOverrides** class (ICloneable, IDisposable) — holds three optional font overrides with apply/restore pattern for safe font swapping
- **GlobalFont** flags enum and **GlobalFontConsumerAttribute** — components declare which global fonts they consume
- **FontOverridePanel** UserControl — Layout Editor UI for per-component font override checkboxes and font choosers
- **FontOverridesMust** / **LayoutSerializationFontOverridesMust** — comprehensive xUnit tests

### Modified files
- **LayoutComponent** — extended with FontOverrides property and Clone() method
- **ComponentRenderer** — applies per-component font overrides around each component's Draw/Update call via 	ry/finally
- **Layout.Clone()** — deep-copies LayoutComponent wrappers with defensive pattern matching for plugin safety
- **XMLLayoutSaver** / **XMLLayoutFactory** — serialize/deserialize FontOverrides with backward compatibility (missing element = no overrides)
- **LayoutSettingsDialog** — snapshots FontOverrides on open, restores on cancel with proper Font disposal
- **LayoutEditorDialog** — double-click guard extended to also check [GlobalFontConsumer] attribute

## Design

The system works by temporarily swapping the global font in LayoutSettings before calling a component's Draw/Update, then restoring the original font in a finally block. Components don't need any code changes — they continue reading from state.LayoutSettings.TimerFont/TimesFont/TextFont as usual.

Components opt in by adding [GlobalFontConsumer(GlobalFont.XXX)] to their class. The attribute is Inherited = true, so derived classes automatically participate. Components that had their own font override settings can provide a MigrateFontOverrides(FontOverrides) method to populate the new unified FontOverrides on the LayoutComponent wrapper.

## Testing

- 485 tests pass (including new tests for FontOverrides clone/dispose/apply/restore and XML serialization round-trip)
- Build: 0 errors, 0 warnings