### PR TITLE
Fix time spacing with high DPI (#2716)

### DIFF
--- a/src/LiveSplit.Core/UI/SimpleLabel.cs
+++ b/src/LiveSplit.Core/UI/SimpleLabel.cs
@@ -105,7 +105,7 @@ public class SimpleLabel
                 LineAlignment = VerticalAlignment
             };
 
-            int measurement = MeasureText(g, "0", Font, new Size((int)(Width + 0.5f), (int)(Height + 0.5f)), TextFormatFlags.NoPadding).Width;
+            int measurement = MeasureCharacterActualWidth("0", g);
             float offset = Width;
             int charIndex = 0;
             SetActualWidth(g);
@@ -124,7 +124,7 @@ public class SimpleLabel
 
                 curOffset = char.IsDigit(curChar)
                     ? measurement
-                    : MeasureText(g, curChar.ToString(), Font, new Size((int)(Width + 0.5f), (int)(Height + 0.5f)), TextFormatFlags.NoPadding).Width;
+                    : MeasureCharacterActualWidth(curChar.ToString(), g);
 
                 DrawText(curChar.ToString(), g, X + offset - (curOffset / 2f), Y, curOffset * 2f, Height, monoFormat);
 
@@ -218,7 +218,7 @@ public class SimpleLabel
     private float MeasureActualWidth(string text, Graphics g)
     {
         int charIndex = 0;
-        int measurement = MeasureText(g, "0", Font, new Size((int)(Width + 0.5f), (int)(Height + 0.5f)), TextFormatFlags.NoPadding).Width;
+        int measurement = MeasureCharacterActualWidth("0", g);
         int offset = 0;
 
         while (charIndex < text.Length)
@@ -231,13 +231,27 @@ public class SimpleLabel
             }
             else
             {
-                offset += MeasureText(g, curChar.ToString(), Font, new Size((int)(Width + 0.5f), (int)(Height + 0.5f)), TextFormatFlags.NoPadding).Width;
+                offset += MeasureCharacterActualWidth(curChar.ToString(), g);
             }
 
             charIndex++;
         }
 
         return offset;
+    }
+    
+    // Intended to measure the width of a single character, taking into account DPI scaling
+    // For longer strings, MeasureActualWidth should be used instead to keep digit spacing consistent
+    private int MeasureCharacterActualWidth(string text, Graphics g)
+    {
+        int width = MeasureText(g, text, Font, new Size((int)(Width + 0.5f), (int)(Height + 0.5f)), TextFormatFlags.NoPadding).Width;
+        
+		if (Font.Unit != GraphicsUnit.Point)
+        {
+            width = (int)((width * 96f / g.DpiY) + 0.5f);
+        }
+
+        return width;
     }
 
     private string CutOff(Graphics g)


### PR DESCRIPTION
SimpleLabel uses MeasureText from WinForms to measure the width of digits that it's rendering, but renders them with GDI+ GraphicsPath. These produce different results when the application is DPI-aware and DPI scaling is enabled in Windows. This PR manually scales the widths to match. The alternative seems to be to use g.MeasureCharacterRanges from GDI+, which would arguably mirror the text-rendering function more cleanly, but might affect non-DPI-aware rendering (it uses floats natively instead of ints, so I think there's potential rounding differences between them?), so I went with this approach to stay on the safe side. It also was relatively easy to implement given that I don't know much .NET at all.