### PR TITLE
Fix Roslyn script compilation

### DIFF
--- a/src/LiveSplit/App.config
+++ b/src/LiveSplit/App.config
@@ -5,5 +5,31 @@
     </startup>
     <runtime>
         <loadFromRemoteSources enabled="true"/>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <!--
+                LiveSplit.ScriptableAutoSplit uses Roslyn (Microsoft.CodeAnalysis),
+                which uses older versions of several assemblies than the ones
+                LiveSplit's other projects use.
+                Because an ASL is loaded dynamically, the LiveSplit's auto-generated
+                binding redirects don't cover these, so they're declared explicitly.
+                Redirects each to the version actually on disk.
+            -->
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0"/>
+            </dependentAssembly>
+        </assemblyBinding>
     </runtime>
 </configuration>


### PR DESCRIPTION
Adds binding redirects for some packages used by `LiveSplit.ScriptableAutoSplit`. Without these, loading a script isn't possible because Roslyn can't find the requested package versions on disk.

See also: https://github.com/LiveSplit/LiveSplit.ScriptableAutoSplit/pull/77.