### PR TITLE
Add run history editor to Split Editor

### DIFF
--- a/src/LiveSplit.Core/Localization/Locales/zh-CN.json
+++ b/src/LiveSplit.Core/Localization/Locales/zh-CN.json
@@ -698,6 +698,7 @@
     "Delete": "删除",
     "All": "全部",
     "No matching attempts": "无匹配的记录",
+    "Page {0} / {1}": "第 {0} / {1} 页",
     "Are you sure you want to delete attempt #{0}?": "确定要删除 #{0} 吗？",
     "Confirm Deletion": "确认删除"
   }

--- a/src/LiveSplit.Core/Localization/Locales/zh-CN.json
+++ b/src/LiveSplit.Core/Localization/Locales/zh-CN.json
@@ -689,6 +689,16 @@
     "Sharing will save a screenshot of LiveSplit.": "分享时会保存一张 LiveSplit 截图。",
     "Sharing to Imgur allows you to share a screenshot of LiveSplit with a popular web database of image content.": "分享到 Imgur 可将 LiveSplit 的截图上传到常用的图片分享网站。",
     "Export your splits as an Excel Sheet to analyze your splits. \r\nThis includes your whole history of all the runs you ever did.": "将你的分段导出为 Excel 表格，便于分析跑分数据。\r\n其中会包含你过往所有尝试的完整历史记录。",
-    "Speedrun.com is a site intended to provide centralized leaderboards for speedrunning.": "Speedrun.com 是一个为速通提供集中排行榜的网站。"
+    "Speedrun.com is a site intended to provide centralized leaderboards for speedrunning.": "Speedrun.com 是一个为速通提供集中排行榜的网站。",
+    "History ▼": "历史 ▼",
+    "History ▲": "历史 ▲",
+    "Completed": "完成的纪录",
+    "Has Best Segment": "含最佳分段",
+    "Best Segment Diff": "最佳分段差值",
+    "Delete": "删除",
+    "All": "全部",
+    "No matching attempts": "无匹配的记录",
+    "Are you sure you want to delete attempt #{0}?": "确定要删除 #{0} 吗？",
+    "Confirm Deletion": "确认删除"
   }
 }

--- a/src/LiveSplit.Core/Model/AttemptDeletionHelper.cs
+++ b/src/LiveSplit.Core/Model/AttemptDeletionHelper.cs
@@ -1,0 +1,23 @@
+namespace LiveSplit.Model;
+
+public static class AttemptDeletionHelper
+{
+    public static void DeleteAttempt(IRun run, int attemptIndex)
+    {
+        // Remove from AttemptHistory
+        for (int i = 0; i < run.AttemptHistory.Count; i++)
+        {
+            if (run.AttemptHistory[i].Index == attemptIndex)
+            {
+                run.AttemptHistory.RemoveAt(i);
+                break;
+            }
+        }
+
+        // Remove from all SegmentHistories
+        foreach (ISegment segment in run)
+        {
+            segment.SegmentHistory.Remove(attemptIndex);
+        }
+    }
+}

--- a/src/LiveSplit.Core/Model/HistoryTimeCalculator.cs
+++ b/src/LiveSplit.Core/Model/HistoryTimeCalculator.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiveSplit.Model;
+
+public static class HistoryTimeCalculator
+{
+    public static IList<TimeSpan?> GetSegmentTimesForAttempt(IRun run, int attemptIndex, TimingMethod method)
+    {
+        var segmentTimes = new List<TimeSpan?>(run.Count);
+        for (int i = 0; i < run.Count; i++)
+        {
+            if (run[i].SegmentHistory.TryGetValue(attemptIndex, out Time segTime))
+            {
+                segmentTimes.Add(segTime[method]);
+            }
+            else
+            {
+                segmentTimes.Add(null);
+            }
+        }
+
+        return segmentTimes;
+    }
+
+    public static IList<TimeSpan?> GetSplitTimesForAttempt(IRun run, int attemptIndex, TimingMethod method)
+    {
+        var splitTimes = new List<TimeSpan?>(run.Count);
+        TimeSpan? total = TimeSpan.Zero;
+
+        for (int i = 0; i < run.Count; i++)
+        {
+            TimeSpan? segmentTime;
+            if (run[i].SegmentHistory.TryGetValue(attemptIndex, out Time segHistTime))
+            {
+                segmentTime = segHistTime[method];
+                if (segmentTime == null)
+                {
+                    total = null;
+                }
+            }
+            else
+            {
+                segmentTime = null;
+                total = null;
+            }
+
+            if (total != null)
+            {
+                total += segmentTime;
+                splitTimes.Add(total);
+            }
+            else
+            {
+                splitTimes.Add(null);
+            }
+        }
+
+        return splitTimes;
+    }
+
+    public static IList<TimeSpan?> GetSegmentBestDiffsForAttempt(IRun run, int attemptIndex, TimingMethod method)
+    {
+        var segmentTimes = GetSegmentTimesForAttempt(run, attemptIndex, method);
+        var diffs = new List<TimeSpan?>(run.Count);
+
+        for (int i = 0; i < run.Count; i++)
+        {
+            TimeSpan? bestSegmentTime = run[i].BestSegmentTime[method];
+            TimeSpan? diff = null;
+
+            if (segmentTimes[i] != null && bestSegmentTime != null)
+            {
+                diff = segmentTimes[i] - bestSegmentTime;
+            }
+
+            diffs.Add(diff);
+        }
+
+        return diffs;
+    }
+}

