### PR TITLE
Fix layout settings dialog spacing, scrolling and font lifecycle

### DIFF
--- a/src/LiveSplit.View/View/FontOverridePanel.cs
+++ b/src/LiveSplit.View/View/FontOverridePanel.cs
@@ -12,6 +12,15 @@ public partial class FontOverridePanel : UserControl
     private FontOverrides _fontOverrides;
     private Options.LayoutSettings _globalSettings;
 
+    // Snapshot of the Font references at Bind time. The btn*Font_Click handlers
+    // use these to tell apart "the Font that already existed when the dialog
+    // opened" (owned by LayoutSettingsDialog's snapshot — must NOT be disposed
+    // here) from "a Font we created in this dialog session via FontChanged"
+    // (orphaned the moment the user picks again — safe to dispose).
+    private Font _origTimerFont;
+    private Font _origTimesFont;
+    private Font _origTextFont;
+
     public FontOverridePanel()
     {
         InitializeComponent();
@@ -21,6 +30,9 @@ public partial class FontOverridePanel : UserControl
     {
         _fontOverrides = fontOverrides;
         _globalSettings = globalSettings;
+        _origTimerFont = fontOverrides.TimerFont;
+        _origTimesFont = fontOverrides.TimesFont;
+        _origTextFont = fontOverrides.TextFont;
         UpdateUI();
         ApplyFontFilter(usedFonts);
     }
@@ -46,8 +58,14 @@ public partial class FontOverridePanel : UserControl
             return;
         }
 
-        // Subtract the proportional height of hidden rows from the table area.
-        // This preserves DPI-scaled values since we derive from the current Height.
+        // Force a layout pass so _tableLayout.Height reflects the Dock=Fill
+        // size inside the GroupBox client area (~86 px) rather than the
+        // unparented designer Size (101 px). Using the designer value
+        // over-shrinks the panel by about 9 px per hidden row, which clips
+        // the bottom of the "Choose..." button (23 px) in the 1-visible-row
+        // case (e.g. Timer / Title / Text / Counter / Splits.SplitsComponent).
+        PerformLayout();
+
         int hiddenRows = _tableLayout.RowCount - visibleRows;
         Height -= _tableLayout.Height * hiddenRows / _tableLayout.RowCount;
     }
@@ -131,8 +149,10 @@ public partial class FontOverridePanel : UserControl
         dialog.FontChanged += (s, ev) =>
         {
             Font newFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+            Font previous = _fontOverrides.TimerFont;
             // Scale back up to the size the Timer component expects
             _fontOverrides.TimerFont = new Font(newFont.FontFamily.Name, newFont.Size / 18f * 50f, newFont.Style, GraphicsUnit.Pixel);
+            DisposePreviousDialogFont(previous, _origTimerFont);
             UpdateFontLabel(_lblTimerFont, _fontOverrides.TimerFont, _globalSettings.TimerFont);
         };
         dialog.ShowDialog(FindForm());
@@ -144,7 +164,9 @@ public partial class FontOverridePanel : UserControl
         CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(current, 11, 26);
         dialog.FontChanged += (s, ev) =>
         {
+            Font previous = _fontOverrides.TimesFont;
             _fontOverrides.TimesFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+            DisposePreviousDialogFont(previous, _origTimesFont);
             UpdateFontLabel(_lblTimesFont, _fontOverrides.TimesFont, _globalSettings.TimesFont);
         };
         dialog.ShowDialog(FindForm());
@@ -156,9 +178,25 @@ public partial class FontOverridePanel : UserControl
         CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(current, 11, 26);
         dialog.FontChanged += (s, ev) =>
         {
+            Font previous = _fontOverrides.TextFont;
             _fontOverrides.TextFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+            DisposePreviousDialogFont(previous, _origTextFont);
             UpdateFontLabel(_lblTextFont, _fontOverrides.TextFont, _globalSettings.TextFont);
         };
         dialog.ShowDialog(FindForm());
+    }
+
+    /// <summary>
+    /// Dispose <paramref name="previous"/> only when it was allocated during
+    /// this dialog session — i.e. it's not the pre-dialog original captured at
+    /// Bind. The original is owned by LayoutSettingsDialog's snapshot list and
+    /// is needed there to roll back on Cancel, so we must not touch it here.
+    /// </summary>
+    private static void DisposePreviousDialogFont(Font previous, Font origAtBind)
+    {
+        if (previous != null && !ReferenceEquals(previous, origAtBind))
+        {
+            previous.Dispose();
+        }
     }
 }

