### PR TITLE
Fix layout settings cancel and font panel layout

### DIFF
--- a/src/LiveSplit.View/View/LayoutSettingsDialog.Designer.cs
+++ b/src/LiveSplit.View/View/LayoutSettingsDialog.Designer.cs
@@ -85,7 +85,7 @@
             this.Controls.Add(this.tableLayoutPanel3);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximumSize = new System.Drawing.Size(520, 10000);
-            this.MinimumSize = new System.Drawing.Size(520, 674);
+            this.MinimumSize = new System.Drawing.Size(520, 703);
             this.Name = "LayoutSettingsDialog";
             this.Padding = new System.Windows.Forms.Padding(7);
             this.Text = "Layout Settings";

--- a/src/LiveSplit.View/View/LayoutSettingsDialog.cs
+++ b/src/LiveSplit.View/View/LayoutSettingsDialog.cs
@@ -63,26 +63,19 @@ public partial class LayoutSettingsDialog : Form
             Components[i].SetSettings(ComponentSettings[i]);
         }
 
-        // Restore font overrides from snapshots, disposing fonts set during the dialog session
+        // Restore font overrides from snapshots.
+        //
+        // Do not dispose the live current fonts here. The snapshot was produced
+        // by FontOverrides.Clone(), so its font objects are different references
+        // from the current ones even when the user changed nothing. Disposing on
+        // reference inequality would therefore dispose the live overrides
+        // unconditionally. Those Font objects can still be aliased into
+        // LayoutSettings.*Font (via FontOverrides.ApplyTo) and captured by
+        // component fields or label caches during render/update.
         for (int i = 0; i < _layoutComponents.Count; i++)
         {
             FontOverrides snapshot = _fontOverrideSnapshots[i];
             FontOverrides current = _layoutComponents[i].FontOverrides;
-
-            if (current.TimerFont != snapshot.TimerFont)
-            {
-                current.TimerFont?.Dispose();
-            }
-
-            if (current.TimesFont != snapshot.TimesFont)
-            {
-                current.TimesFont?.Dispose();
-            }
-
-            if (current.TextFont != snapshot.TextFont)
-            {
-                current.TextFont?.Dispose();
-            }
 
             current.OverrideTimerFont = snapshot.OverrideTimerFont;
             current.TimerFont = snapshot.TimerFont?.Clone() as Font;
@@ -124,15 +117,20 @@ public partial class LayoutSettingsDialog : Form
                 Control tabContent;
                 if (settingsControl != null && showFontPanel)
                 {
-                    // Both: stack font panel above settings
-                    var container = new Panel { Dock = DockStyle.Fill };
-                    var fontPanel = new FontOverridePanel();
-                    fontPanel.Bind(lc.FontOverrides, Layout.Settings, usedFonts);
-                    fontPanel.Dock = DockStyle.Top;
-                    container.Controls.Add(settingsControl);
-                    settingsControl.Dock = DockStyle.Fill;
-                    container.Controls.Add(fontPanel);
-                    tabContent = container;
+                    AddSettingsWithFontOverrideTab(
+                        component.ComponentName,
+                        settingsControl,
+                        lc.FontOverrides,
+                        usedFonts);
+                    ComponentSettings.Add(component.GetSettings(new XmlDocument()));
+                    Components.Add(component);
+
+                    if (component == tabComponent)
+                    {
+                        tabControl.SelectTab(tabControl.TabPages.Count - 1);
+                    }
+
+                    continue;
                 }
                 else if (showFontPanel)
                 {
@@ -165,6 +163,35 @@ public partial class LayoutSettingsDialog : Form
         page.Controls.Add(control);
         page.AutoScroll = true;
         page.Name = name;
+        tabControl.TabPages.Add(page);
+    }
+
+    protected void AddSettingsWithFontOverrideTab(
+        string name,
+        Control settingsControl,
+        FontOverrides fontOverrides,
+        GlobalFont usedFonts)
+    {
+        var page = new TabPage(name)
+        {
+            AutoScroll = true,
+            Name = name,
+        };
+
+        var fontPanel = new FontOverridePanel();
+        fontPanel.Bind(fontOverrides, Layout.Settings, usedFonts);
+        fontPanel.Location = new Point(0, 0);
+        fontPanel.Width = settingsControl.Width;
+
+        settingsControl.Dock = DockStyle.None;
+        settingsControl.Location = new Point(0, fontPanel.Height);
+
+        page.Controls.Add(fontPanel);
+        page.Controls.Add(settingsControl);
+        page.AutoScrollMinSize = new Size(
+            settingsControl.Width,
+            fontPanel.Height + settingsControl.Height);
+
         tabControl.TabPages.Add(page);
     }
 }


### PR DESCRIPTION
Cancel logic:
- Remove incorrect font disposal in Cancel(). The snapshot was produced by FontOverrides.Clone(), so its Font references differ from the live ones even when the user changed nothing. Disposing on reference inequality therefore disposed the live overrides unconditionally, which could cause use-after-free when those Font objects are still aliased into LayoutSettings.*Font or cached by component fields.
  - This change fixes the issue that clicking cancel on layout settings panel causes internal crash and makes layout uneditable anymore.

Font panel layout:
- Extract the 'settings control + font override panel' stacking logic into a dedicated AddSettingsWithFontOverrideTab() helper method.
- Switch from DockStyle.Fill / DockStyle.Top to absolute positioning with AutoScrollMinSize so the tab page scrolls correctly when content overflows.
  - 2 changes above fix the issue that scrollbar is not shown on layout settings panel, neither the panel is fully shown.
- Increase dialog MinimumSize height from 674 to 703 to match the new layout. (for changes in commit 98ec53b)