--- a/src/LiveSplit.Core/Model/RunHistoryService.cs
+++ b/src/LiveSplit.Core/Model/RunHistoryService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiveSplit.Model;
+
+public record RunHistoryFilter(
+    bool CompletedOnly = false,
+    bool PbSegmentsOnly = false,
+    DateTime? FromDate = null,
+    DateTime? ToDate = null,
+    TimingMethod Method = TimingMethod.RealTime
+);
+
+public static class RunHistoryService
+{
+    public static IList<Attempt> GetFilteredAttempts(IRun run, RunHistoryFilter filter)
+    {
+        var filtered = new List<Attempt>();
+
+        foreach (Attempt attempt in run.AttemptHistory)
+        {
+            if (filter.CompletedOnly && attempt.Time[filter.Method] == null)
+            {
+                continue;
+            }
+
+            if (filter.PbSegmentsOnly && !HasPbSegments(run, attempt, filter.Method))
+            {
+                continue;
+            }
+
+            if (filter.FromDate.HasValue && (!attempt.Started.HasValue || attempt.Started.Value.Time < filter.FromDate.Value))
+            {
+                continue;
+            }
+
+            if (filter.ToDate.HasValue && (!attempt.Started.HasValue || attempt.Started.Value.Time > filter.ToDate.Value))
+            {
+                continue;
+            }
+
+            filtered.Add(attempt);
+        }
+
+        filtered.Sort((a, b) => b.Index.CompareTo(a.Index));
+        return filtered;
+    }
+
+    public static IList<Attempt> GetPage(IList<Attempt> attempts, int page, int pageSize)
+    {
+        if (page < 1 || pageSize < 1)
+        {
+            return [];
+        }
+
+        int skip = (page - 1) * pageSize;
+        if (skip >= attempts.Count)
+        {
+            return [];
+        }
+
+        return [.. attempts.Skip(skip).Take(pageSize)];
+    }
+
+    private static bool HasPbSegments(IRun run, Attempt attempt, TimingMethod method)
+    {
+        foreach (ISegment segment in run)
+        {
+            if (segment.SegmentHistory.TryGetValue(attempt.Index, out Time segmentTime))
+            {
+                TimeSpan? segmentTimeValue = segmentTime[method];
+                TimeSpan? bestSegmentValue = segment.BestSegmentTime[method];
+
+                if (segmentTimeValue != null && bestSegmentValue != null && segmentTimeValue == bestSegmentValue)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/LiveSplit.View/View/RunEditorDialog.Designer.cs
+++ b/src/LiveSplit.View/View/RunEditorDialog.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace LiveSplit.View
+namespace LiveSplit.View
 {
     partial class RunEditorDialog
     {
@@ -81,6 +81,18 @@
             this.cleanSumOfBestToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.iRunBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.iSegmentBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.btnToggleHistory = new System.Windows.Forms.Button();
+            this.pnlHistory = new System.Windows.Forms.FlowLayoutPanel();
+            this.pnlHistoryRow1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.pnlHistoryRow2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.cbxAttemptSelect = new System.Windows.Forms.ComboBox();
+            this.btnPrevPage = new System.Windows.Forms.Button();
+            this.btnNextPage = new System.Windows.Forms.Button();
+            this.lblPageInfo = new System.Windows.Forms.Label();
+            this.chkCompletedOnly = new System.Windows.Forms.CheckBox();
+            this.chkPbSegmentsOnly = new System.Windows.Forms.CheckBox();
+            this.cbxMonthFilter = new System.Windows.Forms.ComboBox();
+            this.btnDeleteAttempt = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.runGrid)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picGameIcon)).BeginInit();
@@ -89,6 +101,9 @@
             this.tableLayoutPanel2.SuspendLayout();
             this.flpnlLayoutSelect.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
+            this.pnlHistory.SuspendLayout();
+            this.pnlHistoryRow1.SuspendLayout();
+            this.pnlHistoryRow2.SuspendLayout();
             this.RemoveIconMenu.SuspendLayout();
             this.ImportComparisonMenu.SuspendLayout();
             this.OtherMenu.SuspendLayout();
@@ -142,19 +157,22 @@
             this.tableLayoutPanel1.Controls.Add(this.cbxRunCategory, 3, 2);
             this.tableLayoutPanel1.Controls.Add(this.tbxTimeOffset, 3, 3);
             this.tableLayoutPanel1.Controls.Add(this.picGameIcon, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.runGrid, 1, 7);
-            this.tableLayoutPanel1.Controls.Add(this.tabControl, 1, 6);
+            this.tableLayoutPanel1.Controls.Add(this.runGrid, 1, 8);
+            this.tableLayoutPanel1.Controls.Add(this.tabControl, 1, 7);
             this.tableLayoutPanel1.Controls.Add(this.tbxAttempts, 6, 3);
             this.tableLayoutPanel1.Controls.Add(this.label4, 5, 3);
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 6, 15);
-            this.tableLayoutPanel1.Controls.Add(this.btnOther, 0, 14);
-            this.tableLayoutPanel1.Controls.Add(this.btnImportComparison, 0, 13);
-            this.tableLayoutPanel1.Controls.Add(this.btnAddComparison, 0, 12);
-            this.tableLayoutPanel1.Controls.Add(this.btnMoveDown, 0, 11);
-            this.tableLayoutPanel1.Controls.Add(this.btnMoveUp, 0, 10);
-            this.tableLayoutPanel1.Controls.Add(this.btnRemove, 0, 9);
-            this.tableLayoutPanel1.Controls.Add(this.btnAdd, 0, 8);
-            this.tableLayoutPanel1.Controls.Add(this.btnInsert, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 6, 16);
+            this.tableLayoutPanel1.Controls.Add(this.btnOther, 0, 15);
+            this.tableLayoutPanel1.Controls.Add(this.btnImportComparison, 0, 14);
+            this.tableLayoutPanel1.Controls.Add(this.btnAddComparison, 0, 13);
+            this.tableLayoutPanel1.Controls.Add(this.btnMoveDown, 0, 12);
+            this.tableLayoutPanel1.Controls.Add(this.btnMoveUp, 0, 11);
+            this.tableLayoutPanel1.Controls.Add(this.btnRemove, 0, 10);
+            this.tableLayoutPanel1.Controls.Add(this.btnAdd, 0, 9);
+            this.tableLayoutPanel1.Controls.Add(this.btnInsert, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.btnToggleHistory, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.pnlHistory, 1, 6);
+            this.tableLayoutPanel1.SetColumnSpan(this.pnlHistory, 9);
             this.tableLayoutPanel1.Controls.Add(this.flpnlLayoutSelect, 5, 5);
             this.tableLayoutPanel1.Controls.Add(this.chkbxUseLayout, 4, 5);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 5, 4);
@@ -162,13 +180,14 @@
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 16;
+            this.tableLayoutPanel1.RowCount = 17;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 5F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 0F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
@@ -698,6 +717,131 @@
             // 
             this.iSegmentBindingSource.DataSource = typeof(LiveSplit.Model.ISegment);
             // 
+            // btnToggleHistory
+            // 
+            this.btnToggleHistory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnToggleHistory.Location = new System.Drawing.Point(10, 208);
+            this.btnToggleHistory.Margin = new System.Windows.Forms.Padding(10, 1, 10, 1);
+            this.btnToggleHistory.Name = "btnToggleHistory";
+            this.btnToggleHistory.Size = new System.Drawing.Size(120, 23);
+            this.btnToggleHistory.TabIndex = 22;
+            this.btnToggleHistory.Text = "History ▼";
+            this.btnToggleHistory.UseVisualStyleBackColor = true;
+            this.btnToggleHistory.Click += new System.EventHandler(this.btnToggleHistory_Click);
+            // 
+            // pnlHistory
+            // 
+            this.pnlHistory.AutoSize = false;
+            this.pnlHistory.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlHistory.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.pnlHistory.Location = new System.Drawing.Point(144, 208);
+            this.pnlHistory.Margin = new System.Windows.Forms.Padding(4, 3, 10, 3);
+            this.pnlHistory.Name = "pnlHistory";
+            this.pnlHistory.Size = new System.Drawing.Size(530, 60);
+            this.pnlHistory.TabIndex = 23;
+            this.pnlHistory.Visible = false;
+            this.pnlHistory.WrapContents = false;
+            this.pnlHistory.Controls.Add(this.pnlHistoryRow1);
+            this.pnlHistory.Controls.Add(this.pnlHistoryRow2);
+            // 
+            // pnlHistoryRow1
+            // 
+            this.pnlHistoryRow1.AutoSize = false;
+            this.pnlHistoryRow1.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            this.pnlHistoryRow1.Margin = new System.Windows.Forms.Padding(0);
+            this.pnlHistoryRow1.Name = "pnlHistoryRow1";
+            this.pnlHistoryRow1.Size = new System.Drawing.Size(530, 30);
+            this.pnlHistoryRow1.TabIndex = 0;
+            this.pnlHistoryRow1.WrapContents = false;
+            this.pnlHistoryRow1.Controls.Add(this.cbxMonthFilter);
+            this.pnlHistoryRow1.Controls.Add(this.cbxAttemptSelect);
+            this.pnlHistoryRow1.Controls.Add(this.btnPrevPage);
+            this.pnlHistoryRow1.Controls.Add(this.lblPageInfo);
+            this.pnlHistoryRow1.Controls.Add(this.btnNextPage);
+            // 
+            // pnlHistoryRow2
+            // 
+            this.pnlHistoryRow2.AutoSize = false;
+            this.pnlHistoryRow2.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            this.pnlHistoryRow2.Margin = new System.Windows.Forms.Padding(0);
+            this.pnlHistoryRow2.Name = "pnlHistoryRow2";
+            this.pnlHistoryRow2.Size = new System.Drawing.Size(530, 30);
+            this.pnlHistoryRow2.TabIndex = 1;
+            this.pnlHistoryRow2.WrapContents = false;
+            this.pnlHistoryRow2.Controls.Add(this.chkCompletedOnly);
+            this.pnlHistoryRow2.Controls.Add(this.chkPbSegmentsOnly);
+            this.pnlHistoryRow2.Controls.Add(this.btnDeleteAttempt);
+            // 
+            // cbxAttemptSelect
+            // 
+            this.cbxAttemptSelect.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbxAttemptSelect.Name = "cbxAttemptSelect";
+            this.cbxAttemptSelect.Size = new System.Drawing.Size(240, 21);
+            this.cbxAttemptSelect.TabIndex = 0;
+            // 
+            // btnPrevPage
+            // 
+            this.btnPrevPage.Name = "btnPrevPage";
+            this.btnPrevPage.Size = new System.Drawing.Size(25, 23);
+            this.btnPrevPage.TabIndex = 1;
+            this.btnPrevPage.Text = "◀";
+            this.btnPrevPage.UseVisualStyleBackColor = true;
+            // 
+            // lblPageInfo
+            // 
+            this.lblPageInfo.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.lblPageInfo.AutoSize = true;
+            this.lblPageInfo.Name = "lblPageInfo";
+            this.lblPageInfo.Size = new System.Drawing.Size(70, 23);
+            this.lblPageInfo.Text = "Page 1 / 1";
+            this.lblPageInfo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.lblPageInfo.TabIndex = 2;
+            // 
+            // btnNextPage
+            // 
+            this.btnNextPage.Name = "btnNextPage";
+            this.btnNextPage.Size = new System.Drawing.Size(25, 23);
+            this.btnNextPage.TabIndex = 3;
+            this.btnNextPage.Text = "▶";
+            this.btnNextPage.UseVisualStyleBackColor = true;
+            // 
+            // chkCompletedOnly
+            // 
+            this.chkCompletedOnly.AutoSize = true;
+            this.chkCompletedOnly.Margin = new System.Windows.Forms.Padding(3, 7, 3, 3);
+            this.chkCompletedOnly.Name = "chkCompletedOnly";
+            this.chkCompletedOnly.Size = new System.Drawing.Size(80, 17);
+            this.chkCompletedOnly.TabIndex = 4;
+            this.chkCompletedOnly.Text = "Completed";
+            this.chkCompletedOnly.UseVisualStyleBackColor = true;
+            // 
+            // chkPbSegmentsOnly
+            // 
+            this.chkPbSegmentsOnly.AutoSize = true;
+            this.chkPbSegmentsOnly.Margin = new System.Windows.Forms.Padding(3, 7, 3, 3);
+            this.chkPbSegmentsOnly.Name = "chkPbSegmentsOnly";
+this.chkPbSegmentsOnly.Size = new System.Drawing.Size(120, 17);
+this.chkPbSegmentsOnly.TabIndex = 5;
+this.chkPbSegmentsOnly.Text = "Has Best Segment";
+            this.chkPbSegmentsOnly.UseVisualStyleBackColor = true;
+            // 
+            // cbxMonthFilter
+            // 
+            this.cbxMonthFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbxMonthFilter.Name = "cbxMonthFilter";
+            this.cbxMonthFilter.Size = new System.Drawing.Size(100, 21);
+            this.cbxMonthFilter.TabIndex = 6;
+            // 
+            // btnDeleteAttempt
+            // 
+            this.btnDeleteAttempt.Enabled = false;
+            this.btnDeleteAttempt.Name = "btnDeleteAttempt";
+            this.btnDeleteAttempt.Size = new System.Drawing.Size(55, 23);
+            this.btnDeleteAttempt.TabIndex = 8;
+            this.btnDeleteAttempt.Text = "Delete";
+            this.btnDeleteAttempt.UseVisualStyleBackColor = true;
+            // 
             // RunEditorDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -719,6 +863,11 @@
             this.tableLayoutPanel2.ResumeLayout(false);
             this.flpnlLayoutSelect.ResumeLayout(false);
             this.flowLayoutPanel1.ResumeLayout(false);
+            this.pnlHistory.ResumeLayout(false);
+            this.pnlHistoryRow1.ResumeLayout(false);
+            this.pnlHistoryRow1.PerformLayout();
+            this.pnlHistoryRow2.ResumeLayout(false);
+            this.pnlHistoryRow2.PerformLayout();
             this.RemoveIconMenu.ResumeLayout(false);
             this.ImportComparisonMenu.ResumeLayout(false);
             this.OtherMenu.ResumeLayout(false);
@@ -781,5 +930,17 @@
         private System.Windows.Forms.FlowLayoutPanel flpnlLayoutSelect;
         private System.Windows.Forms.ComboBox cbxLayoutToUse;
         private System.Windows.Forms.Button btnBrowseLayout;
+        private System.Windows.Forms.Button btnToggleHistory;
+        private System.Windows.Forms.FlowLayoutPanel pnlHistory;
+        private System.Windows.Forms.FlowLayoutPanel pnlHistoryRow1;
+        private System.Windows.Forms.FlowLayoutPanel pnlHistoryRow2;
+        private System.Windows.Forms.ComboBox cbxAttemptSelect;
+        private System.Windows.Forms.Button btnPrevPage;
+        private System.Windows.Forms.Button btnNextPage;
+        private System.Windows.Forms.Label lblPageInfo;
+        private System.Windows.Forms.CheckBox chkCompletedOnly;
+        private System.Windows.Forms.CheckBox chkPbSegmentsOnly;
+        private System.Windows.Forms.ComboBox cbxMonthFilter;
+        private System.Windows.Forms.Button btnDeleteAttempt;
     }
 }