--- a/src/LiveSplit.View/View/LayoutSettingsDialog.cs
+++ b/src/LiveSplit.View/View/LayoutSettingsDialog.cs
@@ -18,14 +18,26 @@ public partial class LayoutSettingsDialog : Form
 
     private readonly List<FontOverrides> _fontOverrideSnapshots;
     private readonly List<LayoutComponent> _layoutComponents;
+    private bool _fontSnapshotCleanupDone;
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            foreach (FontOverrides snapshot in _fontOverrideSnapshots)
+            // Belt-and-braces: if Dispose runs before OnFormClosing did
+            // (rare — e.g. some test paths), still run the snapshot cleanup
+            // so we don't leak the user's picks or dispose Fonts that are
+            // still aliased into LayoutSettings/components.
+            EnsureFontSnapshotCleanupDone();
+
+            if (_fontOverrideSnapshots != null)
             {
-                snapshot?.Dispose();
+                foreach (FontOverrides snapshot in _fontOverrideSnapshots)
+                {
+                    // Snapshot Fonts were null'd out by the cleanup above so
+                    // this just drops the FontOverrides shells.
+                    snapshot?.Dispose();
+                }
             }
 
             components?.Dispose();
@@ -56,33 +68,11 @@ public partial class LayoutSettingsDialog : Form
 
     private void btnCancel_Click(object sender, EventArgs e)
     {
-        for (int i = 0; i < Components.Count; i++)
-        {
-            Components[i].SetSettings(ComponentSettings[i]);
-        }
-
-        // Restore font overrides from snapshots.
-        //
-        // Do not dispose the live current fonts here. The snapshot was produced
-        // by FontOverrides.Clone(), so its font objects are different references
-        // from the current ones even when the user changed nothing. Disposing on
-        // reference inequality would therefore dispose the live overrides
-        // unconditionally. Those Font objects can still be aliased into
-        // LayoutSettings.*Font (via FontOverrides.ApplyTo) and captured by
-        // component fields or label caches during render/update.
-        for (int i = 0; i < _layoutComponents.Count; i++)
-        {
-            FontOverrides snapshot = _fontOverrideSnapshots[i];
-            FontOverrides current = _layoutComponents[i].FontOverrides;
-
-            current.OverrideTimerFont = snapshot.OverrideTimerFont;
-            current.TimerFont = snapshot.TimerFont?.Clone() as Font;
-            current.OverrideTimesFont = snapshot.OverrideTimesFont;
-            current.TimesFont = snapshot.TimesFont?.Clone() as Font;
-            current.OverrideTextFont = snapshot.OverrideTextFont;
-            current.TextFont = snapshot.TextFont?.Clone() as Font;
-        }
-
+        // The actual restoration (component XML settings + font overrides) is
+        // done centrally in OnFormClosing → EnsureFontSnapshotCleanupDone so
+        // the same cleanup also runs when the user closes the form via the
+        // X button (which sets DialogResult to Cancel but does NOT fire
+        // this click handler).
         DialogResult = DialogResult.Cancel;
         Close();
     }
@@ -100,10 +90,14 @@ public partial class LayoutSettingsDialog : Form
                 ? ((GlobalFontConsumerAttribute)fontAttr[0]).UsedGlobalFonts
                 : GlobalFont.None;
 
-            // Snapshot font overrides for cancel
+            // Snapshot font overrides for cancel. We deliberately do NOT
+            // Clone() the Fonts: keeping the original references lets the
+            // cleanup logic in EnsureFontSnapshotCleanupDone() tell apart
+            // "user picked something new" (current.Font != snapshot.Font)
+            // from "untouched" (==), which is how it decides what to dispose.
             if (lc != null)
             {
-                _fontOverrideSnapshots.Add((FontOverrides)lc.FontOverrides.Clone());
+                _fontOverrideSnapshots.Add(SnapshotFontOverrides(lc.FontOverrides));
                 _layoutComponents.Add(lc);
             }
 
@@ -162,6 +156,7 @@ public partial class LayoutSettingsDialog : Form
         page.AutoScroll = true;
         page.Name = name;
         tabControl.TabPages.Add(page);
+        EnableMouseWheelForwarding(page);
     }
 
     protected void AddSettingsWithFontOverrideTab(
@@ -176,20 +171,250 @@ public partial class LayoutSettingsDialog : Form
             Name = name,
         };
 
