### PR TITLE
perf: make AutoSplitter update non-blocking with local-cache-first

### DIFF
--- a/src/LiveSplit.Core/Model/AutoSplitterFactory.cs
+++ b/src/LiveSplit.Core/Model/AutoSplitterFactory.cs
@@ -1,9 +1,11 @@
-﻿using LiveSplit.Options;
+using LiveSplit.Options;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using System.Xml;
 
 namespace LiveSplit.Model;
@@ -13,8 +15,12 @@ public class AutoSplitterFactory
     public static AutoSplitterFactory Instance { get; protected set; }
     public IDictionary<string, AutoSplitter> AutoSplitters { get; set; }
 
-    public const string AutoSplittersXmlUrl = "https://raw.githubusercontent.com/LiveSplit/LiveSplit.AutoSplitters/master/LiveSplit.AutoSplitters.xml";
+    public const string AutoSplittersXmlUrl = "https://cdn.jsdelivr.net/gh/LiveSplit/LiveSplit.AutoSplitters@master/LiveSplit.AutoSplitters.xml";
     public const string AutoSplittersXmlFile = "LiveSplit.AutoSplitters.xml";
+
+    private static readonly TimeSpan RemoteTimeout = TimeSpan.FromSeconds(5);
+    private readonly object _initLock = new();
+    private bool _backgroundRefreshStarted;
 
     static AutoSplitterFactory()
     {
@@ -40,16 +46,131 @@ public class AutoSplitterFactory
             return;
         }
 
-        ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
-        XmlDocument document = DownloadAutoSplitters();
-
-        if (document != null)
+        lock (_initLock)
         {
-            AutoSplitters = document["AutoSplitters"].ChildNodes.OfType<XmlElement>()
+            if (AutoSplitters != null)
+            {
+                return;
+            }
+
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            if (TryLoadFromFile(AutoSplittersXmlFile))
+            {
+                StartBackgroundRefresh();
+                return;
+            }
+
+            StartBackgroundRefresh();
+        }
+    }
+
+    private bool TryLoadFromFile(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
+            var doc = new XmlDocument();
+            doc.Load(path);
+            var dict = Parse(doc);
+            if (dict != null)
+            {
+                AutoSplitters = dict;
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+
+        return false;
+    }
+
+    private static IDictionary<string, AutoSplitter> Parse(XmlDocument document)
+    {
+        if (document == null || document["AutoSplitters"] == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return document["AutoSplitters"].ChildNodes.OfType<XmlElement>()
                 .Where(element => element != null)
                 .Select(CreateFromXmlElement)
                 .SelectMany(x => x.Games.Select(y => new KeyValuePair<string, AutoSplitter>(y, x)))
                 .ToDictionary(x => x.Key, x => x.Value);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
+        }
+    }
+
+    private void StartBackgroundRefresh()
+    {
+        if (_backgroundRefreshStarted)
+        {
+            return;
+        }
+
+        _backgroundRefreshStarted = true;
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                var doc = await DownloadRemoteAsync();
+                if (doc == null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    doc.Save(AutoSplittersXmlFile);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex);
+                }
+
+                var dict = Parse(doc);
+                if (dict != null)
+                {
+                    lock (_initLock)
+                    {
+                        AutoSplitters = dict;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex);
+            }
+        });
+    }
+
+    private static async Task<XmlDocument> DownloadRemoteAsync()
+    {
+        try
+        {
+            using var client = new HttpClient { Timeout = RemoteTimeout };
+            var xml = await client.GetStringAsync(AutoSplittersXmlUrl);
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+            return doc;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+            return null;
         }
     }
 
@@ -101,25 +222,46 @@ public class AutoSplitterFactory
 
     protected XmlDocument DownloadAutoSplitters()
     {
-        var autoSplitters = new XmlDocument();
         try
         {
-            autoSplitters.Load(AutoSplittersXmlUrl);
-            autoSplitters.Save(AutoSplittersXmlFile);
+            var task = DownloadRemoteAsync();
+            if (task.Wait(RemoteTimeout))
+            {
+                var doc = task.Result;
+                if (doc != null)
+                {
+                    try
+                    {
+                        doc.Save(AutoSplittersXmlFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex);
+                    }
+
+                    return doc;
+                }
+            }
         }
         catch (Exception ex)
         {
             Log.Error(ex);
-            if (File.Exists(AutoSplittersXmlFile))
-            {
-                autoSplitters.Load(AutoSplittersXmlFile);
-            }
-            else
-            {
-                return null;
-            }
         }
 
-        return autoSplitters;
+        try
+        {
+            if (File.Exists(AutoSplittersXmlFile))
+            {
+                var doc = new XmlDocument();
+                doc.Load(AutoSplittersXmlFile);
+                return doc;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+
+        return null;
     }
 }

--- a/src/LiveSplit.Core/Model/AutoSplitterFactory.cs
+++ b/src/LiveSplit.Core/Model/AutoSplitterFactory.cs
@@ -15,7 +15,7 @@ public class AutoSplitterFactory
     public static AutoSplitterFactory Instance { get; protected set; }
     public IDictionary<string, AutoSplitter> AutoSplitters { get; set; }
 
-    public const string AutoSplittersXmlUrl = "https://cdn.jsdelivr.net/gh/LiveSplit/LiveSplit.AutoSplitters@master/LiveSplit.AutoSplitters.xml";
+    public const string AutoSplittersXmlUrl = "https://raw.githubusercontent.com/LiveSplit/LiveSplit.AutoSplitters/master/LiveSplit.AutoSplitters.xml";
     public const string AutoSplittersXmlFile = "LiveSplit.AutoSplitters.xml";
 
     private static readonly TimeSpan RemoteTimeout = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
### Background
Startup is slow especially on poor networks because AutoSplitterFactory.Init() synchronously calls XmlDocument.Load(AutoSplittersXmlUrl) on the UI thread. aw.githubusercontent.com can block for up to 100s before falling back to the local cache.

### Changes
- Init() now loads LiveSplit.AutoSplitters.xml from disk first for instant startup, then triggers a background refresh
- Background refresh uses HttpClient with 5s timeout, saves and atomically replaces the dictionary on success
- DownloadAutoSplitters() kept for compatibility but also uses 5s timeout
- No URL change, keep aw.githubusercontent.com

### Effect
Good network: silent background update. Poor network: first paint <1s instead of 20-100s.

### Verification
- dotnet build LiveSplit.Core -c Release 0 errors
- Manual timing with throttled/disconnected aw.githubusercontent.com, with and without local cache

### Notes
No caller changes. Create() still called synchronously in TimerForm; when AutoSplitters==null it returns null and is handled by existing null checks, becomes available after background refresh or next Run open.