--- a/src/LiveSplit.View/View/RunEditorDialog.cs
+++ b/src/LiveSplit.View/View/RunEditorDialog.cs
@@ -59,7 +59,6 @@ public partial class RunEditorDialog : Form
     private TimingMethod _cacheMethod;
 
     private const int HistoryPageSize = 50;
-    private RunHistoryFilter currentFilter = new RunHistoryFilter();
     private int currentPage = 1;
     private int totalPages = 1;
     private IList<Attempt> _filteredAttempts = new List<Attempt>();
@@ -650,6 +649,7 @@ public partial class RunEditorDialog : Form
         }
 
         TimeSpan newSegmentTime;
+        TimeSpan newSplitTime = TimeSpan.Zero; // Only meaningful when editing the Split Time column
 
         try
         {
@@ -666,7 +666,7 @@ public partial class RunEditorDialog : Form
                 if (prevSplitTime == null)
                     prevSplitTime = TimeSpan.Zero;
 
-                TimeSpan newSplitTime = parsed;
+                newSplitTime = parsed;
                 if (newSplitTime < prevSplitTime.Value)
                     newSplitTime = prevSplitTime.Value;
 
@@ -691,7 +691,11 @@ public partial class RunEditorDialog : Form
             segment.SegmentHistory[attemptIndex] = time;
         }
 
-        e.Value = TimeFormatter.Format(newSegmentTime);
+        // Store a TimeSpan matching the column's semantic value (split vs segment time).
+        // This mirrors normal mode (ParseCell returns TimeSpan) and keeps the cell's
+        // underlying value consistent with the column. CellFormatting will reformat
+        // for display via the cache after AfterHistoryEdit invalidates the columns.
+        e.Value = columnIndex == HISTORY_SPLITTIMEINDEX ? newSplitTime : newSegmentTime;
         e.ParsingApplied = true;
         AfterHistoryEdit();
     }
@@ -968,7 +972,6 @@ public partial class RunEditorDialog : Form
             ToDate: toDate,
             Method: method
         );
-        currentFilter = filter;
         _filteredAttempts = RunHistoryService.GetFilteredAttempts(Run, filter);
 
         totalPages = _filteredAttempts.Count == 0 ? 1 : (_filteredAttempts.Count + HistoryPageSize - 1) / HistoryPageSize;
@@ -985,7 +988,7 @@ public partial class RunEditorDialog : Form
             cbxAttemptSelect.Items.Add(new AttemptComboItem(attempt, $"#{attempt.Index} — {timeStr} — {dateStr}"));
         }
 
-        lblPageInfo.Text = $"Page {currentPage} / {totalPages}";
+        lblPageInfo.Text = string.Format(T("Page {0} / {1}"), currentPage, totalPages);
         btnPrevPage.Enabled = currentPage > 1;
         btnNextPage.Enabled = currentPage < totalPages;
 
@@ -1212,6 +1215,18 @@ public partial class RunEditorDialog : Form
 
     private void runGrid_DataError(object sender, DataGridViewDataErrorEventArgs e)
     {
+        // Avoid throwing into the WinForms message loop, but log so real bugs
+        // (e.g. parsing/formatting issues introduced by future changes) are not
+        // silently swallowed.
+        if (e.Exception != null)
+        {
+            Log.Error(e.Exception);
+        }
+        else
+        {
+            Log.Error($"DataGridView data error at row {e.RowIndex}, column {e.ColumnIndex}, context {e.Context}.");
+        }
+
         e.ThrowException = false;
     }
 

--- a/src/LiveSplit.View/View/RunEditorDialog.cs
+++ b/src/LiveSplit.View/View/RunEditorDialog.cs
@@ -36,6 +36,10 @@ public partial class RunEditorDialog : Form
     private const int BESTSEGMENTINDEX = 4;
     private const int CUSTOMCOMPARISONSINDEX = 5;
 
+    private const int HISTORY_SPLITTIMEINDEX = 2;
+    private const int HISTORY_SEGMENTTIMEINDEX = 3;
+    private const int HISTORY_SEGMENTBESTDIFFINDEX = 4;
+
     private const int MAXADDITIONSPERADDRANGE = 1000;
 
     public IRun Run { get; set; }
@@ -47,8 +51,22 @@ public partial class RunEditorDialog : Form
     protected Time PreviousPersonalBestTime;
     private readonly CancellationTokenSource FillCbxGameTaskToken = new();
 