+        // Add the page to the tab control first so it has the real ClientSize
+        // before children Anchor against it. Without this, Anchor=Right is
+        // computed against the unparented TabPage default (~200 px) and the
+        // child stays narrow until something else forces re-layout.
+        tabControl.TabPages.Add(page);
+
         var fontPanel = new FontOverridePanel();
         fontPanel.Bind(fontOverrides, Layout.Settings, usedFonts);
         fontPanel.Location = new Point(0, 0);
-        fontPanel.Width = settingsControl.Width;
+
+        // Stretch fontPanel across the TabPage width instead of pinning it
+        // to settingsControl.Width. Some Settings designers are 459 px wide
+        // (Splits / DetailedTimer / Subsplits) while the TabPage interior is
+        // ~478 px — pinning to 459 leaves a visible ~19 px gap on the right
+        // and makes those tabs look "weirdly spaced" relative to other tabs.
+        fontPanel.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+        // Clear the default 3-px Margin so the panel doesn't contribute extra
+        // horizontal extent and spuriously trigger the horizontal scrollbar
+        // (Anchor=Right already stretches it exactly to the visible width).
+        fontPanel.Margin = Padding.Empty;
 
         settingsControl.Dock = DockStyle.None;
         settingsControl.Location = new Point(0, fontPanel.Height);
+        settingsControl.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+        settingsControl.Margin = Padding.Empty;
 
         page.Controls.Add(fontPanel);
         page.Controls.Add(settingsControl);
+
+        // Set AutoScrollMinSize.Height to the exact bottom of the settings
+        // control. Width=0 lets WinForms auto-detect horizontal extent from
+        // the (now Margin-less) children, which equals the page client width
+        // and therefore never triggers the horizontal scrollbar.
         page.AutoScrollMinSize = new Size(
-            settingsControl.Width,
+            0,
             fontPanel.Height + settingsControl.Height);
 
