### PR TITLE
Filepath Command Fixes & New Autosplitter Info Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Commands that return an int:
 Commands that return True/False as a value or whether or not the request succeeds:
 
 - globalhotkeysenabled
+- autosplitteractivated
 - savelayout
 - savesplits
 - savelayoutas FILEPATH
@@ -188,6 +189,7 @@ Commands that return a string:
 (returns a Base64 encoded string (Web URI format) of the screenshot in .png format)
 - getlayoutpath
 - getsplitspath
+- getautosplitterpath
 - gethotkeyprofile
 - getlivesplitversion
 - getlivesplitpath

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -731,7 +731,7 @@ public class CommandServer
             }
             case "getsplitspath":
             {
-                response = !string.IsNullOrEmpty(State.Run.FilePath) ? State.Layout.FilePath.ToString() : "-";
+                response = !string.IsNullOrEmpty(State.Run.FilePath) ? State.Run.FilePath.ToString() : "-";
                 break;
             }
             case "savesplits":

--- a/src/LiveSplit.Core/Server/CommandServer.cs
+++ b/src/LiveSplit.Core/Server/CommandServer.cs
@@ -700,7 +700,7 @@ public class CommandServer
             }
             case "getlayoutpath":
             {
-                response = State.Layout.FilePath.ToString();
+                response = !string.IsNullOrEmpty(State.Layout.FilePath) ? State.Layout.FilePath.ToString() : "-";
                 break;
             }
             case "savelayout":
@@ -731,7 +731,7 @@ public class CommandServer
             }
             case "getsplitspath":
             {
-                response = State.Run.FilePath.ToString();
+                response = !string.IsNullOrEmpty(State.Run.FilePath) ? State.Layout.FilePath.ToString() : "-";
                 break;
             }
             case "savesplits":
@@ -842,6 +842,16 @@ public class CommandServer
             case "getcompletedcount":
             {
                 response = State.Run.AttemptHistory.Count(x => x.Time.RealTime != null).ToString();
+                break;
+            }
+            case "getautosplitterpath":
+            {
+                response = !string.IsNullOrEmpty(State.Run.AutoSplitter?.LocalPath) ? State.Run.AutoSplitter.LocalPath.ToString() : "-";
+                break;
+            }
+            case "autosplitteractivated":
+            {
+                response = (State.Run.AutoSplitter != null && State.Run.AutoSplitter.IsActivated).ToString();
                 break;
             }
             case "gethotkeyprofile":


### PR DESCRIPTION
Summary:
A friend was messing around with the dev build and found an oversight on my part where both 'getlayoutpath' and 'getsplitspath' would crash the program if either value was null when using its respective command. Also took the time to add a couple useful commands involving autosplitters in which I probably should've had prepared when my server branch got pushed to main back in May.

Bug Fixes:
Ensured 'getlayoutpath' returns '-' instead of crashing when using a default layout.
Ensured 'getsplitspath' returns '-' instead of crashing when no splits are open.

New Changes:
Added the following commands:
1. getautosplitterpath - Returns the current filepath of the game's autosplitter (if one exists).
2. autosplitteractivated - Returns whether an autosplitter is currently active on LiveSplit.