+    private int? SelectedAttemptIndex = null;
+    private IList<TimeSpan?> _cachedSegTimes = null;
+    private IList<TimeSpan?> _cachedSplitTimes = null;
+    private IList<TimeSpan?> _cachedSegmentBestDiffs = null;
+    private int _cacheAttemptIndex = -1;
+    private TimingMethod _cacheMethod;
+
+    private const int HistoryPageSize = 50;
+    private RunHistoryFilter currentFilter = new RunHistoryFilter();
+    private int currentPage = 1;
+    private int totalPages = 1;
+    private IList<Attempt> _filteredAttempts = new List<Attempt>();
+
     protected bool IsGridTab => tabControl.SelectedTab == RealTime || tabControl.SelectedTab == GameTime;
     protected bool IsMetadataTab => tabControl.SelectedTab == Metadata;
+    protected bool IsHistoryMode => pnlHistory.Visible;
 
     public List<Image> ImagesToDispose { get; set; }
 
@@ -149,6 +167,34 @@ public partial class RunEditorDialog : Form
         }
     }
 
+    private class AttemptComboItem
+    {
+        public Attempt Attempt { get; }
+        private readonly string displayText;
+
+        public AttemptComboItem(Attempt attempt, string displayText)
+        {
+            Attempt = attempt;
+            this.displayText = displayText;
+        }
+
+        public override string ToString() => displayText;
+    }
+
+    private class MonthFilterItem
+    {
+        public int Year { get; }
+        public int Month { get; }
+
+        public MonthFilterItem(int year, int month)
+        {
+            Year = year;
+            Month = month;
+        }
+
+        public override string ToString() => $"{Year}/{Month:D2}";
+    }
+
     public RunEditorDialog(LiveSplitState state)
     {
         InitializeComponent();
@@ -180,6 +226,7 @@ public partial class RunEditorDialog : Form
         runGrid.CellValidating += runGrid_CellValidating;
         runGrid.CellEndEdit += runGrid_CellEndEdit;
         runGrid.SelectionChanged += runGrid_SelectionChanged;
+        runGrid.DataError += runGrid_DataError;
 
         var iconColumn = new DataGridViewImageColumn
         {
@@ -194,6 +241,7 @@ public partial class RunEditorDialog : Form
         var column = new DataGridViewTextBoxColumn
         {
             Name = "Segment Name",
+            HeaderText = "Segment Name",
             MinimumWidth = 120,
             SortMode = DataGridViewColumnSortMode.NotSortable
         };
@@ -202,6 +250,7 @@ public partial class RunEditorDialog : Form
         column = new DataGridViewTextBoxColumn
         {
             Name = "Split Time",
+            HeaderText = "Split Time",
             Width = 100,
             AutoSizeMode = DataGridViewAutoSizeColumnMode.None
         };
@@ -212,6 +261,7 @@ public partial class RunEditorDialog : Form
         column = new DataGridViewTextBoxColumn
         {
             Name = "Segment Time",
+            HeaderText = "Segment Time",
             Width = 100,
             AutoSizeMode = DataGridViewAutoSizeColumnMode.None
         };
@@ -222,6 +272,7 @@ public partial class RunEditorDialog : Form
         column = new DataGridViewTextBoxColumn
         {
             Name = "Best Segment",
+            HeaderText = "Best Segment",
             Width = 100,
             AutoSizeMode = DataGridViewAutoSizeColumnMode.None
         };
@@ -251,6 +302,15 @@ public partial class RunEditorDialog : Form
         UpdateSegmentList();
         RefreshAutoSplittingUI();
         SetClickEvents(this);
+
+        cbxAttemptSelect.SelectedIndexChanged += cbxAttemptSelect_SelectedIndexChanged;
+        btnPrevPage.Click += btnPrevPage_Click;
+        btnNextPage.Click += btnNextPage_Click;
+        chkCompletedOnly.CheckedChanged += chkCompletedOnly_CheckedChanged;
+        chkPbSegmentsOnly.CheckedChanged += chkPbSegmentsOnly_CheckedChanged;
+        cbxMonthFilter.SelectedIndexChanged += cbxMonthFilter_SelectedIndexChanged;
+        btnDeleteAttempt.Click += btnDeleteAttempt_Click;
+
         UiLocalizer.Apply(this, LanguageResolver.ResolveCurrentCultureLanguage());
     }
 
@@ -441,14 +501,19 @@ public partial class RunEditorDialog : Form
 
     private void UpdateButtonsStatus()
     {
-        if (!AllowChangingSegments)
+        bool canModifySegments = AllowChangingSegments && !IsHistoryMode;
+
+        btnAdd.Enabled = canModifySegments;
+        btnInsert.Enabled = canModifySegments;
+        btnOther.Enabled = canModifySegments;
+        btnAddComparison.Enabled = canModifySegments;
+        btnImportComparison.Enabled = canModifySegments;
+
+        if (!canModifySegments)
         {
-            btnAdd.Enabled = false;
             btnRemove.Enabled = false;
-            btnInsert.Enabled = false;
             btnMoveDown.Enabled = false;
             btnMoveUp.Enabled = false;
-            btnOther.Enabled = false;
         }
         else
         {
@@ -527,6 +592,12 @@ public partial class RunEditorDialog : Form
 
     private void runGrid_CellParsing(object sender, DataGridViewCellParsingEventArgs e)
     {
+        if (SelectedAttemptIndex != null)
+        {
+            ParseHistoryCell(e.Value, e.RowIndex, e.ColumnIndex, e);
+            return;
+        }
+
         ParsingResults parsingResults = ParseCell(e.Value, e.RowIndex, e.ColumnIndex, true);
         if (parsingResults.Parsed)
         {
@@ -537,6 +608,92 @@ public partial class RunEditorDialog : Form
         {
             e.ParsingApplied = false;
         }
+    }
+
+    private void ParseHistoryCell(object value, int rowIndex, int columnIndex, DataGridViewCellParsingEventArgs e)
+    {
+        if (columnIndex == HISTORY_SEGMENTBESTDIFFINDEX)
+        {
+            e.ParsingApplied = false;
+            return;
+        }
+
+        if (columnIndex == SEGMENTNAMEINDEX)
+        {
+            e.ParsingApplied = false;
+            return;
+        }
+
+        if (columnIndex != HISTORY_SPLITTIMEINDEX && columnIndex != HISTORY_SEGMENTTIMEINDEX)
+        {
+            e.ParsingApplied = false;
+            return;
+        }
+
+        int attemptIndex = SelectedAttemptIndex.Value;
+        TimingMethod method = SelectedMethod;
+        ISegment segment = Run[rowIndex];
+
+        if (string.IsNullOrWhiteSpace(value?.ToString()))
+        {
+            if (segment.SegmentHistory.ContainsKey(attemptIndex))
+            {
+                var time = segment.SegmentHistory[attemptIndex];
+                time[method] = null;
+                segment.SegmentHistory[attemptIndex] = time;
+            }
+
+            e.Value = null;
+            e.ParsingApplied = true;
+            AfterHistoryEdit();
+            return;
+        }
+
+        TimeSpan newSegmentTime;
+
+        try
+        {
+            var parsed = TimeSpanParser.Parse(value.ToString());
+
+            if (columnIndex == HISTORY_SEGMENTTIMEINDEX)
+            {
+                newSegmentTime = parsed;
+            }
+            else
+            {
+                IList<TimeSpan?> splitTimes = HistoryTimeCalculator.GetSplitTimesForAttempt(Run, attemptIndex, method);
+                TimeSpan? prevSplitTime = rowIndex > 0 ? splitTimes[rowIndex - 1] : TimeSpan.Zero;
+                if (prevSplitTime == null)
+                    prevSplitTime = TimeSpan.Zero;
+
+                TimeSpan newSplitTime = parsed;
+                if (newSplitTime < prevSplitTime.Value)
+                    newSplitTime = prevSplitTime.Value;
+
+                newSegmentTime = newSplitTime - prevSplitTime.Value;
+            }
+        }
+        catch
+        {
+            e.ParsingApplied = false;
+            return;
+        }
+
+        if (segment.SegmentHistory.TryGetValue(attemptIndex, out Time existing))
+        {
+            existing[method] = newSegmentTime;
+            segment.SegmentHistory[attemptIndex] = existing;
+        }
+        else
+        {
+            var time = new Time();
+            time[method] = newSegmentTime;
+            segment.SegmentHistory[attemptIndex] = time;
+        }
+
+        e.Value = TimeFormatter.Format(newSegmentTime);
+        e.ParsingApplied = true;
+        AfterHistoryEdit();
     }
 
     private ParsingResults ParseCell(object value, int rowIndex, int columnIndex, bool shouldFix)
@@ -636,10 +793,357 @@ public partial class RunEditorDialog : Form
         return new ParsingResults(false, null);
     }
 
+    private void InvalidateHistoryCache()
+    {
+        _cacheAttemptIndex = -1;
+        _cachedSegTimes = null;
+        _cachedSplitTimes = null;
+        _cachedSegmentBestDiffs = null;
+    }
+
+    private void AfterHistoryEdit()
+    {
+        InvalidateHistoryCache();
+        Run.FixSplits();
+        RaiseRunEdited();
+        runGrid.InvalidateColumn(HISTORY_SPLITTIMEINDEX);
+        runGrid.InvalidateColumn(HISTORY_SEGMENTTIMEINDEX);
+        runGrid.InvalidateColumn(HISTORY_SEGMENTBESTDIFFINDEX);
+    }
+
+    private void EnsureHistoryCache()
+    {
+        if (_cacheAttemptIndex == SelectedAttemptIndex.Value && _cacheMethod == SelectedMethod)
+            return;
+        _cacheAttemptIndex = SelectedAttemptIndex.Value;
+        _cacheMethod = SelectedMethod;
+        _cachedSegTimes = HistoryTimeCalculator.GetSegmentTimesForAttempt(Run, _cacheAttemptIndex, _cacheMethod);
+        _cachedSplitTimes = HistoryTimeCalculator.GetSplitTimesForAttempt(Run, _cacheAttemptIndex, _cacheMethod);
+        _cachedSegmentBestDiffs = HistoryTimeCalculator.GetSegmentBestDiffsForAttempt(Run, _cacheAttemptIndex, _cacheMethod);
+    }
+
+    private void SwitchToHistoryMode(int attemptIndex)
+    {
+        InvalidateHistoryCache();
+
+        // Remove columns beyond Segment Name (keep Icon=0, SegmentName=1)
+        while (runGrid.Columns.Count > 2)
+            runGrid.Columns.RemoveAt(2);
+
+        // Add Split Time column
+        var splitCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Split Time",
+            HeaderText = T("Split Time"),
+            Width = 100,
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        splitCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+        runGrid.Columns.Add(splitCol);
+
+        // Add Segment Time column
+        var segCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Segment Time",
+            HeaderText = T("Segment Time"),
+            Width = 100,
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        segCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+        runGrid.Columns.Add(segCol);
+
+        // Add Best Segment Diff column (read-only)
+        var diffCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Best Segment Diff",
+            HeaderText = T("Best Segment Diff"),
+            Width = 120,
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            ReadOnly = true,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        diffCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+        runGrid.Columns.Add(diffCol);
+
+        // Make Segment Name read-only in history mode
+        runGrid.Columns[SEGMENTNAMEINDEX].ReadOnly = true;
+
+        // Set history mode AFTER columns are fully configured
+        // (prevents intermediate repaints from using history formatter with wrong column state)
+        SelectedAttemptIndex = attemptIndex;
+        InvalidateHistoryCache();
+        runGrid.Invalidate();
+    }
+
+    private void SwitchToNormalMode()
+    {
+        SelectedAttemptIndex = null;
+        InvalidateHistoryCache();
+
+        // Remove all columns after Icon
+        while (runGrid.Columns.Count > 1)
+            runGrid.Columns.RemoveAt(1);
+
+        // Restore normal columns (matching constructor column setup)
+        var segNameCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Segment Name",
+            HeaderText = T("Segment Name"),
+            MinimumWidth = 120,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        runGrid.Columns.Add(segNameCol);
+
+        var splitCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Split Time",
+            HeaderText = T("Split Time"),
+            Width = 100,
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        splitCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+        runGrid.Columns.Add(splitCol);
+
+        var segCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Segment Time",
+            HeaderText = T("Segment Time"),
+            Width = 100,
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        segCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+        runGrid.Columns.Add(segCol);
+
+        var bestCol = new DataGridViewTextBoxColumn
+        {
+            Name = "Best Segment",
+            HeaderText = T("Best Segment"),
+            Width = 100,
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            SortMode = DataGridViewColumnSortMode.NotSortable
+        };
+        bestCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+        runGrid.Columns.Add(bestCol);
+
+        // Restore segment name column editability
+        runGrid.Columns[SEGMENTNAMEINDEX].ReadOnly = false;
+
+        // Re-add custom comparison columns (from Run.CustomComparisons)
+        foreach (string comparison in Run.CustomComparisons)
+        {
+            if (comparison == Model.Run.PersonalBestComparisonName) continue;
+            var customCol = new DataGridViewTextBoxColumn
+            {
+                Name = comparison,
+                HeaderText = comparison,
+                Width = 100,
+                AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+                SortMode = DataGridViewColumnSortMode.NotSortable
+            };
+            customCol.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+            runGrid.Columns.Add(customCol);
+        }
+
+        runGrid.Invalidate();
+    }
+
+    private void RefreshHistoryList()
+    {
+        var method = SelectedMethod;
+        DateTime? fromDate = null;
+        DateTime? toDate = null;
+        if (cbxMonthFilter.SelectedItem is MonthFilterItem selectedMonth)
+        {
+            fromDate = new DateTime(selectedMonth.Year, selectedMonth.Month, 1);
+            toDate = fromDate.Value.AddMonths(1).AddTicks(-1);
+        }
+        var filter = new RunHistoryFilter(
+            CompletedOnly: chkCompletedOnly.Checked,
+            PbSegmentsOnly: chkPbSegmentsOnly.Checked,
+            FromDate: fromDate,
+            ToDate: toDate,
+            Method: method
+        );
+        currentFilter = filter;
+        _filteredAttempts = RunHistoryService.GetFilteredAttempts(Run, filter);
+
+        totalPages = _filteredAttempts.Count == 0 ? 1 : (_filteredAttempts.Count + HistoryPageSize - 1) / HistoryPageSize;
+        if (currentPage > totalPages) currentPage = totalPages;
+        if (currentPage < 1) currentPage = 1;
+
+        var pageAttempts = RunHistoryService.GetPage(_filteredAttempts, currentPage, HistoryPageSize);
+
+        cbxAttemptSelect.Items.Clear();
+        foreach (var attempt in pageAttempts)
+        {
+            string timeStr = attempt.Time[method] != null ? TimeFormatter.Format(attempt.Time[method].Value) : "—";
+            string dateStr = attempt.Started.HasValue ? attempt.Started.Value.Time.ToString("yyyy/MM/dd") : "—";
+            cbxAttemptSelect.Items.Add(new AttemptComboItem(attempt, $"#{attempt.Index} — {timeStr} — {dateStr}"));
+        }
+
+        lblPageInfo.Text = $"Page {currentPage} / {totalPages}";
+        btnPrevPage.Enabled = currentPage > 1;
+        btnNextPage.Enabled = currentPage < totalPages;
+
+        if (cbxAttemptSelect.Items.Count > 0)
+        {
+            cbxAttemptSelect.SelectedIndex = 0;
+            // SwitchToHistoryMode will be called by cbxAttemptSelect.SelectedIndexChanged
+        }
+        else
+        {
+            cbxAttemptSelect.Text = T("No matching attempts");
+            btnDeleteAttempt.Enabled = false;
+        }
+    }
+
+    private void cbxAttemptSelect_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cbxAttemptSelect.SelectedItem is AttemptComboItem item)
+        {
+            SwitchToHistoryMode(item.Attempt.Index);
+            btnDeleteAttempt.Enabled = true;
+        }
+        else
+        {
+            btnDeleteAttempt.Enabled = false;
+        }
+    }
+
+    private void btnPrevPage_Click(object sender, EventArgs e)
+    {
+        if (currentPage > 1)
+        {
+            currentPage--;
+            RefreshHistoryList();
+        }
+    }
+
+    private void btnNextPage_Click(object sender, EventArgs e)
+    {
+        if (currentPage < totalPages)
+        {
+            currentPage++;
+            RefreshHistoryList();
+        }
+    }
+
+    private void chkCompletedOnly_CheckedChanged(object sender, EventArgs e)
+    {
+        currentPage = 1;
+        RefreshHistoryList();
+    }
+
+    private void chkPbSegmentsOnly_CheckedChanged(object sender, EventArgs e)
+    {
+        currentPage = 1;
+        RefreshHistoryList();
+    }
+
+    private void cbxMonthFilter_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        currentPage = 1;
+        RefreshHistoryList();
+    }
+
+    private void PopulateMonthFilter()
+    {
+        cbxMonthFilter.SelectedIndexChanged -= cbxMonthFilter_SelectedIndexChanged;
+
+        var previousMonth = cbxMonthFilter.SelectedItem as MonthFilterItem;
+
+        cbxMonthFilter.Items.Clear();
+        cbxMonthFilter.Items.Add("All");
+
+        var months = Run.AttemptHistory
+            .Where(a => a.Started.HasValue)
+            .Select(a => new { a.Started.Value.Time.Year, a.Started.Value.Time.Month })
+            .Distinct()
+            .OrderByDescending(m => m.Year)
+            .ThenByDescending(m => m.Month)
+            .ToList();
+
+        foreach (var m in months)
+            cbxMonthFilter.Items.Add(new MonthFilterItem(m.Year, m.Month));
+
+        bool restored = false;
+        if (previousMonth != null)
+        {
+            foreach (var item in cbxMonthFilter.Items)
+            {
+                if (item is MonthFilterItem mfi && mfi.Year == previousMonth.Year && mfi.Month == previousMonth.Month)
+                {
+                    cbxMonthFilter.SelectedItem = item;
+                    restored = true;
+                    break;
+                }
+            }
+        }
+        if (!restored)
+            cbxMonthFilter.SelectedIndex = 0;
+
+        cbxMonthFilter.SelectedIndexChanged += cbxMonthFilter_SelectedIndexChanged;
+    }
+
     private void runGrid_CellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
     {
         if (e.RowIndex < Run.Count)
         {
+            if (SelectedAttemptIndex != null)
+            {
+                // History mode formatting
+                if (e.ColumnIndex == ICONINDEX)
+                {
+                    e.Value = Run[e.RowIndex].Icon;
+                    return;
+                }
+                if (e.ColumnIndex == SEGMENTNAMEINDEX)
+                {
+                    e.Value = Run[e.RowIndex].Name;
+                    e.FormattingApplied = true;
+                    return;
+                }
+                if (e.ColumnIndex == HISTORY_SPLITTIMEINDEX || e.ColumnIndex == HISTORY_SEGMENTTIMEINDEX || e.ColumnIndex == HISTORY_SEGMENTBESTDIFFINDEX)
+                {
+                    EnsureHistoryCache();
+                    TimeSpan? value = null;
+                    if (e.ColumnIndex == HISTORY_SPLITTIMEINDEX && _cachedSplitTimes != null)
+                        value = _cachedSplitTimes[e.RowIndex];
+                    else if (e.ColumnIndex == HISTORY_SEGMENTTIMEINDEX && _cachedSegTimes != null)
+                        value = _cachedSegTimes[e.RowIndex];
+                    else if (e.ColumnIndex == HISTORY_SEGMENTBESTDIFFINDEX && _cachedSegmentBestDiffs != null)
+                        value = _cachedSegmentBestDiffs[e.RowIndex];
+
+                    if (value == null)
+                    {
+                        e.Value = "";
+                        e.FormattingApplied = true;
+                    }
+                    else if (e.ColumnIndex == HISTORY_SEGMENTBESTDIFFINDEX)
+                    {
+                        // Format Best Segment diff with sign
+                        string sign = value.Value >= TimeSpan.Zero ? "+" : "-";
+                        e.Value = sign + TimeFormatter.Format(value.Value.Duration());
+                        // Color: positive = red (slower), negative = green (faster)
+                        e.CellStyle.ForeColor = value.Value >= TimeSpan.Zero
+                            ? Color.FromArgb(204, 52, 44)
+                            : Color.FromArgb(26, 160, 64);
+                        e.FormattingApplied = true;
+                    }
+                    else
+                    {
+                        e.Value = TimeFormatter.Format(value.Value);
+                        e.FormattingApplied = true;
+                    }
+                    return;
+                }
+                return; // Other columns in history mode: show nothing
+            }
+
             if (e.ColumnIndex == SPLITTIMEINDEX)
             {
                 TimeSpan? comparisonValue = Run[e.RowIndex].PersonalBestSplitTime[SelectedMethod];
@@ -704,6 +1208,11 @@ public partial class RunEditorDialog : Form
                 e.Value = Run[e.RowIndex].Icon;
             }
         }
+    }
+
+    private void runGrid_DataError(object sender, DataGridViewDataErrorEventArgs e)
+    {
+        e.ThrowException = false;
     }
 
     private void runGrid_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