-        tabControl.TabPages.Add(page);
+        EnableMouseWheelForwarding(page);
+    }
+
+    /// <summary>
+    /// Subscribe to MouseWheel on focusable child controls inside <paramref name="scrollTarget"/>
+    /// that natively consume the wheel for value-change behavior (NumericUpDown / ComboBox /
+    /// TrackBar), and forward those events to <paramref name="scrollTarget"/> so the
+    /// surrounding TabPage can still be scrolled when one of these is focused. Controls that
+    /// have meaningful inner scrolling of their own (multi-line TextBox, ListBox, ...) are
+    /// left untouched so their built-in wheel handling continues to work.
+    /// </summary>
+    private static void EnableMouseWheelForwarding(ScrollableControl scrollTarget)
+    {
+        HookMouseWheel(scrollTarget, scrollTarget);
+    }
+
+    private static void HookMouseWheel(Control parent, ScrollableControl scrollTarget)
+    {
+        foreach (Control child in parent.Controls)
+        {
+            if (child != scrollTarget && ShouldForwardWheelFrom(child))
+            {
+                child.MouseWheel += (s, e) => ForwardWheelToScrollTarget(e, scrollTarget);
+            }
+
+            if (child.HasChildren)
+            {
+                HookMouseWheel(child, scrollTarget);
+            }
+        }
+    }
+
+    private static bool ShouldForwardWheelFrom(Control control)
+    {
+        return control is NumericUpDown
+            || control is TrackBar
+            || control is ComboBox;
+    }
+
+    private static void ForwardWheelToScrollTarget(MouseEventArgs e, ScrollableControl scrollTarget)
+    {
+        // Mark the event as handled so NumericUpDown / ComboBox / TrackBar skip
+        // their spin/select-next behavior (they check HandledMouseEventArgs.Handled
+        // before applying the wheel).
+        if (e is HandledMouseEventArgs hme)
+        {
+            hme.Handled = true;
+        }
+
+        if (!scrollTarget.VerticalScroll.Visible)
+        {
+            return;
+        }
+
+        int linesPerNotch = SystemInformation.MouseWheelScrollLines;
+        if (linesPerNotch <= 0 || linesPerNotch > 100)
+        {
+            // SPI_GETWHEELSCROLLLINES returns -1 for "page" or 0 for "no scroll";
+            // both should fall back to a sane default for our purposes.
+            linesPerNotch = 3;
+        }
+
+        int notches = e.Delta / SystemInformation.MouseWheelScrollDelta;
+        const int PixelsPerLine = 20;
+        int scrollDelta = -notches * linesPerNotch * PixelsPerLine;
+
+        // AutoScrollPosition has a quirky API: the getter returns the negated
+        // scroll offset and the setter takes the positive position. Translate
+        // both ways to preserve the current X while updating Y.
+        int currentY = -scrollTarget.AutoScrollPosition.Y;
+        int newY = Math.Max(0, currentY + scrollDelta);
+
+        scrollTarget.AutoScrollPosition = new Point(
+            -scrollTarget.AutoScrollPosition.X,
+            newY);
+    }
+
+    /// <summary>
+    /// Shallow-copy of <paramref name="source"/> that intentionally shares the
+    /// Font references with it (no <c>Font.Clone()</c>). The snapshot is used
+    /// purely as a "what did the world look like when the dialog opened?"
+    /// record so that <see cref="EnsureFontSnapshotCleanupDone"/> can compare
+    /// references (==) to decide whether a slot was changed by the user.
+    /// </summary>
+    private static FontOverrides SnapshotFontOverrides(FontOverrides source)
+    {
+        return new FontOverrides
+        {
+            OverrideTimerFont = source.OverrideTimerFont,
+            TimerFont = source.TimerFont,
+            OverrideTimesFont = source.OverrideTimesFont,
+            TimesFont = source.TimesFont,
+            OverrideTextFont = source.OverrideTextFont,
+            TextFont = source.TextFont,
+        };
+    }
+
+    protected override void OnFormClosing(FormClosingEventArgs e)
+    {
+        // Run before base so the layout sees the restored state before any
+        // other FormClosing subscriber reacts.
+        EnsureFontSnapshotCleanupDone();
+        base.OnFormClosing(e);
+    }
+
+    /// <summary>
+    /// Idempotent finalization step for the per-component snapshots created
+    /// in <see cref="AddComponents"/>. Disposes only the Fonts that are no
+    /// longer needed:
+    /// <list type="bullet">
+    /// <item><description>On Cancel/X-button, disposes the Fonts the user
+    /// picked during this session and reinstalls the original references on
+    /// <c>current</c>.</description></item>
+    /// <item><description>On OK, disposes only those original Fonts that
+    /// the user actually replaced; untouched slots (where <c>current</c>
+    /// and <c>snapshot</c> share the same reference) are left alive because
+    /// they are still in use by the live layout.</description></item>
+    /// </list>
+    /// After running, <c>snapshot.*Font</c> are set to <c>null</c> so the
+    /// subsequent <c>snapshot.Dispose()</c> call in <see cref="Dispose"/> is
+    /// a no-op for Fonts.
+    /// </summary>
+    private void EnsureFontSnapshotCleanupDone()
+    {
+        if (_fontSnapshotCleanupDone)
+        {
+            return;
+        }
+
+        if (_fontOverrideSnapshots == null || _layoutComponents == null
+            || Components == null || ComponentSettings == null)
+        {
+            return;
+        }
+
+        bool cancelPath = DialogResult != DialogResult.OK;
+
+        if (cancelPath)
+        {
+            // Restore component XML settings so the X-button path behaves
+            // like the Cancel button (it didn't before this change — that
+            // was a latent bug).
+            for (int i = 0; i < Components.Count; i++)
+            {
+                Components[i].SetSettings(ComponentSettings[i]);
+            }
+        }
+
+        for (int i = 0; i < _layoutComponents.Count; i++)
+        {
+            FontOverrides snapshot = _fontOverrideSnapshots[i];
+            FontOverrides current = _layoutComponents[i].FontOverrides;
+
+            if (cancelPath)
+            {
+                // Dispose Fonts the user picked in this session (current
+                // differs from snapshot) and reinstall the original
+                // references onto current. After this, current owns the
+                // originals again.
+                if (!ReferenceEquals(current.TimerFont, snapshot.TimerFont))
+                {
+                    current.TimerFont?.Dispose();
+                }
+                if (!ReferenceEquals(current.TimesFont, snapshot.TimesFont))
+                {
+                    current.TimesFont?.Dispose();
+                }
+                if (!ReferenceEquals(current.TextFont, snapshot.TextFont))
+                {
+                    current.TextFont?.Dispose();
+                }
+
+                current.OverrideTimerFont = snapshot.OverrideTimerFont;
+                current.TimerFont = snapshot.TimerFont;
+                current.OverrideTimesFont = snapshot.OverrideTimesFont;
+                current.TimesFont = snapshot.TimesFont;
+                current.OverrideTextFont = snapshot.OverrideTextFont;
+                current.TextFont = snapshot.TextFont;
+            }
+            else
+            {
+                // OK path: current holds the user's final picks. Dispose the
+                // originals that were actually replaced; leave untouched
+                // slots alone (current still references them, disposing
+                // would be use-after-free in the next render).
+                if (!ReferenceEquals(snapshot.TimerFont, current.TimerFont))
+                {
+                    snapshot.TimerFont?.Dispose();
+                }
+                if (!ReferenceEquals(snapshot.TimesFont, current.TimesFont))
+                {
+                    snapshot.TimesFont?.Dispose();
+                }
+                if (!ReferenceEquals(snapshot.TextFont, current.TextFont))
+                {
+                    snapshot.TextFont?.Dispose();
+                }
+            }
+
+            // Detach Fonts from snapshot so the upcoming snapshot.Dispose()
+            // in our Dispose() is a no-op for Fonts (we either disposed
+            // them above or transferred ownership back to current).
+            snapshot.TimerFont = null;
+            snapshot.TimesFont = null;
+            snapshot.TextFont = null;
+        }
+
+        _fontSnapshotCleanupDone = true;
     }
 }


