### PR TITLE
Add binding redirect for `System.Text.Json`

### DIFF
--- a/src/LiveSplit/App.config
+++ b/src/LiveSplit/App.config
@@ -7,11 +7,9 @@
         <loadFromRemoteSources enabled="true"/>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <!--
-                LiveSplit.ScriptableAutoSplit uses Roslyn (Microsoft.CodeAnalysis),
-                which uses older versions of several assemblies than the ones
-                LiveSplit's other projects use.
-                Because an ASL is loaded dynamically, the LiveSplit's auto-generated
-                binding redirects don't cover these, so they're declared explicitly.
+                LiveSplit.ScriptableAutoSplit refernces Roslyn (Microsoft.CodeAnalysis), which uses older versions of several assemblies
+                than the ones LiveSplit's other projects use.
+                Because an ASL is loaded dynamically, LiveSplit's auto-generated binding redirects don't cover these, so they're declared explicitly.
                 Redirects each to the version actually on disk.
             -->
             <dependentAssembly>
@@ -29,6 +27,12 @@
             <dependentAssembly>
                 <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
                 <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0"/>
+            </dependentAssembly>
+
+            <!-- To ensure script helper libraries work even when a package version changes, we need to explicitly redirect all versions. -->
+            <dependentAssembly>
+                <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8"/>
             </dependentAssembly>
         </assemblyBinding>
     </runtime>


### PR DESCRIPTION
Between `1.8.37` and now, the version of `System.Text.Json` used by LiveSplit changed from `9.0.0.4` to `10.0.0.8`, which is a problem for helper libraries. This redirect makes sure no matter what version is requested, it always directs to the one on disk.