@@ -1638,6 +2147,11 @@ public partial class RunEditorDialog : Form
             tableLayoutPanel1.SetRowSpan(tabControl, 1);
             runGrid.Visible = true;
             runGrid.Invalidate();
+            if (IsHistoryMode)
+            {
+                InvalidateHistoryCache();
+                runGrid.Invalidate();
+            }
         }
         else
         {
@@ -1958,6 +2472,53 @@ public partial class RunEditorDialog : Form
     private void cbxGameName_Validated(object sender, EventArgs e)
     {
         GameName = cbxGameName.Text;
+    }
+
+    private void btnDeleteAttempt_Click(object sender, EventArgs e)
+    {
+        if (!(cbxAttemptSelect.SelectedItem is AttemptComboItem item))
+            return;
+
+        int attemptIndex = item.Attempt.Index;
+        DialogResult result = MessageBox.Show(
+            string.Format(T("Are you sure you want to delete attempt #{0}?"), attemptIndex),
+            T("Confirm Deletion"),
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Warning);
+
+        if (result != DialogResult.Yes)
+            return;
+
+        AttemptDeletionHelper.DeleteAttempt(Run, attemptIndex);
+        Run.FixSplits();
+        RaiseRunEdited();
+        PopulateMonthFilter();
+        RefreshHistoryList();
+
+        // If no more attempts, exit history mode
+        if (cbxAttemptSelect.Items.Count == 0)
+        {
+            SwitchToNormalMode();
+        }
+    }
+
+    private void btnToggleHistory_Click(object sender, EventArgs e)
+    {
+        bool show = !pnlHistory.Visible;
+        tableLayoutPanel1.RowStyles[6].Height = show ? 60F : 0F;
+        pnlHistory.Visible = show;
+        btnToggleHistory.Text = show ? T("History ▲") : T("History ▼");
+        if (show)
+        {
+            currentPage = 1;
+            PopulateMonthFilter();
+            RefreshHistoryList();
+        }
+        else
+        {
+            SwitchToNormalMode();
+        }
+        UpdateButtonsStatus();
     }
 
     private void RunEditorDialog_FormClosing(object sender, FormClosingEventArgs e)

--- a/test/LiveSplit.Tests/Model/AttemptDeletionHelperMust.cs
+++ b/test/LiveSplit.Tests/Model/AttemptDeletionHelperMust.cs
@@ -1,0 +1,75 @@
+using System;
+
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+
+using Xunit;
+
+namespace LiveSplit.Tests.Model;
+
+public class AttemptDeletionHelperMust
+{
+    private static readonly TimeSpan _anyTime = TimeSpan.FromSeconds(30);
+
+    private static IRun CreateRunWith5Attempts()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1"),
+            new Segment("S2")
+        };
+
+        for (int a = 1; a <= 5; a++)
+        {
+            run[0].SegmentHistory[a] = new Time(TimingMethod.RealTime, _anyTime);
+            run[1].SegmentHistory[a] = new Time(TimingMethod.RealTime, _anyTime);
+            run.AttemptHistory.Add(new Attempt(a, new Time(TimingMethod.RealTime, _anyTime + _anyTime), null, null, null));
+        }
+
+        return run;
+    }
+
+    [Fact]
+    public void RemoveAttemptFromHistory()
+    {
+        IRun run = CreateRunWith5Attempts();
+        AttemptDeletionHelper.DeleteAttempt(run, 3);
+
+        Assert.Equal(4, run.AttemptHistory.Count);
+        Assert.DoesNotContain(run.AttemptHistory, a => a.Index == 3);
+    }
+
+    [Fact]
+    public void RemoveFromAllSegmentHistories()
+    {
+        IRun run = CreateRunWith5Attempts();
+        AttemptDeletionHelper.DeleteAttempt(run, 3);
+
+        Assert.False(run[0].SegmentHistory.ContainsKey(3));
+        Assert.False(run[1].SegmentHistory.ContainsKey(3));
+    }
+
+    [Fact]
+    public void NotAffectOtherAttempts()
+    {
+        IRun run = CreateRunWith5Attempts();
+        AttemptDeletionHelper.DeleteAttempt(run, 3);
+
+        Assert.True(run[0].SegmentHistory.ContainsKey(1));
+        Assert.True(run[0].SegmentHistory.ContainsKey(2));
+        Assert.True(run[0].SegmentHistory.ContainsKey(4));
+        Assert.True(run[0].SegmentHistory.ContainsKey(5));
+        Assert.Equal(4, run.AttemptHistory.Count);
+    }
+
+    [Fact]
+    public void HandleNonExistentAttempt()
+    {
+        IRun run = CreateRunWith5Attempts();
+        // Should not throw
+        AttemptDeletionHelper.DeleteAttempt(run, 999);
+
+        // Data unchanged
+        Assert.Equal(5, run.AttemptHistory.Count);
+    }
+}