### PR DESCRIPTION
Followup to #2687 which addressed the cancel/dispose semantics in the per-component font override tab but introduced three visible regressions and left one latent leak.

## User report

> the layout editor does seem weirder now, like the widgets are weirdly spaced and sometimes the scrollbars don't work

Concretely:

1. **Widgets are weirdly spaced.** The font override panel + settings control look narrow (~19 px gap on the right) on tabs whose settings control is 459 px wide (Splits, DetailedTimer, Subsplits), and the "Choose..." button is clipped at the bottom on components that consume only one global font (Timer, Title, Text, Counter, Splits.SplitsComponent, ...).
2. **Scrollbar sometimes does nothing.** Scrolling stops working when a `NumericUpDown` / `ComboBox` / `TrackBar` inside the settings control has keyboard focus.
3. **Bottom cut off when scrolled to the end.** Scrolling all the way down occasionally clips the last few pixels of the settings control.
4. **(Latent) Font leak after OK.** When the user picks a new Font and clicks OK, the pre-dialog original Font was leaked. The earlier fix removed the disposal entirely to avoid a use-after-free instead of routing it correctly.

## Diagnosis

### Reference data

Settings control designer widths/heights across font-consuming components:

| Width | Components |
|---|---|
| **476** | Timer (476×301), Title (476×325), PossibleTimeSave (476×370), PreviousSegment (476×388), Delta (476×379), SumOfBest (476×313) |
| **459** | Splits (459×980), DetailedTimer (459×991), Subsplits (459×1660) |

`TabPage` interior width is ~478 px (`tabControl.Size = 484×616`, default `Padding(3)`).

### Issue 1: Weird spacing

Two independent root causes, both introduced by #2687:

**1a. `fontPanel.Width = settingsControl.Width`** — On 459-wide components, the font override panel only fills 459 of the available ~478 px, leaving a visible ~19 px gap. The old `Dock=Top` design auto-stretched to the container width, so the gap didn't exist before.

**1b. `FontOverridePanel.AdjustHeight` under-shrinks.** The formula `Height -= _tableLayout.Height * hiddenRows / RowCount` is computed at a point where the panel hasn't been parented yet, so `_tableLayout.Height` is still the designer value `101 px` instead of the post-Dock-fill value `~86 px`. The over-subtraction shaves an extra ~9 px per hidden row, and in the 1-visible-row case (Timer / Title / Text / Counter / Splits.SplitsComponent / DetailedTimer / etc.) the table cell ends up ~25 px tall while the "Choose..." button is 23 px tall positioned at Y=5 — bottom 3 px clipped.

### Issue 2: Scrollbar gets stuck

Classic WinForms wheel-routing quirk: `WM_MOUSEWHEEL` is delivered to the focused control, and `NumericUpDown` / `ComboBox` / `TrackBar` all consume it for their spin/select-next behavior without bubbling to the scrolling parent. Splits / DetailedTimer / Subsplits settings have a lot of these.