--- a/test/LiveSplit.Tests/Model/HistoryTimeCalculatorMust.cs
+++ b/test/LiveSplit.Tests/Model/HistoryTimeCalculatorMust.cs
@@ -128,7 +128,7 @@ public class HistoryTimeCalculatorMust
     }
 
     [Fact]
-    public void PropagatNullWhenMethodValueAbsent()
+    public void PropagateNullWhenMethodValueAbsent()
     {
         // Key exists in SegmentHistory but GameTime value is null (RealTime-only recording)
         // When viewing under GameTime: null must propagate — subsequent segments should also be null

--- a/test/LiveSplit.Tests/Model/HistoryTimeCalculatorMust.cs
+++ b/test/LiveSplit.Tests/Model/HistoryTimeCalculatorMust.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+
+using Xunit;
+
+namespace LiveSplit.Tests.Model;
+
+public class HistoryTimeCalculatorMust
+{
+    private static readonly TimeSpan _seg1 = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan _seg2 = TimeSpan.FromSeconds(45);
+    private static readonly TimeSpan _seg3 = TimeSpan.FromSeconds(60);
+
+    private static IRun CreateThreeSegmentRun()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1"),
+            new Segment("S2"),
+            new Segment("S3")
+        };
+        // PB split times: 30s, 1:15, 2:15
+        run[0].PersonalBestSplitTime = new Time(TimingMethod.RealTime, _seg1);
+        run[1].PersonalBestSplitTime = new Time(TimingMethod.RealTime, _seg1 + _seg2);
+        run[2].PersonalBestSplitTime = new Time(TimingMethod.RealTime, _seg1 + _seg2 + _seg3);
+        // Attempt #1: seg times = 30, 45, 60
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg1);
+        run[1].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg2);
+        run[2].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg3);
+        return run;
+    }
+
+    [Fact]
+    public void CalculateSplitTimesCorrectly()
+    {
+        IRun run = CreateThreeSegmentRun();
+        IList<TimeSpan?> splitTimes = HistoryTimeCalculator.GetSplitTimesForAttempt(run, 1, TimingMethod.RealTime);
+
+        Assert.Equal(3, splitTimes.Count);
+        Assert.Equal(_seg1, splitTimes[0]);
+        Assert.Equal(_seg1 + _seg2, splitTimes[1]);
+        Assert.Equal(_seg1 + _seg2 + _seg3, splitTimes[2]);
+    }
+
+    [Fact]
+    public void CalculateSegmentTimesCorrectly()
+    {
+        IRun run = CreateThreeSegmentRun();
+        IList<TimeSpan?> segTimes = HistoryTimeCalculator.GetSegmentTimesForAttempt(run, 1, TimingMethod.RealTime);
+
+        Assert.Equal(3, segTimes.Count);
+        Assert.Equal(_seg1, segTimes[0]);
+        Assert.Equal(_seg2, segTimes[1]);
+        Assert.Equal(_seg3, segTimes[2]);
+    }
+
+    [Fact]
+    public void HandleSparseData()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1"),
+            new Segment("S2"),
+            new Segment("S3")
+        };
+        // Attempt #2 only has first 2 segments (reset at segment 3)
+        run[0].SegmentHistory[2] = new Time(TimingMethod.RealTime, _seg1);
+        run[1].SegmentHistory[2] = new Time(TimingMethod.RealTime, _seg2);
+        // Segment 3 has no entry for attempt 2
+
+        IList<TimeSpan?> segTimes = HistoryTimeCalculator.GetSegmentTimesForAttempt(run, 2, TimingMethod.RealTime);
+        IList<TimeSpan?> splitTimes = HistoryTimeCalculator.GetSplitTimesForAttempt(run, 2, TimingMethod.RealTime);
+
+        Assert.Equal(_seg1, segTimes[0]);
+        Assert.Equal(_seg2, segTimes[1]);
+        Assert.Null(segTimes[2]);
+
+        Assert.Equal(_seg1, splitTimes[0]);
+        Assert.Equal(_seg1 + _seg2, splitTimes[1]);
+        Assert.Null(splitTimes[2]);
+    }
+
+    [Fact]
+    public void CalculateSegmentBestDiffCorrectly()
+    {
+        // BestSegmentTime: 30, 45, 60
+        // Attempt segment times: 28, 52, 60
+        // Expected diffs: -2, +7, 0
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1"),
+            new Segment("S2"),
+            new Segment("S3")
+        };
+        run[0].BestSegmentTime = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(30));
+        run[1].BestSegmentTime = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(45));
+        run[2].BestSegmentTime = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(60));
+
+        run[0].SegmentHistory[3] = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(28));
+        run[1].SegmentHistory[3] = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(52));
+        run[2].SegmentHistory[3] = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(60));
+
+        IList<TimeSpan?> diffs = HistoryTimeCalculator.GetSegmentBestDiffsForAttempt(run, 3, TimingMethod.RealTime);
+
+        Assert.Equal(3, diffs.Count);
+        Assert.Equal(TimeSpan.FromSeconds(-2), diffs[0]); // 28 - 30 = -2s (faster)
+        Assert.Equal(TimeSpan.FromSeconds(7), diffs[1]);  // 52 - 45 = +7s (slower)
+        Assert.Equal(TimeSpan.Zero, diffs[2]);            // 60 - 60 = 0s (matched best)
+    }
+
+    [Fact]
+    public void HandleNullBestSegmentTime()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1")
+        };
+        // No BestSegmentTime set (null)
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg1);
+
+        IList<TimeSpan?> diffs = HistoryTimeCalculator.GetSegmentBestDiffsForAttempt(run, 1, TimingMethod.RealTime);
+
+        Assert.Single(diffs);
+        Assert.Null(diffs[0]); // diff is null when BestSegmentTime is null
+    }
+
+    [Fact]
+    public void PropagatNullWhenMethodValueAbsent()
+    {
+        // Key exists in SegmentHistory but GameTime value is null (RealTime-only recording)
+        // When viewing under GameTime: null must propagate — subsequent segments should also be null
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1"),
+            new Segment("S2"),
+            new Segment("S3")
+        };
+
+        // Attempt 1: all segments have RealTime but NOT GameTime
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg1); // GameTime = null
+        run[1].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg2); // GameTime = null
+        run[2].SegmentHistory[1] = new Time(TimingMethod.RealTime, _seg3); // GameTime = null
+
+        IList<TimeSpan?> splitTimes = HistoryTimeCalculator.GetSplitTimesForAttempt(run, 1, TimingMethod.GameTime);
+
+        // All split times must be null because GameTime is absent in each history entry
+        Assert.Null(splitTimes[0]);
+        Assert.Null(splitTimes[1]);
+        Assert.Null(splitTimes[2]);
+    }
+}