The old `Dock=Fill` design hid the symptom because no scrolling happened at all (the settings control was simply shrunk by `Dock=Fill`). After #2687 enabled real scrolling on the page, the focus-stealing behavior became visible.

### Issue 3: Bottom cut off

The explicit `AutoScrollMinSize = (settingsControl.Width, fontPanel.Height + settingsControl.Height)` in #2687 is exactly the children's `Bounds` extent. With default `Margin = Padding(3)` on both children, the scroll calculation can include the margin, pushing the actual minimum past the explicit value and (combined with DPI/font-scale rounding) chipping a few pixels off at the bottom.

### Issue 4: Font lifecycle leak

`AddComponents` snapshot was built via `FontOverrides.Clone()`, which produces *new* `Font` instances. The original `Cancel()` therefore disposed live overrides unconditionally on the `current != snapshot` reference check (use-after-free risk). #2687 removed the disposal — fixing the crash but turning the bug into a silent GDI leak whenever the user actually changes a Font.

## Fix

### 1 — `AddSettingsWithFontOverrideTab` rewritten

```csharp
tabControl.TabPages.Add(page);          // parent first so ClientSize is real

var fontPanel = new FontOverridePanel();
fontPanel.Bind(...);
fontPanel.Location = new Point(0, 0);
fontPanel.Anchor   = Top | Left | Right; // stretch to TabPage width
fontPanel.Margin   = Padding.Empty;      // don't push the H-scroll

settingsControl.Dock     = DockStyle.None;
settingsControl.Location = new Point(0, fontPanel.Height);
settingsControl.Anchor   = Top | Left | Right;
settingsControl.Margin   = Padding.Empty;

page.Controls.Add(fontPanel);
page.Controls.Add(settingsControl);
page.AutoScrollMinSize = new Size(0, fontPanel.Height + settingsControl.Height);

EnableMouseWheelForwarding(page);
```

- `Anchor=Top|Left|Right` stretches both children to the TabPage interior width — 459-wide and 476-wide settings controls now look the same.
- `Margin = Padding.Empty` prevents the auto-detected right extent from overshooting the visible width by 3 px and spuriously triggering the horizontal scrollbar.
- `AutoScrollMinSize.Width = 0` lets WinForms auto-detect horizontal extent from the (now `Margin`-less) children, which equals the page client width and therefore never triggers the horizontal scrollbar.
- `AutoScrollMinSize.Height` is set to the exact children bottom; combined with `Margin = Empty` this matches the real extent and the last pixels stop disappearing.

### 2 — `FontOverridePanel.AdjustHeight` reads the post-layout size

```csharp
PerformLayout();  // force Dock=Fill to apply before reading
int hiddenRows = _tableLayout.RowCount - visibleRows;
Height -= _tableLayout.Height * hiddenRows / _tableLayout.RowCount;
```

`PerformLayout()` cascades `Dock=Fill` through `GroupBox` and `TableLayoutPanel` so `_tableLayout.Height` reflects the real `~86 px` available inside the GroupBox client area, not the designer `101 px`. For the 1-row case the panel ends up `~77 px` tall (was `67`), and the "Choose..." button (23 high at Y=5) fits with ~2 px of clearance.

### 3 — Mouse wheel forwarding

```csharp
private static void EnableMouseWheelForwarding(ScrollableControl scrollTarget) {
    HookMouseWheel(scrollTarget, scrollTarget);
}

private static void HookMouseWheel(Control parent, ScrollableControl scrollTarget) {
    foreach (Control child in parent.Controls) {
        if (child != scrollTarget && ShouldForwardWheelFrom(child))
            child.MouseWheel += (s, e) => ForwardWheelToScrollTarget(e, scrollTarget);
        if (child.HasChildren)
            HookMouseWheel(child, scrollTarget);
    }
}

private static bool ShouldForwardWheelFrom(Control control) =>
    control is NumericUpDown || control is TrackBar || control is ComboBox;
```

`ForwardWheelToScrollTarget` sets `HandledMouseEventArgs.Handled = true` to suppress the focused control's default spin/select-next, then manually advances `scrollTarget.AutoScrollPosition` by `SystemInformation.MouseWheelScrollLines × 20 px` per wheel notch.

Multi-line `TextBox` and `ListBox` are intentionally **not** hooked — they have meaningful inner scrolling and the user expects the wheel to drive that. Applied to both `AddNewTab` (covers tabs without font overrides) and `AddSettingsWithFontOverrideTab`.

### 4 — Font lifecycle

Snapshot now keeps the **original** Font references (no Clone):

```csharp
private static FontOverrides SnapshotFontOverrides(FontOverrides source) =>
    new FontOverrides {
        OverrideTimerFont = source.OverrideTimerFont,
        TimerFont         = source.TimerFont,   // same ref, no Clone
        OverrideTimesFont = source.OverrideTimesFont,
        TimesFont         = source.TimesFont,
        OverrideTextFont  = source.OverrideTextFont,
        TextFont          = source.TextFont,
    };
```

This lets `ReferenceEquals(current.Font, snapshot.Font)` cleanly distinguish *"untouched"* from *"user picked something new"*.

Cleanup is centralized in `EnsureFontSnapshotCleanupDone()`, fired from a new `OnFormClosing` override (and from `Dispose` belt-and-braces). The method is idempotent and branches on `DialogResult`:

- **Cancel/X**: dispose the user's picks (`current.Font != snapshot.Font`) and reinstall the original references onto `current`. Also restore the component XML settings — previously only the Cancel button did this, so closing via the X button silently committed component-settings changes too.
- **OK**: dispose only the originals that the user actually replaced. Untouched slots (where `current` and `snapshot` share the same reference) are left alive — they remain aliased into the live layout and disposing would be use-after-free in the next render.

After cleanup, `snapshot.*Font` are set to `null` so the subsequent `snapshot.Dispose()` in our `Dispose()` is a no-op for Fonts.

`FontOverridePanel` captures the pre-dialog Font references in `_origXxxFont` on `Bind`, and the `btn*Font_Click` handlers dispose intermediate picks during the same dialog session — so the N-pick case stops leaking N-1 Fonts.

### Reference flow for the Cancel path

```
dialog opens:
  current.TimerFont    →  Font_orig
  snapshot.TimerFont   →  Font_orig    (shallow copy, same ref)
  panel._origTimerFont →  Font_orig    (captured in Bind)

user picks A, then B, then C:
  pick A:  previous=Font_orig == _origTimerFont  → don't dispose
           current.TimerFont = Font_A
  pick B:  previous=Font_A != _origTimerFont      → dispose Font_A
           current.TimerFont = Font_B
  pick C:  previous=Font_B != _origTimerFont      → dispose Font_B
           current.TimerFont = Font_C

Cancel:
  current=Font_C, snapshot=Font_orig, !ReferenceEquals
  → dispose current.TimerFont (Font_C)
  → current.TimerFont = snapshot.TimerFont = Font_orig
  → snapshot.TimerFont = null
  final: current.TimerFont = Font_orig alive

OK (instead of Cancel):
  current=Font_C, snapshot=Font_orig, !ReferenceEquals
  → dispose snapshot.TimerFont (Font_orig no longer in use)
  → snapshot.TimerFont = null
  final: current.TimerFont = Font_C alive
```

## Verification

Build and tests are clean (`dotnet build LiveSplit.slnx -c Debug` → 0 warnings / 0 errors; `dotnet test test/LiveSplit.Tests` → 506/506 pass).

Suggested manual checks (pixel-level differences are hard to eyeball — try the focus/scroll cases as well):

| Scenario | Steps | Expected |
|---|---|---|
| **Spacing (1a)** | Edit Layout → double-click Splits / DetailedTimer / Subsplits | Font override panel spans full TabPage width, no ~19 px gap on the right |
| **Button clipping (1b)** | Same, but for Timer / Title / Text / Counter / CurrentComparison | "Choose..." button is fully visible (no clipped bottom edge) |
| **Bottom reachable (3)** | Open Subsplits / DetailedTimer settings, scroll to bottom | Last GroupBox (`Columns` / `Split Name`) fully visible |
| **Wheel still scrolls (2)** | In Splits settings, click into "Total Segments" NumericUpDown, then scroll wheel | Page scrolls, number does NOT change. Same for ComboBox and TrackBar |
| **Font cancel** | Open Timer settings → Choose new font → Cancel | Font reverts to original, no crash |
| **Font multi-pick + Cancel** | Choose 3+ different fonts in a row → Cancel | Reverts to original, GDI handle count doesn't blow up (`Get-Process LiveSplit | Select Handles`) |
| **Font OK** | Choose new font → OK | New font is applied, no crash on next render |
| **X button** | Choose new font + change a setting → close via X | Both font and component settings revert to pre-dialog state (this was previously a silent commit) |