--- a/test/LiveSplit.Tests/Model/RunHistoryServiceMust.cs
+++ b/test/LiveSplit.Tests/Model/RunHistoryServiceMust.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+
+using Xunit;
+
+namespace LiveSplit.Tests.Model;
+
+public class RunHistoryServiceMust
+{
+    private static readonly TimeSpan _anySegTime = TimeSpan.FromSeconds(30);
+
+    private static IRun CreateRun(int segmentCount, int attemptCount, TimeSpan segmentTime)
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory());
+        for (int s = 0; s < segmentCount; s++)
+        {
+            var segment = new Segment($"Segment {s + 1}");
+            run.Add(segment);
+        }
+
+        TimeSpan cumulative = TimeSpan.Zero;
+        for (int s = 0; s < segmentCount; s++)
+        {
+            cumulative += segmentTime;
+            run[s].PersonalBestSplitTime = new Time(TimingMethod.RealTime, cumulative);
+            run[s].BestSegmentTime = new Time(TimingMethod.RealTime, segmentTime);
+        }
+
+        for (int a = 1; a <= attemptCount; a++)
+        {
+            TimeSpan total = TimeSpan.Zero;
+            for (int s = 0; s < segmentCount; s++)
+            {
+                run[s].SegmentHistory[a] = new Time(TimingMethod.RealTime, segmentTime);
+                total += segmentTime;
+            }
+
+            run.AttemptHistory.Add(new Attempt(a, new Time(TimingMethod.RealTime, total), null, null, null));
+        }
+
+        return run;
+    }
+
+    [Fact]
+    public void FilterCompletedRunsOnly()
+    {
+        IRun run = CreateRun(3, 0, _anySegTime);
+
+        // Attempt 1: completed
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, _anySegTime);
+        run[1].SegmentHistory[1] = new Time(TimingMethod.RealTime, _anySegTime);
+        run[2].SegmentHistory[1] = new Time(TimingMethod.RealTime, _anySegTime);
+        run.AttemptHistory.Add(new Attempt(1, new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(90)), null, null, null));
+
+        // Attempt 2: not completed (no final time)
+        run[0].SegmentHistory[2] = new Time(TimingMethod.RealTime, _anySegTime);
+        run.AttemptHistory.Add(new Attempt(2, new Time(), null, null, null));
+
+        // Attempt 3: completed
+        run[0].SegmentHistory[3] = new Time(TimingMethod.RealTime, _anySegTime);
+        run[1].SegmentHistory[3] = new Time(TimingMethod.RealTime, _anySegTime);
+        run[2].SegmentHistory[3] = new Time(TimingMethod.RealTime, _anySegTime);
+        run.AttemptHistory.Add(new Attempt(3, new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(90)), null, null, null));
+
+        var filter = new RunHistoryFilter(CompletedOnly: true, Method: TimingMethod.RealTime);
+        IList<Attempt> result = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        Assert.Equal(2, result.Count);
+        Assert.DoesNotContain(result, a => a.Index == 2);
+    }
+
+    [Fact]
+    public void ReturnAllWhenNoFilters()
+    {
+        IRun run = CreateRun(2, 5, _anySegTime);
+        var filter = new RunHistoryFilter();
+        IList<Attempt> result = RunHistoryService.GetFilteredAttempts(run, filter);
+        Assert.Equal(5, result.Count);
+    }
+
+    [Fact]
+    public void ReturnAttemptsSortedByIndexDescending()
+    {
+        IRun run = CreateRun(2, 3, _anySegTime);
+        var filter = new RunHistoryFilter();
+        IList<Attempt> result = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        Assert.Equal(3, result[0].Index);
+        Assert.Equal(2, result[1].Index);
+        Assert.Equal(1, result[2].Index);
+    }
+
+    [Fact]
+    public void PaginateCorrectly()
+    {
+        IRun run = CreateRun(1, 25, _anySegTime);
+        var filter = new RunHistoryFilter();
+        IList<Attempt> all = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        IList<Attempt> page1 = RunHistoryService.GetPage(all, 1, 10);
+        IList<Attempt> page2 = RunHistoryService.GetPage(all, 2, 10);
+        IList<Attempt> page3 = RunHistoryService.GetPage(all, 3, 10);
+
+        Assert.Equal(10, page1.Count);
+        Assert.Equal(10, page2.Count);
+        Assert.Equal(5, page3.Count);
+    }
+
+    [Fact]
+    public void HandleLastPageWithFewerItems()
+    {
+        IRun run = CreateRun(1, 7, _anySegTime);
+        var filter = new RunHistoryFilter();
+        IList<Attempt> all = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        IList<Attempt> page2 = RunHistoryService.GetPage(all, 2, 5);
+        Assert.Equal(2, page2.Count);
+    }
+
+    [Fact]
+    public void ReturnEmptyForOutOfRangePage()
+    {
+        IRun run = CreateRun(1, 5, _anySegTime);
+        var filter = new RunHistoryFilter();
+        IList<Attempt> all = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        IList<Attempt> result = RunHistoryService.GetPage(all, 99, 10);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterPbSegmentsOnly()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory());
+        var seg = new Segment("S1");
+        run.Add(seg);
+
+        var bestTime = TimeSpan.FromSeconds(25);
+        run[0].BestSegmentTime = new Time(TimingMethod.RealTime, bestTime);
+
+        // Attempt 1: segment time equals best segment (is a PB segment)
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, bestTime);
+        run.AttemptHistory.Add(new Attempt(1, new Time(TimingMethod.RealTime, bestTime), null, null, null));
+
+        // Attempt 2: segment time does not match
+        run[0].SegmentHistory[2] = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(40));
+        run.AttemptHistory.Add(new Attempt(2, new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(40)), null, null, null));
+
+        var filter = new RunHistoryFilter(PbSegmentsOnly: true, Method: TimingMethod.RealTime);
+        IList<Attempt> result = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Index);
+    }
+
+    [Fact]
+    public void CombineFiltersWithAndLogic()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1")
+        };
+        var bestTime = TimeSpan.FromSeconds(25);
+        run[0].BestSegmentTime = new Time(TimingMethod.RealTime, bestTime);
+
+        // Attempt 1: completed AND has PB segment
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, bestTime);
+        run.AttemptHistory.Add(new Attempt(1, new Time(TimingMethod.RealTime, bestTime), null, null, null));
+
+        // Attempt 2: completed but NO PB segment
+        run[0].SegmentHistory[2] = new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(40));
+        run.AttemptHistory.Add(new Attempt(2, new Time(TimingMethod.RealTime, TimeSpan.FromSeconds(40)), null, null, null));
+
+        // Attempt 3: has PB segment but NOT completed
+        run[0].SegmentHistory[3] = new Time(TimingMethod.RealTime, bestTime);
+        run.AttemptHistory.Add(new Attempt(3, new Time(), null, null, null));
+
+        var filter = new RunHistoryFilter(CompletedOnly: true, PbSegmentsOnly: true, Method: TimingMethod.RealTime);
+        IList<Attempt> result = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Index);
+    }
+
+    [Fact]
+    public void FilterByDateRange()
+    {
+        var run = new Run(new StandardComparisonGeneratorsFactory())
+        {
+            new Segment("S1")
+        };
+        run[0].SegmentHistory[1] = new Time(TimingMethod.RealTime, _anySegTime);
+        run[0].SegmentHistory[2] = new Time(TimingMethod.RealTime, _anySegTime);
+        run[0].SegmentHistory[3] = new Time(TimingMethod.RealTime, _anySegTime);
+
+        var jan2024 = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var feb2024 = new DateTime(2024, 2, 15, 0, 0, 0, DateTimeKind.Utc);
+        var mar2024 = new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        run.AttemptHistory.Add(new Attempt(1, new Time(TimingMethod.RealTime, _anySegTime), new AtomicDateTime(jan2024, false), null, null));
+        run.AttemptHistory.Add(new Attempt(2, new Time(TimingMethod.RealTime, _anySegTime), new AtomicDateTime(feb2024, false), null, null));
+        run.AttemptHistory.Add(new Attempt(3, new Time(TimingMethod.RealTime, _anySegTime), new AtomicDateTime(mar2024, false), null, null));
+
+        // Filter to only include Feb 2024
+        var filter = new RunHistoryFilter(
+            FromDate: new DateTime(2024, 2, 1),
+            ToDate: new DateTime(2024, 2, 28, 23, 59, 59),
+            Method: TimingMethod.RealTime
+        );
+        IList<Attempt> result = RunHistoryService.GetFilteredAttempts(run, filter);
+
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Index);
+    }
+}


### PR DESCRIPTION
## Changes

- Add RunHistoryService (filtering by completion/segment-best/date, pagination)
- Add HistoryTimeCalculator (split times, segment best diff per segment)
- Add AttemptDeletionHelper (cascade remove from AttemptHistory + SegmentHistory)
- Embed history panel in RunEditorDialog: two-row navigation panel with month filter dropdown, attempt selector, pagination, Completed/Has Segment Best checkboxes, and Delete button
- History mode DataGridView columns: Split Time, Segment Time, Segment Best Diff (diff = segment time vs BestSegmentTime, colored red/green)
- In-place editing of segment times in history mode with BestSegment recalc
- 19 unit tests covering data layer (RunHistoryServiceMust, HistoryTimeCalculatorMust, AttemptDeletionHelperMust)
- Simplified Chinese translations for all new UI strings (zh-CN.json)

## Why

I need this feature in some scenes:
- Sometimes I did a test using practice tool, which generates bad data that should be deleted
- Need to tweak some segments in a run in order not to accumulate `Best Segment`s to a wrong `Sum of Best`, especially when I changed my route in a trial run (this is why there is a filter button `Has Best Segment`)

## How to test the new feature

`Edit Splits` -> Click `History` button